### PR TITLE
create_environment: Add show_stdout argument

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -944,7 +944,7 @@ def find_wheels(projects, search_dirs):
 
     return wheels
 
-def install_wheel(project_names, py_executable, search_dirs=None):
+def install_wheel(project_names, py_executable, search_dirs=None, show_stdout=False):
     if search_dirs is None:
         search_dirs = file_search_dirs()
 
@@ -959,7 +959,7 @@ def install_wheel(project_names, py_executable, search_dirs=None):
     logger.start_progress('Installing %s...' % (', '.join(project_names)))
     logger.indent += 2
     try:
-        call_subprocess(cmd, show_stdout=False,
+        call_subprocess(cmd, show_stdout=show_stdout,
             extra_env = {
                 'PYTHONPATH': pythonpath,
                 'JYTHONPATH': pythonpath,  # for Jython < 3.x
@@ -977,7 +977,7 @@ def create_environment(home_dir, site_packages=False, clear=False,
                        unzip_setuptools=False,
                        prompt=None, search_dirs=None, never_download=False,
                        no_setuptools=False, no_pip=False, no_wheel=False,
-                       symlink=True):
+                       symlink=True, show_stdout=False):
     """
     Creates a new environment in ``home_dir``.
 
@@ -1001,7 +1001,8 @@ def create_environment(home_dir, site_packages=False, clear=False,
             to_install.append('pip')
         if not no_wheel:
             to_install.append('wheel')
-        install_wheel(to_install, py_executable, search_dirs)
+        install_wheel(to_install, py_executable, search_dirs,
+                      show_stdout=show_stdout)
 
     install_activate(home_dir, bin_dir, prompt)
 


### PR DESCRIPTION
This allows the caller to specify that they would like to see the stdout, which could be useful for troubleshooting, optimizing, etc.

I want to use this while trying to speed up the tests for pip; this will allow me to not have to hack virtualenv to see what's going on when the pip tests create a virtualenv,  setuptools gets installed, etc.

```
$ .tox/py27/bin/py.test tests/functional/test_freeze.py -s -v --tb=short -k test_freeze_basic
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.9 -- py-1.4.26 -- pytest-2.6.4 -- /Users/marca/dev/git-repos/pip/.tox/py27/bin/python
plugins: capturelog, cov, timeout, xdist
collected 8 items

tests/functional/test_freeze.py::test_freeze_basic Ignoring indexes: https://pypi.python.org/simple
Collecting setuptools
Installing collected packages: setuptools
Successfully installed setuptools-14.3
PASSED

================================================================= 7 tests deselected by '-ktest_freeze_basic' ==================================================================
==================================================================== 1 passed, 7 deselected in 3.76 seconds ====================================================================
```