### PR TITLE
Cleaner fish prompt-switching behavior

### DIFF
--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -13,13 +13,13 @@ function deactivate  -d "Exit virtualenv and return to normal shell environment"
     end
     
     if test -n "$_OLD_FISH_PROMPT_OVERRIDE"
+        # set an empty local fish_function_path, so fish_prompt doesn't automatically reload
+        set -l fish_function_path
+        # erase the virtualenv's fish_prompt function, and restore the original
         functions -e fish_prompt
-        set -e _OLD_FISH_PROMPT_OVERRIDE
-        . ( begin
-                printf "function fish_prompt\n\t#"
-                functions _old_fish_prompt
-            end | psub )
+        functions -c _old_fish_prompt fish_prompt
         functions -e _old_fish_prompt
+        set -e _OLD_FISH_PROMPT_OVERRIDE
     end
     
     set -e VIRTUAL_ENV
@@ -46,17 +46,15 @@ end
 if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
     # fish uses a function instead of an env var to generate the prompt.
     
-    # save the current fish_prompt function as the function _old_fish_prompt
-    . ( begin
-            printf "function _old_fish_prompt\n\t#"
-            functions fish_prompt
-        end | psub )
+    # copy the current fish_prompt function as the function _old_fish_prompt
+    functions -c fish_prompt _old_fish_prompt
     
-    # with the original prompt function renamed, we can override with our own.
+    # with the original prompt function copied, we can override with our own.
     function fish_prompt
         # Prompt override?
         if test -n "__VIRTUAL_PROMPT__"
-            printf "%s%s%s" "__VIRTUAL_PROMPT__" (set_color normal) (_old_fish_prompt)
+            printf "%s%s" "__VIRTUAL_PROMPT__" (set_color normal)
+            _old_fish_prompt
             return
         end
         # ...Otherwise, prepend env
@@ -64,9 +62,11 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
         if test $_checkbase = "__"
             # special case for Aspen magic directories
             # see http://www.zetadev.com/software/aspen/
-            printf "%s[%s]%s %s" (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal) (_old_fish_prompt)
+            printf "%s[%s]%s " (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal) 
+            _old_fish_prompt
         else
-            printf "%s(%s)%s%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal) (_old_fish_prompt)
+            printf "%s(%s)%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal)
+            _old_fish_prompt
         end
     end 
     


### PR DESCRIPTION
Fixed an issue that flattened a multi-line custom prompt into a single line, and cleaned up the prompt prefixing behavior.  

The `fish_prompt` function is now copied via `functions -c` instead of by replacing the function name of the `functions` string output. (see here: http://ridiculousfish.com/shell/user_doc/html/commands.html#functions)

Also, `_old_fish_prompt` is called directly after the `(virtualenv)` prefix is printed, instead of being shoved into a `%s` with a `printf`. This does not change the behavior for the default prompt, but preserves the newlines of any user-defined custom prompt (e.g. mine). This also avoids some other weird behavior caused by the `printf`. 
