### PR TITLE
Fixing bytes/str mismatch in create_bootstrap_script()

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -4,11 +4,12 @@
 
 # If you change the version here, change it in setup.py
 # and docs/conf.py as well.
-virtualenv_version = "1.7.1.2.post1"
+virtualenv_version = "1.7.1.2.fix"
 
 import base64
 import sys
 import os
+import codecs
 import optparse
 import re
 import shutil
@@ -1759,13 +1760,12 @@ def create_bootstrap_script(extra_text, python_version=''):
     filename = __file__
     if filename.endswith('.pyc'):
         filename = filename[:-1]
-    f = open(filename, 'rb')
-    content = f.read()
-    f.close()
+    with codecs.open(filename, 'r', encoding='utf-8') as f:
+        content = f.read()
     py_exe = 'python%s' % python_version
     content = (('#!/usr/bin/env %s\n' % py_exe)
-               + '## WARNING: This file is generated\n'
-               + content)
+              + '## WARNING: This file is generated\n'
+              + content)
     return content.replace('##EXT' 'END##', extra_text)
 
 ##EXTEND##


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/vent", line 4, in <module>
    vent.main()
  File "/usr/lib/python3.2/site-packages/vent.py", line 21, in main
    contents = virtualenv.create_bootstrap_script(BOOTSTRAP)
  File "/usr/lib/python3.2/site-packages/virtualenv.py", line 1759, in create_bootstrap_script
    + content)
TypeError: Can't convert 'bytes' object to str implicitly

On a Python 3.2.3 environment with latest virtualenv installed

Relevant part of code:

``` python

    filename = __file__
    if filename.endswith('.pyc'):
        filename = filename[:-1]

    f = open(filename, 'rb')     # Point 1, mode: bytes
    content = f.read()
    f.close()

    py_exe = 'python%s' % python_version

    content = (('#!/usr/bin/env %s\n' % py_exe)
               + '## WARNING: This file is generated\n'
               + content)       # Point 2, Concat bytes and str?

    return content.replace('##EXT' 'END##', extra_text)
```

Instead, opening the file without the b flag, or using codecs.open() allows the program to run with no errors.

Essentially, the virtualenv.py file was being read in byte mode. These bytes were then joined to strings, resulting in a type error.

It has been repeatedly drummed into my head that opening a file without specifying its encoding is a bad idea, so instead of just removing the b flag, I opted to interface with the files using the codecs module.
