### PR TITLE
Relative local symlinks

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1505,9 +1505,14 @@ def fix_local_scheme(home_dir, symlink=True):
                 for subdir_name in os.listdir(home_dir):
                     if subdir_name == 'local':
                         continue
-                    cp_or_ln = (os.symlink if symlink else copyfile)
-                    cp_or_ln(os.path.abspath(os.path.join(home_dir, subdir_name)), \
-                                                            os.path.join(local_path, subdir_name))
+                    if symlink:
+                        # use relative link target, so a virtualencv can be relocated,
+                        # and also be built in a staging area and then packaged to DEB etc.
+                        os.symlink(os.path.join('..', subdir_name),
+                            os.path.join(local_path, subdir_name))
+                    else:
+                        copyfile(os.path.abspath(os.path.join(home_dir, subdir_name)),
+                            os.path.join(local_path, subdir_name))
 
 def fix_lib64(lib_dir, symlink=True):
     """

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1506,7 +1506,7 @@ def fix_local_scheme(home_dir, symlink=True):
                     if subdir_name == 'local':
                         continue
                     if symlink:
-                        # use relative link target, so a virtualencv can be relocated,
+                        # use relative link target, so a virtualenv can be relocated,
                         # and also be built in a staging area and then packaged to DEB etc.
                         os.symlink(os.path.join('..', subdir_name),
                             os.path.join(local_path, subdir_name))


### PR DESCRIPTION
This bit me when packaging a virtualenv for Debian, the resulting package had symlinks pointing to the build staging directory in my home! Not sure if this breaks other use-cases and why the abspath is there, might need some kind of configuration switch then.