### PR TITLE
fixed bug where --always-copy cannot copy executable when --python is us...

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1328,7 +1328,8 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             if symlink:
                 os.symlink(py_executable_base, full_pth)
             else:
-                shutil.copyfile(py_executable_base, full_pth)
+                shutil.copyfile(py_executable, full_pth)
+                shutil.copymode(py_executable, full_pth)
 
     if is_win and ' ' in py_executable:
         # There's a bug with subprocess on Windows when using a first


### PR DESCRIPTION
When --always-copy is used in conjunction with --python=python2.6 (or --python=/usr/bin/python2.6), virtualenv was unable to copy the python binary (rather than symlinking it).

This occurred on osx 10.7.5, although it didn't look like a platform-specific issue.

This change fixes this as well as copying the file permissions.
