### PR TITLE
Suppress warning message when bash hashing is disabled.

### DIFF
--- a/virtualenv_embedded/activate.sh
+++ b/virtualenv_embedded/activate.sh
@@ -18,7 +18,7 @@ deactivate () {
     # be called to get it to forget past commands.  Without forgetting
     # past commands the $PATH changes we made may not be respected
     if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
-        hash -r
+        hash -r 2>/dev/null
     fi
 
     if [ -n "$_OLD_VIRTUAL_PS1" ] ; then
@@ -72,5 +72,5 @@ fi
 # be called to get it to forget past commands.  Without forgetting
 # past commands the $PATH changes we made may not be respected
 if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
-    hash -r
+    hash -r 2>/dev/null
 fi


### PR DESCRIPTION
I have hashing disabled in bash (because I think the benefits are dubious nowadays and that way I don't have to remember to clear the hash cache when I install a new program, etc.) But whenever I use virtualenv's "activate" script, I get the following warning (twice): "bash: hash: hashing disabled".

The following branch suppresses said warning by redirecting the stderr of the "hash" builtin to /dev/null. Please consider merging.
