### PR TITLE
Fixed pip/setuptools installation on Jython

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -955,6 +955,7 @@ def install_wheel(project_names, py_executable, search_dirs=None):
         call_subprocess(cmd, show_stdout=False,
             extra_env = {
                 'PYTHONPATH': pythonpath,
+                'JYTHONPATH': pythonpath,  # for Jython < 3.x
                 'PIP_FIND_LINKS': findlinks,
                 'PIP_USE_WHEEL': '1',
                 'PIP_PRE': '1',


### PR DESCRIPTION
This clears one roadblock from getting virtualenv to work with Jython. There are more, but they should probably be fixed on Jython's side.