### PR TITLE
Give precedence to --extra-search-dir paths when finding distribute/setuptools 

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -469,12 +469,9 @@ def make_exe(fn):
         logger.info('Changed mode of %s to %s', fn, oct(newmode))
 
 def _find_file(filename, dirs):
-    matches = []
-    for dir in dirs:
+    for dir in reversed(dirs):
         if os.path.exists(join(dir, filename)):
-            matches.append(join(dir, filename))
-    if len(matches):
-        return matches[-1]
+            return join(dir, filename)
     return filename
 
 def _install_req(py_executable, unzip=False, distribute=False,


### PR DESCRIPTION
Currently the first matching setuptools/distribute package is installed by virtualenv.  Since `--extra-search-dir` paths are _appended_ to the `search_dirs` list, this means that the default search_dirs (`virtualenv_support` etc) always have precedence over the user-provided search dirs.

The opposite seems like it would be more useful, since it would allow a user to circumvent the default installations without needing to dig through system files and delete `virtualenv_support` directories.  See #181 for an example where someone tried to do exactly this, but failed because of the current behavior.
