### PR TITLE
Fix for #87, #160, and #176 using virtualenv on Windows with multiple python installs and/or cygwin/MingW

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1379,7 +1379,11 @@ sys.stdout.write(prefix)
             'ERROR: virtualenv is not compatible with this system or executable')
         if sys.platform == 'win32':
             logger.fatal(
-                'Note: some Windows users have reported this error when they installed Python for "Only this user".  The problem may be resolvable if you install Python "For all users".  (See https://bugs.launchpad.net/virtualenv/+bug/352844)')
+                'Note: some Windows users have reported this error when they '
+                'installed Python for "Only this user" or have multiple '
+                'versions of Python installed. Copying the appropriate '
+                'PythonXX.dll to the virtualenv Scripts/ directory may fix '
+                'this problem.')
         sys.exit(100)
     else:
         logger.info('Got sys.prefix result: %r' % proc_stdout)


### PR DESCRIPTION
https://github.com/greghaskins/virtualenv/commit/d681c0ff9afbfba1fb225edc24fbab8bb9212678

To always create an activate on windows which can be used by cygwin and
mingw even for native windows python.

Added fix for bug #352844 "Windows: cannot create virtualenv on different
drive from system Python executable"

The real problem is that on windows, the DLL loading will look for the DLL
using the following criteria:
1. same directory as the exe
2. first occurance on the DLL lookup path in the registry
3. first occurance on the shell/system PATH vairable

The python.exe on windows relies on 1. This causes a problem if you have
multiple versions of python on your machine (32bit and 64bit for instance),
or if python was only installed for one user and thus is not placed in
registry path location (the windows system dir).

We should always copy the .dll as well on windows to make sure there is not
a conflict.
