### PR TITLE
writefile: fix content comparison

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -443,7 +443,7 @@ def writefile(dest, content, overwrite=True):
         f = open(dest, 'rb')
         c = f.read()
         f.close()
-        if c != content:
+        if c != content.encode("utf-8"):
             if not overwrite:
                 logger.notify('File %s exists with different content; not overwriting', dest)
                 return


### PR DESCRIPTION
When running twice the same command to create a virtual environment I get the following error:

```
k:\py\virtualenv\virtualenv.py:446: UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if c != content:
Overwriting a1\Scripts\activate.ps1 with new content
```

This patch works on my PC.

Environment:
- Python 2.6.6 & 2.7.3
- virtualenv virtualenv 1.7.1.2 & tip
- Windows 7 x64 & Windows Server 2008 x64
