### PR TITLE
Cleaned up activate.fish.

### DIFF
--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -1,74 +1,65 @@
-# This file must be used with "source bin/activate.fish" *from fish* (http://fishshell.com)
-# you cannot run it directly
+# This file should be used using `. bin/activate.fish` *within a running fish ( http://fishshell.com ) session*.
+# Do not run it directly.
 
-function deactivate  -d "Exit virtualenv and return to normal shell environment"
-    # reset old environment variables
-    if test -n "$_OLD_VIRTUAL_PATH" 
-        set -gx PATH $_OLD_VIRTUAL_PATH
-        set -e _OLD_VIRTUAL_PATH
+function deactivate -d 'Exit virtualenv mode and return to the normal environment.'
+    if test -n $_OLD_PATH
+        set -gx PATH $_OLD_PATH
+        set -e _OLD_PATH
     end
-    if test -n "$_OLD_VIRTUAL_PYTHONHOME"
-        set -gx PYTHONHOME $_OLD_VIRTUAL_PYTHONHOME
-        set -e _OLD_VIRTUAL_PYTHONHOME
+
+    if test -n $_OLD_PYTHONHOME
+        set -gx PYTHONHOME $_OLD_PYTHONHOME
+        set -e _OLD_PYTHONHOME
     end
-    
-    if test -n "$_OLD_FISH_PROMPT_OVERRIDE"
-        # set an empty local fish_function_path, so fish_prompt doesn't automatically reload
+
+    if test -n $_OLD_FISH_PROMPT_OVERRIDE
+        # Set an empty local `$fish_function_path` to allow the removal of `fish_prompt` using `functions -e`.
         set -l fish_function_path
-        # erase the virtualenv's fish_prompt function, and restore the original
+
+        # Erase virtualenv's `fish_prompt` and restore the original.
         functions -e fish_prompt
         functions -c _old_fish_prompt fish_prompt
         functions -e _old_fish_prompt
         set -e _OLD_FISH_PROMPT_OVERRIDE
     end
-    
+
     set -e VIRTUAL_ENV
-    if test "$argv[1]" != "nondestructive"
-        # Self destruct!
+
+    if test $argv[1] != 'nondestructive'
+        # Self-destruct!
         functions -e deactivate
     end
 end
 
-# unset irrelevant variables
+# Unset irrelevant variables.
 deactivate nondestructive
 
 set -gx VIRTUAL_ENV "__VIRTUAL_ENV__"
 
-set -gx _OLD_VIRTUAL_PATH $PATH
-set -gx PATH "$VIRTUAL_ENV/__BIN_NAME__" $PATH
+set -gx _OLD_PATH $PATH
+set -gx PATH $VIRTUAL_ENV/"__BIN_NAME__" $PATH
 
-# unset PYTHONHOME if set
+# Unset `$PYTHONHOME` if set.
 if set -q PYTHONHOME
-    set -gx _OLD_VIRTUAL_PYTHONHOME $PYTHONHOME
+    set -gx _OLD_PYTHONHOME $PYTHONHOME
     set -e PYTHONHOME
 end
 
-if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
-    # fish uses a function instead of an env var to generate the prompt.
-    
-    # copy the current fish_prompt function as the function _old_fish_prompt
+if test \( -z $VIRTUALENV_DISABLE_PROMPT \) -o \( -z $VIRTUAL_ENV_DISABLE_PROMPT \)
+    # Copy the current `fish_prompt` function as `_old_fish_prompt`.
     functions -c fish_prompt _old_fish_prompt
-    
-    # with the original prompt function copied, we can override with our own.
+
     function fish_prompt
-        # Prompt override?
+        # Prompt override provided?
+        # If not, just prepend the environment name.
         if test -n "__VIRTUAL_PROMPT__"
