### PR TITLE
Fixed fish_prompt not displaying $status

### DIFF
--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -51,10 +51,12 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
     
     # with the original prompt function copied, we can override with our own.
     function fish_prompt
+        # Get the old prompt right away, to capture the $status
+        set -l rendered_old_prompt (_old_fish_prompt)
+        
         # Prompt override?
         if test -n "__VIRTUAL_PROMPT__"
-            printf "%s%s" "__VIRTUAL_PROMPT__" (set_color normal)
-            _old_fish_prompt
+            printf "%s%s%s" "__VIRTUAL_PROMPT__" (set_color normal) $rendered_old_prompt
             return
         end
         # ...Otherwise, prepend env
@@ -62,11 +64,9 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
         if test $_checkbase = "__"
             # special case for Aspen magic directories
             # see http://www.zetadev.com/software/aspen/
-            printf "%s[%s]%s " (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal) 
-            _old_fish_prompt
+            printf "%s[%s]%s %s" (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal) $rendered_old_prompt
         else
-            printf "%s(%s)%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal)
-            _old_fish_prompt
+            printf "%s(%s)%s%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal) $rendered_old_prompt
         end
     end 
     

--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -54,20 +54,34 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
         # Get the old prompt right away, to capture the $status
         set -l rendered_old_prompt (_old_fish_prompt)
         
+        # This function reconstructs a multi-line prompt. It is erased later.
+        # This is needed because fish splits commands into arrays on newline
+        function _write_prompt
+            printf '%s' $argv[1]
+            if test (count $argv) -gt 1
+                for part in $argv[2..-1]
+                    printf '\n%s' $part
+                end
+            end
+        end
+        
         # Prompt override?
         if test -n "__VIRTUAL_PROMPT__"
-            printf "%s%s%s" "__VIRTUAL_PROMPT__" (set_color normal) $rendered_old_prompt
-            return
+            printf "%s%s" "__VIRTUAL_PROMPT__" (set_color normal)
+            _write_prompt $rendered_old_prompt
         end
         # ...Otherwise, prepend env
         set -l _checkbase (basename "$VIRTUAL_ENV")
         if test $_checkbase = "__"
             # special case for Aspen magic directories
             # see http://www.zetadev.com/software/aspen/
-            printf "%s[%s]%s %s" (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal) $rendered_old_prompt
+            printf "%s[%s]%s " (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal)
+            _write_prompt $rendered_old_prompt
         else
-            printf "%s(%s)%s%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal) $rendered_old_prompt
+            printf "%s(%s)%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal)
+            _write_prompt $rendered_old_prompt
         end
+        functions -e _write_prompt
     end 
     
     set -gx _OLD_FISH_PROMPT_OVERRIDE "$VIRTUAL_ENV"

--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -69,6 +69,7 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
         if test -n "__VIRTUAL_PROMPT__"
             printf "%s%s" "__VIRTUAL_PROMPT__" (set_color normal)
             _write_prompt $rendered_old_prompt
+            return
         end
         # ...Otherwise, prepend env
         set -l _checkbase (basename "$VIRTUAL_ENV")


### PR DESCRIPTION
Many `fish_prompt`s display the `$status` of the previous command (`$status` being fish's equivalent of `$?` in POSIX shells). However, in order for this to work correctly, `$status` must be retrieved right away; otherwise, the `$status` will be of some command within the `fish_prompt` function. This pull request updates an activated virtualenv's `fish_prompt` to call `_old_fish_prompt` first, and store the resultant prompt string in a local variable, to ensure that `$status` is captured correctly.