### PR TITLE
Fix URL for fish shell

### DIFF
--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -1,4 +1,4 @@
-# This file must be used with ". bin/activate.fish" *from fish* (http://fishshell.org)
+# This file must be used with ". bin/activate.fish" *from fish* (http://fishshell.com)
 # you cannot run it directly
 
 function deactivate  -d "Exit virtualenv and return to normal shell environment"


### PR DESCRIPTION
The URL for fish shell is currently listed as http://fishshell.org , but that's not the right URL! It should be http://fishshell.com .

Thanks!
