### PR TITLE
Removed unused imports

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -13,7 +13,6 @@ import optparse
 import re
 import shutil
 import logging
-import tempfile
 import zlib
 import errno
 import glob
@@ -21,7 +20,6 @@ import distutils.sysconfig
 from distutils.util import strtobool
 import struct
 import subprocess
-import tarfile
 
 if sys.version_info < (2, 6):
     print('ERROR: %s' % sys.exc_info()[1])


### PR DESCRIPTION
I have removed a couple of imports that are not used within virtualenv.py. This is not an entirely spurious change since importing 'tempfile' was causing a imort error when I was trying to create a virtual environment with python3.4,
```
jdowner@erebor:~$ virtualenv -p /usr/bin/python3.4 --no-site-packages /tmp/venv
Running virtualenv with interpreter /usr/bin/python3.4
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/virtualenv.py", line 16, in <module>
    import tempfile
  File "/usr/lib/python3.4/tempfile.py", line 175, in <module>
    from random import Random as _Random
  File "/usr/lib/python3.4/random.py", line 45, in <module>
    from hashlib import sha512 as _sha512
  File "/usr/local/lib/python2.7/dist-packages/hashlib.py", line 80
    raise ValueError, "unsupported hash type"
                    ^
SyntaxError: invalid syntax
jdowner@erebor:~$ 
```
Removing the 'import tempfile' line fixes the problem.