### PR TITLE
Unset VIRTUAL_ENV environment variable in deactivate.bat. Fixes issue #9.

### DIFF
--- a/virtualenv_embedded/deactivate.bat
+++ b/virtualenv_embedded/deactivate.bat
@@ -1,5 +1,7 @@
 @echo off
 
+set VIRTUAL_ENV=
+
 if defined _OLD_VIRTUAL_PROMPT (
     set "PROMPT=%_OLD_VIRTUAL_PROMPT%"
 	set _OLD_VIRTUAL_PROMPT=


### PR DESCRIPTION
`activate.bat` sets `VIRTUAL_ENV` environment variable. This variable is treated as a sign that virtualenv is active. For this reason `deactivate.bat` should unset this variable.
