### PR TITLE
Fix `--relocatable` on systems that use lib64.

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1551,7 +1551,8 @@ def fix_lib64(lib_dir):
         lib_parent = os.path.dirname(lib_dir)
         assert os.path.basename(lib_parent) == 'lib', (
             "Unexpected parent dir: %r" % lib_parent)
-        copyfile(lib_parent, os.path.join(os.path.dirname(lib_parent), 'lib64'))
+        os.symlink(os.path.join('.', os.path.basename(lib_parent)),
+                   os.path.join(os.path.dirname(lib_parent), 'lib64'))
 
 def resolve_interpreter(exe):
     """


### PR DESCRIPTION
#78 bit me. Hopefully this commit fixes it without creating any new problems. I considered altering `copyfile` to take an additional `relative` flag, but that got complicated pretty quick. I figure that since this is the only client code that requires the behavior, a direct call to `os.symlink` is more prudent.
