### PR TITLE
Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error on exit of `python setup.py test`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,16 @@ f = open(os.path.join(here, 'docs', 'news.txt'))
 long_description += "\n\n" + f.read()
 f.close()
 
+
+# Hack to prevent stupid TypeError: 'NoneType' object is not callable error on
+# exit of python setup.py test # in multiprocessing/util.py _exit_function when
+# running python setup.py test (see
+# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
+try:
+    import multiprocessing
+except ImportError:
+    pass
+
 setup(name='virtualenv',
       # If you change the version here, change it in virtualenv.py and
       # docs/conf.py as well


### PR DESCRIPTION
Hack to prevent stupid `TypeError: 'NoneType' object is not callable` error on exit of `python setup.py test`
in `multiprocessing/util.py` `_exit_function` when running `python setup.py test` (see
http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
