### PR TITLE
Update site.py for Debian's py3k layout

### DIFF
--- a/virtualenv_support/site.py
+++ b/virtualenv_support/site.py
@@ -246,9 +246,14 @@ def addsitepackages(known_paths, sys_prefix=sys.prefix, exec_prefix=sys.exec_pre
                 except AttributeError:
                     pass
                 # Debian-specific dist-packages directories:
-                sitedirs.append(os.path.join(prefix, "lib",
-                                             "python" + sys.version[:3],
-                                             "dist-packages"))
+                if sys.version[0] == '2':
+                    sitedirs.append(os.path.join(prefix, "lib",
+                                                 "python" + sys.version[:3],
+                                                 "dist-packages"))
+                else:
+                    sitedirs.append(os.path.join(prefix, "lib",
+                                                 "python" + sys.version[0],
+                                                 "dist-packages"))
                 sitedirs.append(os.path.join(prefix, "local/lib",
                                              "python" + sys.version[:3],
                                              "dist-packages"))


### PR DESCRIPTION
Debian installs all Python 3.x site modules in one directory, taking
advantage of PEP3147 and PEP3149: /usr/lib/python3/dist-packages/
Unlike 2.x, where each minor Python version has its own site modules
tree.
