### PR TITLE
Fixed sanity check for bytecode and setuptools vs distribute

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -883,7 +883,8 @@ def main():
     if majver > 2:
         options.use_distribute = True
 
-    if os.environ.get('PYTHONDONTWRITEBYTECODE') and not options.use_distribute:
+    if (os.environ.get('PYTHONDONTWRITEBYTECODE') and 
+        not (options.use_distribute or os.environ.get('VIRTUALENV_USE_DISTRIBUTE'))):
         print(
             "The PYTHONDONTWRITEBYTECODE environment variable is "
             "not compatible with setuptools. Either use --distribute "


### PR DESCRIPTION
Currently if both PYTHONDONTWRITEBYTECODE and VIRTUALENV_USE_DISTRIBUTE are set, the creation of an environment still fails because the byte code sanity check fails to take into account the environment variable. 

This update changes the bytecode sanity check to check for distribute via command line and the environment variable.

Hopefully I didn't screw up this pull request. :)

chad
