### PR TITLE
Add check for .pyo extension when creating site.py.

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1185,7 +1185,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
     mkdir(join(lib_dir, 'site-packages'))
     import site
     site_filename = site.__file__
-    if site_filename.endswith('.pyc'):
+    if site_filename.endswith('.pyc') or site_filename.endswith('.pyo'):
         site_filename = site_filename[:-1]
     elif site_filename.endswith('$py.class'):
         site_filename = site_filename.replace('$py.class', '.py')


### PR DESCRIPTION
virtualenv fails when creating the environment's site.py for distributions with only optimized bytecode (only .pyo and no .pyc files). It ends up writing the .py file to site.pyo. This fix adds a check for .pyo extensions to resolve the issue.