### PR TITLE
Remove versioned entry point

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Release History
 14.1.0 (unreleased)
 -------------------
 
+* Remove the `virtualenv-N.N` script from the package; this can no longer be correctly created from a wheel installation.
+  Resolves :issue:`851`, :issue:`692`
+
 
 14.0.6 (2016-02-07)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,7 @@ try:
 
     setup_params = {
         'entry_points': {
-            'console_scripts': [
-                'virtualenv=virtualenv:main',
-                'virtualenv-%s.%s=virtualenv:main' % sys.version_info[:2]
-            ],
+            'console_scripts': ['virtualenv=virtualenv:main'],
         },
         'zip_safe': False,
         'cmdclass': {'test': PyTest},
@@ -46,9 +43,7 @@ except ImportError:
         setup_params = {}
     else:
         script = 'scripts/virtualenv'
-        script_ver = script + '-%s.%s' % sys.version_info[:2]
-        shutil.copy(script, script_ver)
-        setup_params = {'scripts': [script, script_ver]}
+        setup_params = {'scripts': [script]}
 
 
 def read_file(*paths):


### PR DESCRIPTION
This is no longer compatible with static wheel installations, unless another hack was added to pip! :D

Solves #851