### PR TITLE
Hide deprecated options by default.

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -643,10 +643,16 @@ class ConfigOptionParser(optparse.OptionParser):
 
 
 def main():
+    # preprocess the -v, --verbose flag to hide deprecated options
+    suppress_deprecated = optparse.SUPPRESS_HELP
+    if '-v' in sys.argv or '--verbose' in sys.argv:
+        suppress_deprecated = None
+
     parser = ConfigOptionParser(
         version=virtualenv_version,
         usage="%prog [OPTIONS] DEST_DIR",
-        formatter=UpdatingDefaultsHelpFormatter())
+        formatter=UpdatingDefaultsHelpFormatter(),
+        epilog="Specify --verbose to view deprecated options.")
 
     parser.add_option(
         '-v', '--verbose',
@@ -681,7 +687,7 @@ def main():
         '--no-site-packages',
         dest='system_site_packages',
         action='store_false',
-        help="DEPRECATED. Retained only for backward compatibility. "
+        help=suppress_deprecated or "DEPRECATED. Retained only for backward compatibility. "
              "Not having access to global site-packages is now the default behavior.")
 
     parser.add_option(
@@ -737,8 +743,8 @@ def main():
         dest="never_download",
         action="store_true",
         default=True,
-        help="DEPRECATED. Retained only for backward compatibility. This option has no effect. "
-              "Virtualenv never downloads pip or setuptools.")
+        help=suppress_deprecated or "DEPRECATED. Retained only for backward compatibility. "
+             "This option has no effect. Virtualenv never downloads pip or setuptools.")
 
     parser.add_option(
         '--prompt',
@@ -749,13 +755,15 @@ def main():
         '--setuptools',
         dest='setuptools',
         action='store_true',
-        help="DEPRECATED. Retained only for backward compatibility. This option has no effect.")
+        help=suppress_deprecated or "DEPRECATED. Retained only for backward compatibility. "
+             "This option has no effect.")
 
     parser.add_option(
         '--distribute',
         dest='distribute',
         action='store_true',
-        help="DEPRECATED. Retained only for backward compatibility. This option has no effect.")
+        help=suppress_deprecated or "DEPRECATED. Retained only for backward compatibility. "
+             "This option has no effect.")
 
     if 'extend_parser' in globals():
         extend_parser(parser)


### PR DESCRIPTION
This leaves only essential stuff in help output, showing deprecated stuff only when --verbose is specified.

```
You must provide a DEST_DIR
Usage: virtualenv.py [OPTIONS] DEST_DIR

Options:
  --version             show program's version number and exit
  -h, --help            show this help message and exit
  -v, --verbose         Increase verbosity.
  -q, --quiet           Decrease verbosity.
  -p PYTHON_EXE, --python=PYTHON_EXE
                        The Python interpreter to use, e.g.,
                        --python=python2.5 will use the python2.5 interpreter
                        to create the new environment.  The default is the
                        interpreter that virtualenv was installed with
                        (C:\Python34\python.EXE)
  --clear               Clear out the non-root install and start from scratch.
  --system-site-packages
                        Give the virtual environment access to the global
                        site-packages.
  --always-copy         Always copy files rather than symlinking.
  --unzip-setuptools    Unzip Setuptools when installing it.
  --relocatable         Make an EXISTING virtualenv environment relocatable.
                        This fixes up scripts and makes all .pth files
                        relative.
  --no-setuptools       Do not install setuptools (or pip) in the new
                        virtualenv.
  --no-pip              Do not install pip in the new virtualenv.
  --extra-search-dir=DIR
                        Directory to look for setuptools/pip distributions in.
                        This option can be used multiple times.
  --prompt=PROMPT       Provides an alternative prompt prefix for this
                        environment.

Specify --verbose to view deprecated options.
```