### PR TITLE
Made make_relative_path handle symlinks correctly.

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -118,3 +118,30 @@ def test_install_python_symlinks():
                             "exist in bin_dir" % pth)
     finally:
         shutil.rmtree(tmp_virtualenv)
+
+def test_make_relative_path_symlinks():
+    """Don't care about symlinks when calculating a relative path."""
+    tmp_folder = tempfile.mkdtemp()
+    try:
+        # Set up a directory tree with different paths to the same folder
+        # through symlinks.
+        real = os.path.join(tmp_folder, 'real')
+        a = os.path.join(real, 'a')
+        b = os.path.join(real, 'b')
+        os.mkdir(real)
+        os.mkdir(a)
+        os.mkdir(b)
+
+        symlink = os.path.join(tmp_folder, 'symlink')
+        symlink_b = os.path.join(symlink, 'b')
+        os.symlink(real, symlink)
+
+        actual = virtualenv.make_relative_path(a+'/', b+'/')
+        target = '../b'
+        assert actual == target, '%r != %r' % (actual, target)
+
+        actual = virtualenv.make_relative_path(a+'/', symlink_b+'/')
+        target = '../b'
+        assert actual == target, '%r != %r' % (actual, target)
+    finally:
+        shutil.rmtree(tmp_folder)

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1835,8 +1835,8 @@ def make_relative_path(source, dest, dest_is_directory=True):
     if not dest_is_directory:
         dest_filename = os.path.basename(dest)
         dest = os.path.dirname(dest)
-    dest = os.path.normpath(os.path.abspath(dest))
-    source = os.path.normpath(os.path.abspath(source))
+    dest = os.path.realpath(dest)
+    source = os.path.realpath(source)
     dest_parts = dest.strip(os.path.sep).split(os.path.sep)
     source_parts = source.strip(os.path.sep).split(os.path.sep)
     while dest_parts and source_parts and dest_parts[0] == source_parts[0]:


### PR DESCRIPTION
I ran into this problem when building a relocatable virtualenv on a system with symlinks between the requirements and the virtualenv location. The easy_install.pth file was generated with relative paths that went all the way up to the root and back down again, which broke the relocatability.