### PR TITLE
Interpret path in filesystem encoding

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1252,9 +1252,9 @@ sys.stdout.write(prefix)
 
     proc_stdout = proc_stdout.strip().decode("utf-8")
     proc_stdout = os.path.normcase(os.path.abspath(proc_stdout))
-    if hasattr(home_dir, 'decode'):
-        home_dir = home_dir.decode(sys.getfilesystemencoding())
     norm_home_dir = os.path.normcase(os.path.abspath(home_dir))
+    if hasattr(norm_home_dir, 'decode'):
+        norm_home_dir = norm_home_dir.decode(sys.getfilesystemencoding())
     if proc_stdout != norm_home_dir:
         logger.fatal(
             'ERROR: The executable %s is not functioning' % py_executable)
@@ -1296,13 +1296,14 @@ def install_activate(home_dir, bin_dir, prompt=None):
 
 
     files['activate_this.py'] = ACTIVATE_THIS
+    home_dir = os.path.abspath(home_dir)
     if hasattr(home_dir, 'decode'):
         home_dir = home_dir.decode(sys.getfilesystemencoding())
-    vname = os.path.basename(os.path.abspath(home_dir))
+    vname = os.path.basename(home_dir)
     for name, content in files.items():
         content = content.replace('__VIRTUAL_PROMPT__', prompt or '')
         content = content.replace('__VIRTUAL_WINPROMPT__', prompt or '(%s)' % vname)
-        content = content.replace('__VIRTUAL_ENV__', os.path.abspath(home_dir))
+        content = content.replace('__VIRTUAL_ENV__', home_dir)
         content = content.replace('__VIRTUAL_NAME__', vname)
         content = content.replace('__BIN_NAME__', os.path.basename(bin_dir))
         writefile(os.path.join(bin_dir, name), content)


### PR DESCRIPTION
(as opposed to platform default encoding)

This resolves pypa/virtualenv#186 ... but that leaves the virtualenv
creation to fail on the next hurdle, which is:

```
New python executable in FOO/bin/python
/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/virtualenv-1.6.4-py2.7.egg/virtualenv.py:1233:
UnicodeWarning: Unicode unequal comparison failed to convert both
arguments to Unicode - interpreting them as being unequal
  if proc_stdout != os.path.normcase(os.path.abspath(home_dir)):
ERROR: The executable GED27/bin/python is not functioning
ERROR: It thinks sys.prefix is u'/Users/gthb/quickies/\xc6ttartal/GED27'
(should be '/Users/gthb/quickies/\xc3\x86ttartal/GED27')
ERROR: virtualenv is not compatible with this system or executable
```

and that, I guess is a Python bug. Still, this change gets virtualenv
doing the right thing, plus it makes the attempt fail in an
easier-to-understand manner.
