### PR TITLE
fix broken #coding after relocatable

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -73,6 +73,84 @@ def test_activate_after_future_statements():
         'print("Hello, world!")'
     ]
 
+    # added encoding at second string
+    script = [
+        '#!/usr/bin/env python',
+        '# coding: utf-8',
+        'from __future__ import with_statement',
+        'from __future__ import print_function',
+        'print("Hello, world!")'
+    ]
+    assert virtualenv.relative_script(script) == [
+        '#!/usr/bin/env python',
+        '# coding: utf-8',
+        'from __future__ import with_statement',
+        'from __future__ import print_function',
+        '',
+        "import os; activate_this=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'activate_this.py'); exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this)); del os, activate_this",
+        '',
+        'print("Hello, world!")'
+    ]
+
+    # added encoding at first string
+    script = [
+        '# coding: utf-8',
+        '#!/usr/bin/env python',
+        'from __future__ import with_statement',
+        'from __future__ import print_function',
+        'print("Hello, world!")'
+    ]
+    assert virtualenv.relative_script(script) == [
+        '# coding: utf-8',
+        '#!/usr/bin/env python',
+        'from __future__ import with_statement',
+        'from __future__ import print_function',
+        '',
+        "import os; activate_this=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'activate_this.py'); exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this)); del os, activate_this",
+        '',
+        'print("Hello, world!")'
+    ]
+
+    # added encoding at first string
+    script = [
+        '# coding: utf-8',
+        '#!/usr/bin/env python',
+        'print("Hello, world!")'
+    ]
+
+    assert virtualenv.relative_script(script) == [
+        '# coding: utf-8',
+        '#!/usr/bin/env python',
+        '',
+        "import os; activate_this=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'activate_this.py'); exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this)); del os, activate_this",
+        '',
+        'print("Hello, world!")'
+    ]
+
+    # some comments at the begining of the file and coding before shebang
+    script = [
+        '#################',
+        '# some comment1 #',
+        '#################',
+        '# coding: utf-8',
+        '# ONE MORE COMMENT',
+        '#!/usr/bin/env python',
+        'print("Hello, world!")'
+    ]
+
+    assert virtualenv.relative_script(script) == [
+        '#################',
+        '# some comment1 #',
+        '#################',
+        '# coding: utf-8',
+        '# ONE MORE COMMENT',
+        '#!/usr/bin/env python',
+        '',
+        "import os; activate_this=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'activate_this.py'); exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this)); del os, activate_this",
+        '',
+        'print("Hello, world!")'
+    ]
+
 
 def test_cop_update_defaults_with_store_false():
     """store_false options need reverted logic"""

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1702,7 +1702,7 @@ def detect_encoding_position(lines):
         if clean_line.startswith('#') and re.search(
                 r'coding[:=]\s*([-\w.]+)', line):
             return idx + 1
-
+    return 0
 
 def detect_shebang_position(lines):
     """ detecting line which contains shebang string


### PR DESCRIPTION
Hi! I found a nasty bug when using --relocatable option. Function relative_script ignores "# coding" declarations in the top of scripts and breaks it by inserting custom imports between shebang and coding.

Example.

After pip install(before relocatable) script starts with:
```
#!/tmp/virtualenv/bin/python
# coding: utf-8
from argparse import ArgumentParser
import os
import sys

import requests
...
```

And after --relocatable it changes to:
```
#!/usr/bin/env python2.7

import os; activate_this=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'activate_this.py'); exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this)); del os, activate_this

# coding: utf-8
```

and if the file has Unicode comments or strings, this leads to breakage of the script:
python /tmp/virtualenv/bin/my_script
  File "/tmp/virtualenv/bin/my_script", line 37
SyntaxError: Non-ASCII character '\xd0' in file /tmp/virtualenv/bin/my_script on line 37, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
