### PR TITLE
ignore system installed pip/setuptools

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -942,7 +942,7 @@ def install_wheel(project_names, py_executable, search_dirs=None):
 
     cmd = [
         py_executable, '-c',
-        'import sys, pip; pip.main(["install"] + sys.argv[1:])',
+        'import sys, pip; pip.main(["install", "--ignore-installed"] + sys.argv[1:])',
     ] + project_names
     logger.start_progress('Installing %s...' % (', '.join(project_names)))
     logger.indent += 2


### PR DESCRIPTION
fix for #521

previously, we installed pip/setuptools sdists using "python setup.py install", which ignores the global site (when using  --system-site-packages)

but now, we're using pip itself to install wheels, so we need to use `--ignore-installed` (and luckily we fixed that option just recently)
