### PR TITLE
Split out this setup.py fix from https://github.com/pypa/virtualenv/pull/635

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ try:
 
         def initialize_options(self):
             TestCommand.initialize_options(self)
-            self.pytest_args = None
+            # use this directory instead of falling back on the 'test'
+            # command-as-directory which will fail
+            self.pytest_args = 'tests' 
 
         def finalize_options(self):
             TestCommand.finalize_options(self)


### PR DESCRIPTION
Fix default args for py.test to be "tests" instead of using the
command name "test" also as the directory name to find tests.