### PR TITLE
do not apply fix_lib64 for PyPy

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1638,12 +1638,13 @@ def fix_lib64(lib_dir):
     """
     if [p for p in distutils.sysconfig.get_config_vars().values()
         if isinstance(p, basestring) and 'lib64' in p]:
-        logger.debug('This system uses lib64; symlinking lib64 to lib')
-
+        # PyPy's library path scheme is not affected by this.
+        # Return early or we will die on the following assert.
         if is_pypy:
-            # PyPy's library path scheme is not affected by this.
-            # Return early or we will die on the following assert.
+            logger.debug('PyPy detected, skipping lib64 symlinking')
             return
+
+        logger.debug('This system uses lib64; symlinking lib64 to lib')
 
         assert os.path.basename(lib_dir) == 'python%s' % sys.version[:3], (
             "Unexpected python lib dir: %r" % lib_dir)


### PR DESCRIPTION
The current version of virtualenv breaks when trying to create a virtualenv with PyPy on a Gentoo/AMD64 system, where `fix_lib64()` logic would be triggered. Inside the function are two `assert`'s, the first of which not true under PyPy's path scheme.

This commit makes `fix_lib64()` PyPy-aware, disabling the (PyPy-unfriendly) fix if the environment would otherwise be subject to `lib64` symlinking.

Note: you can't test this out with Gentoo-packaged PyPy, because of a patch introduced by Gentoo bug [#373487](https://bugs.gentoo.org/show_bug.cgi?id=373487). The distutils patch must be reverted, or you will get `Access denied` error (ordinary user) / overwrite system scripts (root).
