### PR TITLE
Fix for PYTHONDONTWRITEBYTECODE Nuance

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -883,7 +883,9 @@ def main():
     if majver > 2:
         options.use_distribute = True
 
-    if os.environ.get('PYTHONDONTWRITEBYTECODE') and not options.use_distribute:
+    if os.environ.get('PYTHONDONTWRITEBYTECODE') and not (
+        options.use_distribute or os.environ.get('VIRTUALENV_USE_DISTRIBUTE')):
+
         print(
             "The PYTHONDONTWRITEBYTECODE environment variable is "
             "not compatible with setuptools. Either use --distribute "


### PR DESCRIPTION
If you have both the `PYTHONDONTWRITEBYTECODE` and `VIRTUALENV_USE_DISTRIBUTE` environment variables set, virtualenv yells at you, because it only checks for the `--distribute` flag.
