### PR TITLE
Allow -p to take a Python version number (Windows only)

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -25,6 +25,8 @@ Changes & News
   directory) is no longer supported for security reasons and will fail with an error.
   Along with this, ``--never-download`` is now always pinned to True, and is only being maintained
   in the short term for backward compatibility (Pull #412).
+* Added the option to use a version number with the -p option to get the system
+  copy of that Python version (Windows only)
 
 1.9.1 (2013-03-08)
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add the option to use a Python version in the -p option (something like -p 2.7 or -p 3.3). This is only supported on Windows, where the registry is read to determine the installed versions.

Not currently available for Unix, as there's no evidence that it's needed (version-specific executables like python-2.7 are normally on $PATH).
