### PR TITLE
Add support for non-standard directory layouts

### DIFF
--- a/virtualenv_embedded/site.py
+++ b/virtualenv_embedded/site.py
@@ -62,7 +62,7 @@ site-specific customizations.  If this import fails with an
 ImportError exception, it is silently ignored.
 
 """
-
+import sysconfig
 import sys
 import os
 try:
@@ -215,9 +215,9 @@ def addsitepackages(known_paths, sys_prefix=sys.prefix, exec_prefix=sys.exec_pre
     for prefix in prefixes:
         if prefix:
             if sys.platform in ('os2emx', 'riscos') or _is_jython:
-                sitedirs = [os.path.join(prefix, "Lib", "site-packages")]
+                sitedirs = [sysconfig.get_path('purelib', vars={'base':prefix})]
             elif _is_pypy:
-                sitedirs = [os.path.join(prefix, 'site-packages')]
+                sitedirs = [sysconfig.get_path('purelib', vars={'base':prefix})]
             elif sys.platform == 'darwin' and prefix == sys_prefix:
 
                 if prefix.startswith("/System/Library/Frameworks/"): # Apple's Python
@@ -558,7 +558,7 @@ def virtual_install_main_packages():
     if sys.path[0] == '':
         pos += 1
     if _is_jython:
-        paths = [os.path.join(sys.real_prefix, 'Lib')]
+        paths = [sysconfig.get_path('stdlib', vars={'base': sys.real_prefix})]
     elif _is_pypy:
         if sys.version_info > (3, 2):
             cpyver = '%d' % sys.version_info[0]
@@ -566,8 +566,10 @@ def virtual_install_main_packages():
             cpyver = '%d.%d' % sys.version_info[:2]
         else:
             cpyver = '%d.%d.%d' % sys.version_info[:3]
-        paths = [os.path.join(sys.real_prefix, 'lib_pypy'),
-                 os.path.join(sys.real_prefix, 'lib-python', cpyver)]
+        paths = [sysconfig.get_path('stdlib', vars={'base': sys.real_prefix})]
+        for path in sys.path:
+            if path.endswith('lib_pypy'):
+                 paths.append(path.replace(sys.prefix, sys.real_prefix))
         if sys.pypy_version_info < (1, 9):
             paths.insert(1, os.path.join(sys.real_prefix,
                                          'lib-python', 'modified-%s' % cpyver))


### PR DESCRIPTION
# Context
On FreeBSD, pypy has been modified to follow the same layout as python, so as to better facilitate the installation of python packages on different python implementations (without having to rework the underlying ports).  

Since virtualenv hard codes the directory layout, this breaks virtualenv under pypy on FreeBSD, and on any python implementation that does not conform to virtualenv's assumptions about directory layout.  

# Changes
This pull request removes the hard codings and instead replaces them with paths provided by sysconfig.  sysconfig was used in favour of distutils.sysconfig as the later does not provide an interface for getting 'script' or 'bin' paths.  