### PR TITLE
Add option to set environment variable VIRTUALENV_NO_SITE_PACKAGES

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -707,7 +707,8 @@ def main():
         dest='no_site_packages',
         action='store_true',
         help="Don't give access to the global site-packages dir to the "
-             "virtual environment")
+             "virtual environment. Set environ variable "
+             "VIRTUALENV_NO_SITE_PACKAGES to make it the default.")
 
     parser.add_option(
         '--unzip-setuptools',
@@ -725,7 +726,7 @@ def main():
     parser.add_option(
         '--distribute',
         dest='use_distribute',
-        action='store_true',
+        action='store_true',/
         help='Use Distribute instead of Setuptools. Set environ variable '
         'VIRTUALENV_USE_DISTRIBUTE to make it the default ')
 
@@ -895,6 +896,9 @@ def create_environment(home_dir, site_packages=True, clear=False,
     first be cleared.
     """
     home_dir, lib_dir, inc_dir, bin_dir = path_locations(home_dir)
+
+    if os.environ.get('VIRTUALENV_NO_SITE_PACKAGES'):
+        site_packages=False
 
     py_executable = os.path.abspath(install_python(
         home_dir, lib_dir, inc_dir, bin_dir,


### PR DESCRIPTION
Add option to set environment variable VIRTUALENV_NO_SITE_PACKAGES to make it the default.

This is way faster than:

$ mkvirtualenv newproject
New python executable in newproject/bin/python
Installing distribute..................................................................................................................................................................................done.
$ # doh!
$ rmvirtualenv newproject
$ mkvirtualenv newproject --no-site-packages
