### PR TITLE
Fix option string for the prompt option

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -857,7 +857,7 @@ def main():
         "if local distributions of setuptools/distribute/pip are not present.")
 
     parser.add_option(
-        '--prompt=',
+        '--prompt',
         dest='prompt',
         help='Provides an alternative prompt prefix for this environment')
 


### PR DESCRIPTION
Option string should be '--prompt' and not '--prompt='. Its current
form prevents it to be used in configuration files (e.g.
virtualenv.ini) although it doesn't seem to cause any problems on the
command line.
