### PR TITLE
Fix assert error when virtual path shares a common prefix with real path

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1134,6 +1134,8 @@ def change_prefix(filename, dst_prefix):
         prefixes.append(sys.base_prefix)
     prefixes = list(map(os.path.expanduser, prefixes))
     prefixes = list(map(os.path.abspath, prefixes))
+    # Check longer prefixes first so we don't split in the middle of a filename
+    prefixes = sorted(prefixes, key=len, reverse=True)
     filename = os.path.abspath(filename)
     for src_prefix in prefixes:
         if filename.startswith(src_prefix):


### PR DESCRIPTION
If (real) Python is installed at (say) `/opt/python2.7.3` and you have a
virtualenv at `/opt/python`, `change_prefix()` will try to split off
`/opt/python` from a path like `/opt/python2.7.3/lib/python2.7/distutils`,
leaving `2.7.3/lib/python2.7/distutils`, which is not valid and fails
the assert.

This patch sorts the list of prefixes by length, so the longer path is
tried before its prefix.
