### PR TITLE
Make fixup_scripts() unicode-aware so it works under Python 3.

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1557,8 +1557,15 @@ def fixup_scripts(home_dir):
             # ignore subdirs, e.g. .svn ones.
             continue
         f = open(filename, 'rb')
-        lines = f.readlines()
-        f.close()
+        try:
+            try:
+                lines = f.read().decode('utf-8').splitlines()
+            except UnicodeDecodeError:
+                # This is probably a binary program instead
+                # of a script, so just ignore it.
+                continue
+        finally:
+            f.close()
         if not lines:
             logger.warn('Script %s is an empty file' % filename)
             continue
@@ -1574,7 +1581,7 @@ def fixup_scripts(home_dir):
         logger.notify('Making script %s relative' % filename)
         lines = [new_shebang+'\n', activate+'\n'] + lines[1:]
         f = open(filename, 'wb')
-        f.writelines(lines)
+        f.write(lines.join('\n').encode('utf-8'))#writelines(lines)
         f.close()
 
 def fixup_pth_and_egg_link(home_dir, sys_path=None):


### PR DESCRIPTION
I ran into a problem with virtualenv under Python 3.2.2 while testing virtualenvwrapper support for Python 3. The --relocatable flag was causing a traceback because the script file contents were not being decoded before string operations were applied:

```
Traceback (most recent call last):
  File "/Users/dhellmann/Devel/virtualenvwrapper/dakra/.tox/py32/bin/virtualenv", line 9, in <module>
    load_entry_point('virtualenv==1.7', 'console_scripts', 'virtualenv')()
  File "/Users/dhellmann/Devel/virtualenvwrapper/dakra/.tox/py32/lib/python3.2/site-packages/virtualenv.py", line 914, in main
    make_environment_relocatable(home_dir)
  File "/Users/dhellmann/Devel/virtualenvwrapper/dakra/.tox/py32/lib/python3.2/site-packages/virtualenv.py", line 1484, in make_environment_relocatable
    fixup_scripts(home_dir)
  File "/Users/dhellmann/Devel/virtualenvwrapper/dakra/.tox/py32/lib/python3.2/site-packages/virtualenv.py", line 1514, in fixup_scripts
    if not lines[0].strip().startswith(shebang):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

This changeset fixes the problem by decoding the bytes being read from script files before checking the contents of the first line and reencoding them before writing any changes. Files that cannot be decoded are skipped entirely under the assumption that they are binary files. An alternate solution would be to pass bytes to startswith(), but that wasn't backwards-compatible.
