### PR TITLE
Read first line from file as link path

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1667,7 +1667,7 @@ def fixup_pth_file(filename):
 
 def fixup_egg_link(filename):
     f = open(filename)
-    link = f.read().strip()
+    link = f.readline().strip()
     f.close()
     if os.path.abspath(link) != link:
         logger.debug('Link in %s already relative' % filename)


### PR DESCRIPTION
In some cases, (e.g. cherrypy and pyaml) when installed from github, results in a egg-link file that has two paths:

/home/kyle/env/src/yaml/lib
../

The consequence of such an egg-link is that virtualenv believes that the file is already relative, even if it clearly isn't.

Although asking why the above malformed egg-link occurs is something I am still investigating, I think it should be considered whether using readline is better than read, given that file paths can't contain new lines anyway. 
