### PR TITLE
invert site-packages behavior

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -207,15 +207,16 @@ On Windows you just do::
 
 And use ``deactivate.bat`` to undo the changes.
 
-The ``--no-site-packages`` Option
+The ``--use-site-packages`` Option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you build with ``virtualenv --no-site-packages ENV`` it will *not*
-inherit any packages from ``/usr/lib/python2.5/site-packages`` (or
-wherever your global site-packages directory is).  This can be used if
-you don't have control over site-packages and don't want to depend on
-the packages there, or you just want more isolation from the global
-system.
+If you build with ``virtualenv --use-site-packages ENV``, your virtual
+environment will inherit packages from ``/usr/lib/python2.5/site-packages``
+(or wherever your global site-packages directory is).
+
+This can be used if you have control over the global site-packages directory,
+and you want to depend on the packages there.  If you want isolation from the
+global system, do not use this flag.
 
 Using Virtualenv without ``bin/python``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -236,8 +237,7 @@ can setup the environment like::
 This will change ``sys.path`` and even change ``sys.prefix``, but also allow
 you to use an existing interpreter.  Items in your environment will show up
 first on ``sys.path``, before global items.  However, global items will
-always be accessible -- this technique does not support the
-``--no-site-packages`` flag.  Also, this cannot undo the activation of other
+always be accessible.  Also, this cannot undo the activation of other
 environments, or modules that have been imported.  You shouldn't try to, for
 instance, activate an environment before a web request; you should activate
 *one* environment as early as possible, and not do it again in that process.
@@ -277,8 +277,8 @@ libraries on the system, if those C libraries are located somewhere
 different (either different versions, or a different filesystem
 layout).
 
-Currently the ``--no-site-packages`` option will not be honored if you
-use this on an environment.
+If you use this flag to create an environment, currently, the
+``--use-site-packages`` option will be implied.
 
 The ``--extra-search-dir`` Option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/news.txt
+++ b/docs/news.txt
@@ -6,6 +6,16 @@ Next release (1.7) schedule
 
 Beta release mid-July 2011, final release early August.
 
+Next release
+~~~~~~~~~~~~
+
+* Made ``--no-site-packages`` behavior the default behavior.  The
+  ``--no-site-packages`` flag is still permitted, but displays a warning when
+  used.
+
+* New flag: ``--use-site-packages``; this flag should be passed to get the
+  previous default global-site-package-including behavior back.
+
 1.6.4 (2011-07-21)
 ~~~~~~~~~~~~~~~~~~
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -494,7 +494,7 @@ def _install_req(py_executable, unzip=False, distribute=False,
                 if not hasattr(pkg_resources, '_distribute'):
                     location = os.path.dirname(pkg_resources.__file__)
                     logger.notify("A globally installed setuptools was found (in %s)" % location)
-                    logger.notify("Use the --no-site-packages option to use distribute in "
+                    logger.notify("Refrain from using the --use-site-packages option to use distribute in "
                                   "the virtualenv.")
             except ImportError:
                 pass
@@ -710,6 +710,13 @@ def main():
              "virtual environment")
 
     parser.add_option(
+        '--use-site-packages',
+        dest='use_site_packages',
+        action='store_true',
+        help="Give access to the global site-packages dir to the "
+             "virtual environment")
+
+    parser.add_option(
         '--unzip-setuptools',
         dest='unzip_setuptools',
         action='store_true',
@@ -802,7 +809,13 @@ def main():
         make_environment_relocatable(home_dir)
         return
 
-    create_environment(home_dir, site_packages=not options.no_site_packages, clear=options.clear,
+    if options.no_site_packages:
+        logger.warn('The --no-site-packages flag is deprecated; it is now '
+                    'the default behavior.')
+
+    create_environment(home_dir,
+                       site_packages=options.use_site_packages,
+                       clear=options.clear,
                        unzip_setuptools=options.unzip_setuptools,
                        use_distribute=options.use_distribute or majver > 2,
                        prompt=options.prompt,
@@ -882,14 +895,14 @@ def call_subprocess(cmd, show_stdout=True,
                 % (cmd_desc, proc.returncode))
 
 
-def create_environment(home_dir, site_packages=True, clear=False,
+def create_environment(home_dir, site_packages=False, clear=False,
                        unzip_setuptools=False, use_distribute=False,
                        prompt=None, search_dirs=None, never_download=False):
     """
     Creates a new environment in ``home_dir``.
 
-    If ``site_packages`` is true (the default) then the global
-    ``site-packages/`` directory will be on the path.
+    If ``site_packages`` is true, then the global ``site-packages/``
+    directory will be on the path.
 
     If ``clear`` is true (default False) then the environment will
     first be cleared.


### PR DESCRIPTION
Virtualenv is used, primarily, to create an isolated packaging environment.  The current default use-site-packages behavior is suboptimal for this purpose.  New users (and some experienced users) invariably fail to pass the flag even when instructions to do so are in blinking red text in a 72 point font, and they wind up in a place where they have conflicting global and virtualenv packages.  This is, by far, the most common support issue I've experienced in regards to instructing other people to use virtualev.

It would make a lot more sense if virtualenv defaulted to `--no-site-packages` behavior.  This patch does that, and adds a `--use-site-packages` flag to get the old behavior back.
