### PR TITLE
Add "default; deprecated" info/help to --no-site-packages option.

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -811,7 +811,7 @@ def main():
         dest='no_site_packages',
         action='store_true',
         help="Don't give access to the global site-packages dir to the "
-             "virtual environment")
+             "virtual environment (default; deprecated)")
 
     parser.add_option(
         '--system-site-packages',


### PR DESCRIPTION
I had to look at virtualenv's source to figure out if/that the behavior of site-packages handling changed and would have liked to see it mentioned in the help.
