### PR TITLE
Source distributions should include tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include bin *
 recursive-include docs *
 recursive-include scripts *
+recursive-include tests *.py *.ini *.output *.sh
 recursive-include virtualenv_support *.whl
 recursive-include virtualenv_embedded *
 recursive-exclude docs/_templates *


### PR DESCRIPTION
They are typically used by distributions to build RPM packages. As such, they may want to run the testsuite to verify the results.