### PR TITLE
Fix activate.csh so that it will work in non-interactive environments

### DIFF
--- a/virtualenv_embedded/activate.csh
+++ b/virtualenv_embedded/activate.csh
@@ -12,7 +12,7 @@ setenv VIRTUAL_ENV "__VIRTUAL_ENV__"
 set _OLD_VIRTUAL_PATH="$PATH"
 setenv PATH "$VIRTUAL_ENV/__BIN_NAME__:$PATH"
 
-set _OLD_VIRTUAL_PROMPT="$prompt"
+
 
 if ("__VIRTUAL_PROMPT__" != "") then
     set env_name = "__VIRTUAL_PROMPT__"
@@ -25,7 +25,15 @@ else
         set env_name = `basename "$VIRTUAL_ENV"`
     endif
 endif
-set prompt = "[$env_name] $prompt"
+
+# Could be in a non-interactive environment,
+# in which case, $prompt is undefined and we wouldn't
+# care about the prompt anyway.
+if ( $?prompt ) then
+    set _OLD_VIRTUAL_PROMPT="$prompt"
+    set prompt = "[$env_name] $prompt"
+endif
+
 unset env_name
 
 alias pydoc python -m pydoc


### PR DESCRIPTION
The access of the $prompt variable was causing "source" commands to error out, thereby causing issues with non-interactive sessions such as "scp" and sourcing while in crontabs.  This fix merely moves the two lines inside a single if-block.  Note that I am not sure why the first line was positioned where it was, so if I am wrong to move it, just let me know.
