### PR TITLE
Add a --setuptools option

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -865,6 +865,9 @@ def main():
         help='Use Setuptools instead of Distribute.  Set environ variable '
         'VIRTUALENV_SETUPTOOLS to make it the default ')
 
+    # Set this to True to use distribute by default, even in Python 2.
+    parser.set_defaults(use_distribute=False)
+
     default_search_dirs = file_search_dirs()
     parser.add_option(
         '--extra-search-dir',


### PR DESCRIPTION
This adds an explicit --setuptools option, and an implicit $VIRTUALENV_SETUPTOOLS environment variable.  It also explicitly sets the default value of `use_distribute` to False for backward compatibility.  However, this will allow us in Debian to easily change the default to use distribute (as per Debian policy).
