### PR TITLE
remove special case for user_dir on win32 platform

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -56,7 +56,6 @@ abiflags = getattr(sys, 'abiflags', '')
 
 user_dir = os.path.expanduser('~')
 if sys.platform == 'win32':
-    user_dir = os.environ.get('APPDATA', user_dir)  # Use %APPDATA% for roaming
     default_storage_dir = os.path.join(user_dir, 'virtualenv')
 else:
     default_storage_dir = os.path.join(user_dir, '.virtualenv')


### PR DESCRIPTION
Align with the pip way of locating the config file, see:

https://github.com/pypa/pip/commit/3e1e131da0449daf7fe22f8704fa94c15c48c434

https://github.com/pypa/pip/issues/82
