### PR TITLE
support install into non-ASCII directories

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -129,6 +129,8 @@ def test_install_python_bin():
 def test_install_unicode():
     """Should be able to install in directories containing Unicode & spaces"""
     subdir_unicode = "Heävy Mëtal ☃"
+    if sys.version_info[0] == '2' and sys.getfilesystemencoding() == 'mbcs':
+        subdir_unicode = subdir_unicode.decode('utf-8').encode('mbcs')
     tmp_virtualenv = tempfile.mkdtemp()
     tmp_virtualenv_unicode = os.path.join(tmp_virtualenv, subdir_unicode)
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1,3 +1,4 @@
+#-*- coding: utf-8 -*-
 import virtualenv
 import optparse
 import os
@@ -97,31 +98,45 @@ def test_cop_update_defaults_with_store_false():
     cop.update_defaults(defaults)
     assert defaults == {'system_site_packages': 0}
 
-def test_install_python_bin():
-    """Should create the right python executables and links"""
-    tmp_virtualenv = tempfile.mkdtemp()
-    try:
-        home_dir, lib_dir, inc_dir, bin_dir = \
-                                virtualenv.path_locations(tmp_virtualenv)
-        virtualenv.install_python(home_dir, lib_dir, inc_dir, bin_dir, False,
-                                  False)
 
+def install_python_bin(tmp_virtualenv):
+    try:
+        home_dir, lib_dir, inc_dir, bin_dir = virtualenv.path_locations(tmp_virtualenv)
+        virtualenv.install_python(home_dir, lib_dir, inc_dir, bin_dir, False, False)
         if virtualenv.is_win:
-            required_executables = [ 'python.exe', 'pythonw.exe']
+            required_executables = ['python.exe', 'pythonw.exe']
         else:
             py_exe_no_version = 'python'
             py_exe_version_major = 'python%s' % sys.version_info[0]
             py_exe_version_major_minor = 'python%s.%s' % (
                 sys.version_info[0], sys.version_info[1])
-            required_executables = [ py_exe_no_version, py_exe_version_major,
-                                     py_exe_version_major_minor ]
-
+            required_executables = [py_exe_no_version, py_exe_version_major,
+                py_exe_version_major_minor]
         for pth in required_executables:
-            assert os.path.exists(os.path.join(bin_dir, pth)), ("%s should "
-                            "exist in bin_dir" % pth)
+            assert os.path.exists(os.path.join(bin_dir, pth)), (
+                "%s should "
+                "exist in bin_dir" %
+                pth)
     finally:
+
         shutil.rmtree(tmp_virtualenv)
 
+def test_install_python_bin():
+    """Should create the right python executables and links"""
+    tmp_virtualenv = tempfile.mkdtemp()
+    install_python_bin(tmp_virtualenv)
+
+def test_install_unicode():
+    """Should be able to install in directories containing Unicode & spaces"""
+    subdir_unicode = "Heävy Mëtal ☃"
+    tmp_virtualenv = tempfile.mkdtemp()
+    tmp_virtualenv_unicode = os.path.join(tmp_virtualenv, subdir_unicode)
+
+    try:
+        os.mkdir(tmp_virtualenv_unicode)
+        install_python_bin(tmp_virtualenv_unicode)
+    finally:
+        shutil.rmtree(tmp_virtualenv)
 
 def test_always_copy_option():
     """Should be no symlinks in directory tree"""

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1424,7 +1424,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         py_executable = '"%s"' % py_executable
     # NOTE: keep this check as one line, cmd.exe doesn't cope with line breaks
     cmd = [py_executable, '-c', 'import sys;out=sys.stdout;'
-        'getattr(out, "buffer", out).write(sys.prefix.encode("utf-8"))']
+        'getattr(out, "buffer", out).write((sys.version_info[0] == 2 and sys.prefix) or sys.prefix.encode("utf-8"))']
     logger.info('Testing executable with %s %s "%s"' % tuple(cmd))
     try:
         proc = subprocess.Popen(cmd,


### PR DESCRIPTION
On Python 2 sys.prefix is already not unicode and should not be encoded.

So far only tested on Linux with sys.getfilesystemencoding() == 'utf-8' (certainly it is ascii sometimes, even on the same system, depending on how I've logged in).