### PR TITLE
Fix PATH in sh subshells in fish shell

### DIFF
--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -1,10 +1,23 @@
 # This file must be used using `. bin/activate.fish` *within a running fish ( http://fishshell.com ) session*.
 # Do not run it directly.
 
+function _bashify_path -d "Converts a fish path to something bash can recognize"
+    set fishy_path $argv
+    set bashy_path $fishy_path[1]
+    for path_part in $fishy_path[2..-1]
+        set bashy_path "$bashy_path:$path_part"
+    end
+    echo $bashy_path
+end
+
+function _fishify_path -d "Converts a bash path to something fish can recognize"
+    echo $argv | tr ':' ' '
+end
+
 function deactivate -d 'Exit virtualenv mode and return to the normal environment.'
     # reset old environment variables
     if test -n "$_OLD_VIRTUAL_PATH"
-        set -gx PATH $_OLD_VIRTUAL_PATH
+        set -gx PATH (_fishify_path $_OLD_VIRTUAL_PATH)
         set -e _OLD_VIRTUAL_PATH
     end
 
@@ -30,6 +43,8 @@ function deactivate -d 'Exit virtualenv mode and return to the normal environmen
         # Self-destruct!
         functions -e pydoc
         functions -e deactivate
+        functions -e _bashify_path
+        functions -e _fishify_path
     end
 end
 
@@ -38,7 +53,7 @@ deactivate nondestructive
 
 set -gx VIRTUAL_ENV "__VIRTUAL_ENV__"
 
-set -gx _OLD_VIRTUAL_PATH $PATH
+set -gx _OLD_VIRTUAL_PATH (_bashify_path $PATH)
 set -gx PATH "$VIRTUAL_ENV/__BIN_NAME__" $PATH
 
 # Unset `$PYTHONHOME` if set.


### PR DESCRIPTION
If in a subshell from within `fish`, the PATH variable will be converted to the proper format for sh, but none of the custom path-like variables will. This causes errors because it sets the PATH to an invalid value when activating.

This patch makes activate.fish always store the old path using `:` deliminators and then converts it back to `fish` format later.

### Issue reproduction
Simplest example:

`PATH` converts correctly
```
fish $ echo $PATH
  /bin /usr/local/bin
fish $ bash -c 'echo $PATH'
  /bin:/usr/local/bin
```

`OLD_PATH` does not
```
fish $ set -x OLD_PATH $PATH
fish $ echo $OLD_PATH
  /bin /usr/local/bin
fish $ bash -c 'echo $OLD_PATH'
  /bin/usr/local/bin
```

There you will see the `OLD_PATH` is not a valid path for sh.
