### PR TITLE
remove deprecated function in activate.fish

### DIFF
--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -1,4 +1,4 @@
-# This file must be used with ". bin/activate.fish" *from fish* (http://fishshell.com)
+# This file must be used with "source bin/activate.fish" *from fish* (http://fishshell.com)
 # you cannot run it directly
 
 function deactivate  -d "Exit virtualenv and return to normal shell environment"


### PR DESCRIPTION
replaced . bin/activate.fish with source bin/activate.fish, because of this:
marcel@marcel ~> .
source: '.' command is deprecated, and doesn't work with STDIN anymore. Did you mean 'source' or './'?
(1) marcel@marcel ~>
