### PR TITLE
only stage OS X readline if it is an extension

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1102,7 +1102,8 @@ def copy_required_modules(dst_prefix, symlink):
                 if f is not None:
                     f.close()
                 # special-case custom readline.so on OS X, but not for pypy:
-                if modname == 'readline' and sys.platform == 'darwin' and not (
+                if modname == 'readline' and sys.platform == 'darwin' and \
+                        filename.endswith('.so') and not (
                         is_pypy or filename.endswith(join('lib-dynload', 'readline.so'))):
                     dst_filename = join(dst_prefix, 'lib', 'python%s' % sys.version[:3], 'readline.so')
                 elif modname == 'readline' and sys.platform == 'win32':


### PR DESCRIPTION
Custom readline can be readline.py, which shouldn't be staged as readline.so.

Since pip doesn't do the sys.path shenanigans that easy_install does, the readline project is considering a change where the extension is renamed to `gnureadline.so`, since there is no way to override a stdlib module with pip. The proposed change adds a `readline.py` that does `from gnureadline import *` for people who still expect the easy_install behavior.

With this change, `imp.find_module('readline')` would find `readline.py`, which is currently being staged as `readline.so` on OS X, which will not be importable, failing with:

```python
ImportError: dlopen(VIRTUAL_ENV/lib/python2.7/readline.so, 2): no suitable image found.  Did find:
	VIRTUAL_ENV/lib/python2.7/readline.so: file too short
```

This PR simply excludes non-extension readline from the special handling.

Only easy_installed readline is affected, since pip installed readline will never be found by `find_module('readline')`.

The long-term effect of this will be that users who install a site-packages readline will never have that package staged into virtualenv.