### PR TITLE
Fixed the name for the pypy include lib

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1189,8 +1189,9 @@ def copy_required_modules(dst_prefix):
             else:
                 if f is not None:
                     f.close()
-                # special-case custom readline.so on OS X:
-                if modname == 'readline' and sys.platform == 'darwin' and not filename.endswith(join('lib-dynload', 'readline.so')):
+                # special-case custom readline.so on OS X, but not for pypy:
+                if modname == 'readline' and sys.platform == 'darwin' and not (
+                        is_pypy or filename.endswith(join('lib-dynload', 'readline.so'))):
                     dst_filename = join(dst_prefix, 'lib', 'python%s' % sys.version[:3], 'readline.so')
                 else:
                     dst_filename = change_prefix(filename, dst_prefix)


### PR DESCRIPTION
As noted here: http://doc.pypy.org/en/latest/getting-started-python.html#installation

pypy will look for a lib_pypy directory, and if not found, will use its compiled in sys.path

a consequence of this is that sys.prefix will not be set

virtualenv will then bail out as it expects this to be set here:

https://github.com/pypa/virtualenv/blob/develop/virtualenv.py#L1516

this relatively small change seems to set things straight
