### PR TITLE
Use simpler pip bootstrap

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -938,9 +938,14 @@ def install_wheel(project_names, py_executable, search_dirs=None):
     pythonpath = os.pathsep.join(wheels)
     findlinks = ' '.join(search_dirs)
 
+    # Workaround for http://bugs.python.org/issue20621
+    pip_import_line = 'import sys, pip; sys.exit(pip.main())'
+    if sys.version_info[:3]  == (3, 3, 4):
+        pip_import_line = "'%s'" % pip_import_line
+
     cmd = [
         py_executable, '-c',
-        '"import sys, pip; sys.exit(pip.main())"',
+        pip_import_line,
         'install', '--ignore-installed',
     ] + project_names
     logger.start_progress('Installing %s...' % (', '.join(project_names)))


### PR DESCRIPTION
Hopefully fixes #564 (fixes on my machine)

It has something to do with Windows paths, and maybe quadruple backslashes, but this fix works without quadruple backslashes, so I like it infinitely better.

Problem found on [at least] Python 3.3.4, x64, Windows 8.1.

Problem encountered:

```
C:\Users\Ivo>virtualenv testfoo
Using base prefix 'C:\\Python33'
New python executable in testfoo\Scripts\python.exe
Installing setuptools, pip...
  Complete output from command C:\Users\Ivo\testfoo\Scripts\python.exe -c "import sys, pip; sys...d\"] + sys.argv[1:]))" setuptools pip:
  Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: 'module' object has no attribute 'main'
----------------------------------------
...Installing setuptools, pip...done.
Traceback (most recent call last):
  File "C:\Python33\lib\runpy.py", line 160, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "C:\Python33\lib\runpy.py", line 73, in _run_code
    exec(code, run_globals)
  File "C:\Python33\Scripts\virtualenv.exe\__main__.py", line 9, in <module>
  File "C:\Python33\lib\site-packages\virtualenv.py", line 824, in main
    symlink=options.symlink)
  File "C:\Python33\lib\site-packages\virtualenv.py", line 992, in create_environment
    install_wheel(to_install, py_executable, search_dirs)
  File "C:\Python33\lib\site-packages\virtualenv.py", line 960, in install_wheel
    'PIP_NO_INDEX': '1'
  File "C:\Python33\lib\site-packages\virtualenv.py", line 902, in call_subprocess
    % (cmd_desc, proc.returncode))
OSError: Command C:\Users\Ivo\testfoo\Scripts\python.exe -c "import sys, pip; sys...d\"] + sys.argv[1:]))" setuptools pip failed with error code 1
```

Also seems to be present on Windows Server 2008 3.3.4 as indicated by that issue.

I am on Windows ATM so checking it works on both *nixes should be in order before any merge.
