### PR TITLE
Try to download the latest versions of preinstalled packages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,11 @@ Release History
 
 * Remove use of () in .bat files so ``Program Files (x86)`` works :issue:`35`
 
+* Download new releases of the preinstalled software from PyPI when there are
+  new releases available. This behavior can be disabled using
+  ``--no-download``.
+
+
 13.1.2 (2015-08-23)
 -------------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -90,11 +90,13 @@ Options
    Provides an alternative prompt prefix for this
    environment.
 
-.. option:: --never-download
+.. option:: --download
 
-   DEPRECATED. Retained only for backward compatibility.
-   This option has no effect. Virtualenv never downloads
-   pip or setuptools.
+   Download preinstalled packages from PyPI.
+
+.. option:: --no-download
+
+   Do not download preinstalled packages from PyPI.
 
 .. option:: --no-site-packages
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -128,7 +128,7 @@ below.
 Removing an Environment
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Removing a virtual environment is simply done by deactivating it and deleting the 
+Removing a virtual environment is simply done by deactivating it and deleting the
 environment folder with all its contents::
 
     (ENV)$ deactivate
@@ -254,5 +254,3 @@ As well as the extra directories, the search order includes:
 #. The directory where virtualenv.py is located.
 #. The current directory.
 
-If no satisfactory local distributions are found, virtualenv will
-fail. Virtualenv will never download packages.


### PR DESCRIPTION
* Will only accept Wheels (because that is all we can install without setuptools).
* Will still fall back to using the bundled copies of the preinstalled packages if it cannot access the internet.

This should prevent errors happening from too old of versions of software being bundled with virtualenv, while still allowing people to prevent talking to the internet with ``--no-download``. Unlike the previous implementation of downloading which was insecure, this implementation simply allows pip to handle it, which makes it safe, secure, and fast when it's been cached.

This should make issues like #835 better.

Fixes #801
Fixes #781
Fixes #563
Fixes #491