### PR TITLE
Python 2.4 fix to allow later error to propagate

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1575,7 +1575,9 @@ def fix_lib64(lib_dir, symlink=True):
             "Unexpected parent dir: %r" % lib_parent)
         if os.path.lexists(lib64_link):
             return
-        cp_or_ln = (os.symlink if symlink else copyfile)
+        cp_or_ln = copyfile
+        if symlink:
+            cp_or_len = os.symlink
         cp_or_ln('lib', lib64_link)
 
 def resolve_interpreter(exe):


### PR DESCRIPTION
Yes, virtualenv no longer supports Python 2.4. However, there is some non-Python 2.4 early on that prevents the "this script requires Python 2.6 or greater" message from propagating to the user.

```
[someguy@fcknrh ~]$ python virtualenv.py py_virtual
  File "virtualenv.py", line 1578
    cp_or_ln = (os.symlink if symlink else copyfile)
                            ^
SyntaxError: invalid syntax
[someguy@fcknrh ~]$ vim virtualenv.py # Same edits as in this PR
[someguy@fcknrh ~]$ python virtualenv.py py_virtual
ERROR: None
ERROR: this script requires Python 2.6 or greater.
```
