### PR TITLE
Prevent accidental execution instead of sourcing

### DIFF
--- a/virtualenv_embedded/activate.sh
+++ b/virtualenv_embedded/activate.sh
@@ -1,5 +1,13 @@
 # This file must be used with "source bin/activate" *from bash*
 # you cannot run it directly
+if [ "$(basename $0)" == "activate" ];
+then
+    echo "ERROR: this must be used with used with:"
+    echo "source $0"
+    echo
+    echo "You cannot run it directly."
+    exit 1
+fi
 
 deactivate () {
     unset pydoc


### PR DESCRIPTION
This prevents a very common issue with newbies - trying to execute "activate" instead of sourcing it and thinks some magic would just happen.

