### PR TITLE
Catch errors when reading installed version from registry

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -86,7 +86,10 @@ else:
                 break
         exes = dict()
         for ver in versions:
-            path = winreg.QueryValue(python_core, "%s\\InstallPath" % ver)
+            try:
+                path = winreg.QueryValue(python_core, "%s\\InstallPath" % ver)
+            except WindowsError:
+                continue
             exes[ver] = join(path, "python.exe")
 
         winreg.CloseKey(python_core)


### PR DESCRIPTION
The Python uninstaller leaves some trails in the registry. In 
such a case, accessing the `InstallPath` entry will fail.

Fixes #505.
