### PR TITLE
If $PYTHONDONTWRITEBYTECODE is set, issue a useful error message and die

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -783,7 +783,10 @@ def main():
                 file = file[:-1]
             popen = subprocess.Popen([interpreter, file] + sys.argv[1:], env=env)
             raise SystemExit(popen.wait())
-
+    
+    if os.environ.get('PYTHONDONTWRITEBYTECODE'):
+        print('You must unset the $PYTHONDONTWRITEBYTECODE environment variable before running virtualenv.')
+        sys.exit(2)
     if not args:
         print('You must provide a DEST_DIR')
         parser.print_help()


### PR DESCRIPTION
It's always annoying when you want to create a virtualenv and it fails, but the error message hides the useful information ("error:byte-compiling is disabled") in a big stacktrace. I thing this could be made more clear, by specifying the exact thing you need to fix and by failing faster.
