### PR TITLE
Support for Jython 2.7rc2+

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Release History
 12.2.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~~
 
+* Support Jython 2.7 using its bundled pip.
+
 
 12.1.1 (2015-04-07)
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Jython 2.7 has to use its bundled version of pip [as detailed in this bug](http://bugs.jython.org/issue2302) and expounded upon in detail [in this bug](http://bugs.jython.org/issue2329). Attempting to install or use newer versions simply fails.

This PR awkwardly makes that happen. Most notably, there is no way to install *only* setuptools but not pip...because installing setuptools depends on putting the newer bundled copy of pip on the PYTHONPATH, which fails.

Without a working virtualenv on Jython, tox can't work either, and without a working tox many projects won't bother to test on Jython. I didn't include changes to tox.ini for that reason: it needs a newer release based on a newer release of virtualenv before it can work.

If the upstream Pip is changed, then this 'if' block can be dropped in favor of adding `JYTHONPATH` alongside `PYTHONPATH` in `install_wheel` (because Jython only reads from that environment variable).