### PR TITLE
Encode bytes from popen

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1044,7 +1044,8 @@ def path_locations(home_dir):
             p = subprocess.Popen(multiarch_exec, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
             # stdout.strip is needed to remove newline character
-            inc_dir = join(home_dir, 'include', stdout.strip(), py_version + abiflags)
+            stdout = stdout.decode(sys.getdefaultencoding()).strip()
+            inc_dir = join(home_dir, 'include', stdout, py_version + abiflags)
         else:
             inc_dir = join(home_dir, 'include', py_version + abiflags)
         bin_dir = join(home_dir, 'bin')


### PR DESCRIPTION
* fixes crash on python3 (Archlinux)

Popen returns bytes encoded in the default system encoding (at least on Archlinux python 3.4.0):
```
Traceback (most recent call last):
  File "/usr/bin/virtualenv", line 3, in <module>
    virtualenv.main()
  File "/usr/lib/python3.4/site-packages/virtualenv.py", line 824, in main
    symlink=options.symlink)
  File "/usr/lib/python3.4/site-packages/virtualenv.py", line 980, in create_environment
    home_dir, lib_dir, inc_dir, bin_dir = path_locations(home_dir)
  File "/usr/lib/python3.4/site-packages/virtualenv.py", line 1047, in path_locations
    inc_dir = join(home_dir, 'include', stdout.strip(), py_version + abiflags)
  File "/usr/lib/python3.4/posixpath.py", line 92, in join
    "components.") from None
TypeError: Can't mix strings and bytes in path components.
```

Quite urgent IMHO.
cheers