### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,7 +115,8 @@ Distribute instead of setuptools, just call virtualenv like this::
 
     $ virtualenv --distribute ENV
 
-You can also set the environment variable VIRTUALENV_DISTRIBUTE.
+This will install distribute version `0.6.34`. You can also set 
+the environment variable VIRTUALENV_DISTRIBUTE.
 
 A new virtualenv also includes the `pip <http://pypi.python.org/pypi/pip>`_
 installer, so you can use ``ENV/bin/pip`` to install additional packages into


### PR DESCRIPTION
Added the version of distribute if used with the `--distribute` flag. Currently, distribute version 0.6.34 is the latest that can be installed with default option according to the sources (no extra search dir). It may surprise more than one if 0.6.35 (the latest at the time of writing) is installed into global python interpreter.