### PR TITLE
Prevent traceback with non-exec interpreter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,7 @@ setup(name='virtualenv',
       py_modules=['virtualenv'],
       packages=['virtualenv_support'],
       package_data={'virtualenv_support': ['*-py%s.egg' % sys.version[:3], '*.tar.gz']},
+      test_suite='nose.collector',
+      tests_require=['nose', 'Mock'],
       **kw
       )

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1,0 +1,75 @@
+import virtualenv
+from mock import patch, Mock
+import os.path
+import sys
+
+def test_version():
+    """Should have a version string"""
+    assert virtualenv.virtualenv_version == "1.6", "Should have version"
+
+@patch('os.path.exists')
+@patch('os.path.abspath')
+def test_resolve_interpreter_with_absolute_path(mock_abspath, mock_exists):
+    """Should return absolute path if given and exists"""
+    mock_abspath.return_value = True
+    mock_exists.return_value = True
+    virtualenv.is_executable = Mock(return_value=True)
+
+    mock_abspath.start()
+    mock_exists.start()
+
+    exe = virtualenv.resolve_interpreter("/usr/bin/python42")
+
+    assert exe == "/usr/bin/python42", "Absolute path should return as is"
+    mock_abspath.assert_called_with("/usr/bin/python42")
+    mock_exists.assert_called_with("/usr/bin/python42")
+    virtualenv.is_executable.assert_called_with("/usr/bin/python42")
+
+    mock_abspath.stop()
+    mock_exists.stop()
+
+@patch('os.path.exists')
+@patch('os.path.abspath')
+def test_resolve_intepreter_with_nonexistant_interpreter(mock_abspath, mock_exists):
+    """Should exit when with absolute path if not exists"""
+    mock_abspath.return_value = True
+    mock_exists.return_value = False
+    
+    mock_abspath.start()
+    mock_exists.start()
+
+    try:
+        exe = virtualenv.resolve_interpreter("/usr/bin/python42")
+        assert False, "Should raise exception"
+    except SystemExit:
+        pass
+        
+    mock_abspath.assert_called_with("/usr/bin/python42")
+    mock_exists.assert_called_with("/usr/bin/python42")
+
+    mock_abspath.stop()
+    mock_exists.stop()
+
+@patch('os.path.exists')
+@patch('os.path.abspath')
+def test_resolve_intepreter_with_invalid_interpreter(mock_abspath, mock_exists):
+    """Should exit when with absolute path if not exists"""
+    mock_abspath.return_value = True
+    mock_exists.return_value = True
+    virtualenv.is_executable = Mock(return_value=False)
+    
+    mock_abspath.start()
+    mock_exists.start()
+
+    try:
+        exe = virtualenv.resolve_interpreter("/usr/bin/python42")
+        assert False, "Should raise exception"
+    except SystemExit:
+        pass
+        
+    mock_abspath.assert_called_with("/usr/bin/python42")
+    mock_exists.assert_called_with("/usr/bin/python42")
+    virtualenv.is_executable.assert_called_with("/usr/bin/python42")
+
+    mock_abspath.stop()
+    mock_exists.stop()

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1228,8 +1228,15 @@ def resolve_interpreter(exe):
                 break
     if not os.path.exists(exe):
         logger.fatal('The executable %s (from --python=%s) does not exist' % (exe, exe))
-        sys.exit(3)
+        raise SystemExit(3)
+    if not is_executable(exe):
+        logger.fatal('The executable %s (from --python=%s) is not executable' % (exe, exe))
+        raise SystemExit(3)
     return exe
+
+def is_executable(exe):
+    """Checks a file is executable"""
+    return os.access(exe, os.X_OK)
 
 ############################################################
 ## Relocating the environment:


### PR DESCRIPTION
Fixes #121

Add tests for virtualenv  with nose and mock
Add helper method to virtualenv for is_executable
Raise SystemExit rather than sys.exit directly

Tested on 2.4.4, 2.7.1 and 3.2

This time without .swp file 
