### PR TITLE
Windows: include dir was not copied into env due to

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -41,6 +41,7 @@ py_version = 'python%s.%s' % (sys.version_info[0], sys.version_info[1])
 
 is_jython = sys.platform.startswith('java')
 is_pypy = hasattr(sys, 'pypy_version_info')
+is_win  = (sys.platform == 'win32')
 abiflags = getattr(sys, 'abiflags', '')
 
 if is_pypy:
@@ -1039,7 +1040,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear):
             logger.info('Deleting %s' % site_packages_filename)
             os.unlink(site_packages_filename)
 
-    if is_pypy:
+    if is_pypy or is_win:
         stdinc_dir = join(prefix, 'include')
     else:
         stdinc_dir = join(prefix, 'include', py_version + abiflags)


### PR DESCRIPTION
invalid source path specification

--- test-venv.before.log
+++ test-venv.after.log
@@ -31,3 +31,3 @@
 Writing test-venv\lib\orig-prefix.txt
-No include dir C:~env\Python26\include\python2.6
+Copying to test-venv\Include
 Creating test-venv\Scripts
