### PR TITLE
Make not having setuptools or pip sdists a fatal error

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -868,7 +868,7 @@ def install_sdist(project_name, sdist, py_executable, search_dirs=None):
     found, sdist_path = _find_file(sdist, search_dirs)
     if not found:
         logger.fatal("Cannot find sdist %s" % (sdist,))
-        return
+        sys.exit(100)
 
     tmpdir = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
Makes it a fatal error for the setuptools and/or pip sdists to be missing from the virtualenv support directory.

Review requested - I am not completely convinced this is a good idea, as it changes the current behaviour, where the resulting virtualenv is usable but missing pip/setuptools (which can then be installed manually) to leave the new virtualenv incomplete (the activate scripts are not installed, for example).

Having an incomplete/missing virtualenv_support directory is unsupported in any case, so this should fall firmly into the "cannot happen" area, anyway...
