### PR TITLE
Fix long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ here = os.path.dirname(os.path.abspath(__file__))
 ## Get long_description from index.txt:
 f = open(os.path.join(here, 'docs', 'index.rst'))
 long_description = f.read().strip()
-long_description = long_description.split('split here', 1)[1]
+long_description = long_description.split('split here', 1)[0]
 f.close()
 f = open(os.path.join(here, 'docs', 'news.rst'))
 long_description += "\n\n" + f.read()


### PR DESCRIPTION
Includes the right half of docs/index.rst (the one with links instead of the one with a `.. toctree:` directive).

Fixes the embarrassing unformatted PyPI page.  I'd appreciate a 'setup.py register', or a manual PyPI description update, because seeing unformatted PyPI pages causes me pain in the aesthetic gland.
