### PR TITLE
Include bin in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+recursive-include bin *
 recursive-include docs *.txt
 recursive-include scripts *
 recursive-include virtualenv_support *.egg *.tar.gz


### PR DESCRIPTION
In issue #199, we added `virtualenv_support` to the `sdist` tarball, so that `virtualenv.py` can be rebuilt, without needing a git checkout. Unfortunately, the necessary script to do that work isn't being included in the `sdist` tarball any more.
