### PR TITLE
use relative paths in symlinks

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -473,6 +473,7 @@ def copyfile(src, dest, symlink=True):
     if symlink and hasattr(os, 'symlink') and not is_win:
         logger.info('Symlinking %s', dest)
         try:
+            srcpath = os.path.relpath(srcpath, os.path.dirname(os.path.abspath(dest)))
             os.symlink(srcpath, dest)
         except (OSError, NotImplementedError):
             logger.info('Symlinking failed, copying to %s', dest)


### PR DESCRIPTION
Hi, I don't know how much this is related with #473, but this makes all symlinks relative.

I meet this problem because the symlinks break when I want to use printed paths outside the LXC container (much like a chroot if you don't know it) in which I use virtualenv. If all symlinks are relative, I can simply prepend the path to the LXC root to refer to the files.