-            printf "%s%s" "__VIRTUAL_PROMPT__" (set_color normal)
-            _old_fish_prompt
-            return
-        end
-        # ...Otherwise, prepend env
-        set -l _checkbase (basename "$VIRTUAL_ENV")
-        if test $_checkbase = "__"
-            # special case for Aspen magic directories
-            # see http://www.zetadev.com/software/aspen/
-            printf "%s[%s]%s " (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal) 
-            _old_fish_prompt
+            printf '%s%s' "__VIRTUAL_PROMPT__" (set_color normal)
         else
-            printf "%s(%s)%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal)
-            _old_fish_prompt
+            printf '%svirtualenv:%s %s%s%s\n' (set_color white) (set_color normal) (set_color -b black white) (basename $VIRTUAL_ENV) (set_color normal)
         end
-    end 
-    
-    set -gx _OLD_FISH_PROMPT_OVERRIDE "$VIRTUAL_ENV"
+
+        _old_fish_prompt
+    end
+
+    set -gx _OLD_FISH_PROMPT_OVERRIDE $VIRTUAL_ENV
 end

--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -2,17 +2,17 @@
 # Do not run it directly.
 
 function deactivate -d 'Exit virtualenv mode and return to the normal environment.'
-    if test -n $_OLD_PATH
-        set -gx PATH $_OLD_PATH
-        set -e _OLD_PATH
+    if test -n $_VIRTUALENV_OLD_PATH
+        set -gx PATH $_VIRTUALENV_OLD_PATH
+        set -e _VIRTUALENV_OLD_PATH
     end
 
-    if test -n $_OLD_PYTHONHOME
-        set -gx PYTHONHOME $_OLD_PYTHONHOME
-        set -e _OLD_PYTHONHOME
+    if test -n $_VIRTUALENV_OLD_PYTHONHOME
+        set -gx PYTHONHOME $_VIRTUALENV_OLD_PYTHONHOME
+        set -e _VIRTUALENV_OLD_PYTHONHOME
     end
 
-    if test -n $_OLD_FISH_PROMPT_OVERRIDE
+    if test -n $_VIRTUALENV_OLD_FISH_PROMPT_OVERRIDE
         # Set an empty local `$fish_function_path` to allow the removal of `fish_prompt` using `functions -e`.
         set -l fish_function_path
 
@@ -20,7 +20,7 @@ function deactivate -d 'Exit virtualenv mode and return to the normal environmen
         functions -e fish_prompt
         functions -c _old_fish_prompt fish_prompt
         functions -e _old_fish_prompt
-        set -e _OLD_FISH_PROMPT_OVERRIDE
+        set -e _VIRTUALENV_OLD_FISH_PROMPT_OVERRIDE
     end
 
     set -e VIRTUAL_ENV
@@ -36,12 +36,12 @@ deactivate nondestructive
 
 set -gx VIRTUAL_ENV "__VIRTUAL_ENV__"
 
-set -gx _OLD_PATH $PATH
+set -gx _VIRTUALENV_OLD_PATH $PATH
 set -gx PATH $VIRTUAL_ENV/"__BIN_NAME__" $PATH
 
 # Unset `$PYTHONHOME` if set.
 if set -q PYTHONHOME
-    set -gx _OLD_PYTHONHOME $PYTHONHOME
+    set -gx _VIRTUALENV_OLD_PYTHONHOME $PYTHONHOME
     set -e PYTHONHOME
 end
 
@@ -61,5 +61,5 @@ if test \( -z $VIRTUALENV_DISABLE_PROMPT \) -o \( -z $VIRTUAL_ENV_DISABLE_PROMPT
         _old_fish_prompt
     end
 
-    set -gx _OLD_FISH_PROMPT_OVERRIDE $VIRTUAL_ENV
+    set -gx _VIRTUALENV_OLD_FISH_PROMPT_OVERRIDE $VIRTUAL_ENV
 end


### PR DESCRIPTION
Cleaned up __activate.fish__ to be more *idiomatic* fish and removed a bit of unnecessary code (such as support for "Aspen magic directories", since *AFAIK* and *[AFAICT](http://aspen.io/virtual-paths 'Aspen: Python Web Framework with Simplates')*, this is no longer the case).

\- Jonathan