### PR TITLE
Fix Python API broken by implementation of --extra-search-dir feature

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -459,6 +459,10 @@ def _find_file(filename, dirs):
 
 def _install_req(py_executable, unzip=False, distribute=False,
                  search_dirs=None, never_download=False):
+
+    if search_dirs is None:
+        search_dirs = file_search_dirs()
+
     if not distribute:
         setup_fn = 'setuptools-0.6c11-py%s.egg' % sys.version[:3]
         project_name = 'setuptools'
@@ -588,7 +592,10 @@ def install_distribute(py_executable, unzip=False,
                  search_dirs=search_dirs, never_download=never_download)
 
 _pip_re = re.compile(r'^pip-.*(zip|tar.gz|tar.bz2|tgz|tbz)$', re.I)
-def install_pip(py_executable, search_dirs=None, never_download=False):
+def install_pip(py_executable, search_dirs=None, never_download=False):    
+    if search_dirs is None:
+        search_dirs = file_search_dirs()
+
     filenames = []
     for dir in search_dirs:
         filenames.extend([join(dir, fn) for fn in os.listdir(dir)


### PR DESCRIPTION
My previous pull request which was merged to pypa/develop (https://github.com/pypa/virtualenv/pull/114) broke the virtualenv Python API:

```
>>> import virtualenv
>>> virtualenv.create_environment("/tmp/ve")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "virtualenv.py", line 894, in create_environment
    search_dirs=search_dirs, never_download=never_download)
  File "virtualenv.py", line 587, in install_setuptools
    search_dirs=search_dirs, never_download=never_download)
  File "virtualenv.py", line 489, in _install_req
    setup_fn = _find_file(setup_fn, search_dirs)
  File "virtualenv.py", line 455, in _find_file
    for dir in dirs:
TypeError: 'NoneType' object is not iterable
```

This patch restores it, by setting `search_dirs=file_search_dirs()` where needed if no explicit `search_dirs` argument is passed in.

(My previous patch broke it by moving the `search_dirs` default out to the option-parsing code and assuming it will always be passed in explicitly.)
