### PR TITLE
Add missing lib required to run py33 in venv

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -117,7 +117,7 @@ elif majver == 3:
             #"dis",
             #"doctest",
             #"dummy_threading",
-            #"_dummy_thread",
+            "_dummy_thread",
             #"email",
             #"filecmp",
             #"fileinput",


### PR DESCRIPTION
Manually tested based on how the integration tests run. This stops the aborts and gives a running python interpreter in the virtualenv
