### PR TITLE
Fix paths of users' site-packages on OSX

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1113,10 +1113,15 @@ def change_prefix(filename, dst_prefix):
         prefixes.extend((
             os.path.join("/Library/Python", sys.version[:3], "site-packages"),
             os.path.join(sys.prefix, "Extras", "lib", "python"),
-            os.path.join("~", "Library", "Python", sys.version[:3], "site-packages")))
+            os.path.join("~", "Library", "Python", sys.version[:3], "site-packages"),
+            # Python 2.6 no-frameworks
+            os.path.join("~", ".local", "lib","python", sys.version[:3], "site-packages"),
+            # System Python 2.7 on OSX Mountain Lion
+            os.path.join("~", "Library", "Python", sys.version[:3], "lib", "python", "site-packages")))
 
     if hasattr(sys, 'real_prefix'):
         prefixes.append(sys.real_prefix)
+    prefixes = list(map(os.path.expanduser, prefixes))
     prefixes = list(map(os.path.abspath, prefixes))
     filename = os.path.abspath(filename)
     for src_prefix in prefixes:


### PR DESCRIPTION
I have virtualenv installed with the option ˆ--userˆ on OSX Mountain Lion.
Files are located in ˆ$HOME/Library/Python/2.7/lib/python/site-packages'ˆ

Trying to create a new environment I get the following error:

```
$ virtualenv testenv
Traceback (most recent call last):
  File "/Users/antonio/Library/Python/2.7/bin/virtualenv", line 9, in <module>
    load_entry_point('virtualenv==1.7.2', 'console_scripts', 'virtualenv')()
  File "/Users/antonio/Library/Python/2.7/lib/python/site-packages/virtualenv.py", line 942, in main
    never_download=options.never_download)
  File "/Users/antonio/Library/Python/2.7/lib/python/site-packages/virtualenv.py", line 1043, in create_environment
    site_packages=site_packages, clear=clear))
  File "/Users/antonio/Library/Python/2.7/lib/python/site-packages/virtualenv.py", line 1188, in install_python
    copy_required_modules(home_dir)
  File "/Users/antonio/Library/Python/2.7/lib/python/site-packages/virtualenv.py", line 1140, in copy_required_modules
    dst_filename = change_prefix(filename, dst_prefix)
  File "/Users/antonio/Library/Python/2.7/lib/python/site-packages/virtualenv.py", line 1115, in change_prefix
    (filename, prefixes)
AssertionError: Filename /Users/antonio/Library/Python/2.7/lib/python/site-packages/readline.so does not start with any of these prefixes: ['/System/Library/Frameworks/Python.framework/Versions/2.7', '/Library/Python/2.7/site-packages', '/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python', '/Users/antonio/projects/~/Library/Python/2.7/site-packages']
```

This pull request fixes this issue.
