### PR TITLE
TypeError fix on virtualenv init

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1013,7 +1013,7 @@ def path_locations(home_dir):
             # instead of being virtualenv/include/python2.7
             p = subprocess.Popen(multiarch_exec, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
-             # stdout.strip is needed to remove newline character
+            # stdout.strip is needed to remove newline character
             stdo = stdout.strip()
             # ensure that we join strings not bytes
             stdo = stdo.decode(sys.getdefaultencoding()) if isinstance(stdo, bytes) else stdo


### PR DESCRIPTION
stdout returns bytes, not string so I got TypeError on join on my machine

```
~> virtualenv venv                                                        
Traceback (most recent call last):
  File "/usr/bin/virtualenv", line 3, in <module>
    virtualenv.main()
  File "/usr/lib/python3.3/site-packages/virtualenv.py", line 821, in main
    symlink=options.symlink)
  File "/usr/lib/python3.3/site-packages/virtualenv.py", line 952, in create_environment
    home_dir, lib_dir, inc_dir, bin_dir = path_locations(home_dir)
  File "/usr/lib/python3.3/site-packages/virtualenv.py", line 1020, in path_locations
    inc_dir = join(home_dir, 'include', stdout.strip(), py_version + abiflags)
  File "/usr/lib/python3.3/posixpath.py", line 92, in join
    "components.") from None
TypeError: Can't mix strings and bytes in path components. 
```
