### PR TITLE
Bug fix: error at non ASCII symbols in the path

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1400,8 +1400,8 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
     proc_stdout = proc_stdout.strip().decode("utf-8")
     proc_stdout = os.path.normcase(os.path.abspath(proc_stdout))
     norm_home_dir = os.path.normcase(os.path.abspath(home_dir).decode(sys.getfilesystemencoding())) 
-    if hasattr(norm_home_dir, 'decode'):
-        norm_home_dir = norm_home_dir.decode(sys.getfilesystemencoding())
+    #if hasattr(norm_home_dir, 'decode'):
+    #    norm_home_dir = norm_home_dir.decode(sys.getfilesystemencoding())
     if proc_stdout != norm_home_dir:
         logger.fatal(
             'ERROR: The executable %s is not functioning' % py_executable)
@@ -1452,7 +1452,8 @@ def install_activate(home_dir, bin_dir, prompt=None):
 
         # Run-time conditional enables (basic) Cygwin compatibility
         home_dir_sh = ("""$(if [ "$OSTYPE" "==" "cygwin" ]; then cygpath -u '%s'; else echo '%s'; fi;)""" %
-                       (home_dir, home_dir_msys))
+                       (home_dir, home_dir_msys)).decode(sys.getfilesystemencoding())
+        
         files['activate'] = ACTIVATE_SH.replace('__VIRTUAL_ENV__', home_dir_sh)
 
     else:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1383,7 +1383,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         py_executable = '"%s"' % py_executable
     # NOTE: keep this check as one line, cmd.exe doesn't cope with line breaks
     cmd = [py_executable, '-c', 'import sys;out=sys.stdout;'
-        'getattr(out, "buffer", out).write(sys.prefix.encode("utf-8"))']
+        'getattr(out, "buffer", out).write(sys.prefix.decode(sys.getfilesystemencoding()).encode("utf-8"))']
     logger.info('Testing executable with %s %s "%s"' % tuple(cmd))
     try:
         proc = subprocess.Popen(cmd,
@@ -1399,7 +1399,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
 
     proc_stdout = proc_stdout.strip().decode("utf-8")
     proc_stdout = os.path.normcase(os.path.abspath(proc_stdout))
-    norm_home_dir = os.path.normcase(os.path.abspath(home_dir))
+    norm_home_dir = os.path.normcase(os.path.abspath(home_dir).decode(sys.getfilesystemencoding())) 
     if hasattr(norm_home_dir, 'decode'):
         norm_home_dir = norm_home_dir.decode(sys.getfilesystemencoding())
     if proc_stdout != norm_home_dir:


### PR DESCRIPTION
I had problems when I created an environment in a non ASCII folder, for example:

c:\Привет>virtualenv myenv

Now it's working.