### PR TITLE
Don't try to copy readline on Windows

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1223,6 +1223,11 @@ def copy_required_modules(dst_prefix, symlink):
                 if modname == 'readline' and sys.platform == 'darwin' and not (
                         is_pypy or filename.endswith(join('lib-dynload', 'readline.so'))):
                     dst_filename = join(dst_prefix, 'lib', 'python%s' % sys.version[:3], 'readline.so')
+                elif modname == 'readline' and sys.platform == 'win32':
+                    # special-case for Windows, where readline is not a
+                    # standard module, though it may have been installed in
+                    # site-packages by a third-party package
+                    pass
                 else:
                     dst_filename = change_prefix(filename, dst_prefix)
                 copyfile(filename, dst_filename, symlink)


### PR DESCRIPTION
Fixes a variant of #4 for Windows.  Normally there is no readline module on Windows, though there may be one in site-packages if [pyreadline](https://pypi.python.org/pypi/pyreadline) is installed, leading to a crash like the one described in #4 when running `virtualenv.py`.
