### PR TITLE
Fixes for validating activation output and setuptools test integration.

### DIFF
--- a/tests/test_activate_expected.output
+++ b/tests/test_activate_expected.output
@@ -1,3 +1,2 @@
 New python executable in /tmp/test_virtualenv_activate.venv/bin/python
-Installing setuptools............done.
-Installing pip...............done.
+Installing setuptools, pip...done.


### PR DESCRIPTION
Fix expected output to match actual output for setuptools
and pip installation progress.  The progress line has been
one line for a while but the expected output was looking for
two lines.

Rename tests to test to fix python setup.py test functionality.
