### PR TITLE
Add getsitepackages() to site module (Issue #355)

### DIFF
--- a/virtualenv_embedded/site.py
+++ b/virtualenv_embedded/site.py
@@ -206,6 +206,87 @@ def addsitedir(sitedir, known_paths=None):
         known_paths = None
     return known_paths
 
+def getsitepackages():
+    """Returns a list containing all global site-packages directories
+    (and possibly site-python)."""
+
+    prefixes = [sys.prefix, sys.exec_prefix]
+    if not os.path.exists(os.path.join(os.path.dirname(__file__), 'no-global-site-packages.txt')):
+        prefixes.append(sys.real_prefix)
+
+    sitepackages = []
+    seen = set()
+
+    for prefix in prefixes:
+        if not prefix or prefix in seen:
+            continue
+        seen.add(prefix)
+
+        if sys.platform in ('os2emx', 'riscos') or _is_jython:
+            sitedirs = [os.path.join(prefix, "Lib", "site-packages")]
+        elif _is_pypy:
+            sitedirs = [os.path.join(prefix, 'site-packages')]
+        elif sys.platform == 'darwin' and prefix == sys.prefix:
+            if prefix.startswith("/System/Library/Frameworks/"): # Apple's Python
+                sitedirs = [os.path.join("/Library/Python", sys.version[:3], "site-packages"),
+                            os.path.join(prefix, "Extras", "lib", "python")]
+
+            else: # any other Python distros on OSX work this way
+                sitedirs = [os.path.join(prefix, "lib",
+                                         "python" + sys.version[:3], "site-packages")]
+
+        elif os.sep == '/':
+            sitedirs = [os.path.join(prefix,
+                                     "lib",
+                                     "python" + sys.version[:3],
+                                     "site-packages"),
+                        os.path.join(prefix, "lib", "site-python"),
+                        os.path.join(prefix, "python" + sys.version[:3], "lib-dynload")]
+            lib64_dir = os.path.join(prefix, "lib64", "python" + sys.version[:3], "site-packages")
+            if (os.path.exists(lib64_dir) and
+                os.path.realpath(lib64_dir) not in [os.path.realpath(p) for p in sitedirs]):
+                if _is_64bit:
+                    sitedirs.insert(0, lib64_dir)
+                else:
+                    sitedirs.append(lib64_dir)
+            try:
+                # sys.getobjects only available in --with-pydebug build
+                sys.getobjects
+                sitedirs.insert(0, os.path.join(sitedirs[0], 'debug'))
+            except AttributeError:
+                pass
+            # Debian-specific dist-packages directories:
+            if sys.version[0] == '2':
+                sitedirs.append(os.path.join(prefix, "lib",
+                                             "python" + sys.version[:3],
+                                             "dist-packages"))
+            else:
+                sitedirs.append(os.path.join(prefix, "lib",
+                                             "python" + sys.version[0],
+                                             "dist-packages"))
+            sitedirs.append(os.path.join(prefix, "local/lib",
+                                         "python" + sys.version[:3],
+                                         "dist-packages"))
+            sitedirs.append(os.path.join(prefix, "lib", "dist-python"))
+        else:
+            sitedirs = [prefix, os.path.join(prefix, "lib", "site-packages")]
+        if sys.platform == 'darwin':
+            # for framework builds *only* we add the standard Apple
+            # locations. Currently only per-user, but /Library and
+            # /Network/Library could be added too
+            if 'Python.framework' in prefix:
+                home = os.environ.get('HOME')
+                if home:
+                    sitedirs.append(
+                        os.path.join(home,
+                                     'Library',
+                                     'Python',
+                                     sys.version[:3],
+                                     'site-packages'))
+        for sitedir in sitedirs:
+            sitepackages.append(os.path.abspath(sitedir))
+    return sitepackages
+
 def addsitepackages(known_paths, sys_prefix=sys.prefix, exec_prefix=sys.exec_prefix):
     """Add site-packages (and possibly site-python) to sys.path"""
     prefixes = [os.path.join(sys_prefix, "local"), sys_prefix]


### PR DESCRIPTION
This is part of a fix for issue #355. Since virtualenv has its own implementation of the site module, and since it lacks all the functions added past Python 2.6, I thought it might be useful to start adding those functions in. This one in particular has been specifically requested (#228).