### PR TITLE
Fix test command invocation causing ERROR

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ try:
 
         def initialize_options(self):
             TestCommand.initialize_options(self)
-            self.pytest_args = None
+            self.pytest_args = []
 
         def finalize_options(self):
             TestCommand.finalize_options(self)


### PR DESCRIPTION
Currently, running the test suite via the test command (pythonX.Y setup.py test) produces the following error:

```
ERROR: file not found: test
```

This change tweaks initialize_options to match the code described upstream [1].

[1] https://pytest.org/latest/goodpractises.html