### PR TITLE
fix update_defaults for options with 'store_false' action

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1,4 +1,5 @@
 import virtualenv
+import optparse
 from mock import patch, Mock
 
 
@@ -48,3 +49,27 @@ def test_resolve_intepreter_with_invalid_interpreter(mock_exists):
 
     mock_exists.assert_called_with("/usr/bin/python42")
     virtualenv.is_executable.assert_called_with("/usr/bin/python42")
+
+
+def test_cop_update_defaults_with_store_false():
+    """store_false options need reverted logic"""
+    class MyConfigOptionParser(virtualenv.ConfigOptionParser):
+        def __init__(self, *args, **kwargs):
+            self.config = virtualenv.ConfigParser.RawConfigParser()
+            self.files = []
+            optparse.OptionParser.__init__(self, *args, **kwargs)
+
+        def get_environ_vars(self, prefix='VIRTUALENV_'):
+            yield ("no_site_packages", "1")
+
+    cop = MyConfigOptionParser()
+    cop.add_option(
+        '--no-site-packages',
+        dest='system_site_packages',
+        action='store_false',
+        help="Don't give access to the global site-packages dir to the "
+             "virtual environment (default)")
+
+    defaults = {}
+    cop.update_defaults(defaults)
+    assert defaults == {'system_site_packages': 0}

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -732,7 +732,9 @@ class ConfigOptionParser(optparse.OptionParser):
                     val = val.split()
                 else:
                     option.nargs = 1
-                if option.action in ('store_true', 'store_false', 'count'):
+                if option.action == 'store_false':
+                    val = not strtobool(val)
+                elif option.action in ('store_true', 'count'):
                     val = strtobool(val)
                 try:
                     val = option.convert_value(key, val)


### PR DESCRIPTION
these need to revert the logic, otherwise calling virtualenv with
VIRTUALENV_NO_SITE_PACKAGES=1 set will create a virtual _with_ site
packages.

also adds a test
