### PR TITLE
Appveyor support (fixes #859)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 install:
-  - cmd: pip install tox
+  - cmd: python -m pip install tox
 
 build_script:
   - cmd: python --version
-  - cmd: tox
+  - cmd: puthon -m tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,19 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python26"
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python26-x64"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python33-x64"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
+    
 install:
-  - cmd: python -m pip install tox
-
+  - "%PYTHON%\\python.exe -m pip install tox"
 build_script:
-  - cmd: python --version
-  - cmd: python -m tox
+  - "%PYTHON%\\python.exe --version"
+test_script:
+  - "%PYTHON%\\python.exe -m tox"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,4 +3,4 @@ install:
 
 build_script:
   - cmd: python --version
-  - cmd: puthon -m tox
+  - cmd: python -m tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ install:
 build_script:
   - "%PYTHON%\\python.exe --version"
 test_script:
-  - "%PYTHON%\\python.exe -m tox"
+  - "%PYTHON%\\python.exe -m tox -e"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     
 install:
-  - "%PYTHON%\\python.exe -m pip install tox"
+  - "%PYTHON%\\Scripts\\pip install tox"
 build_script:
   - "%PYTHON%\\python.exe --version"
 test_script:
-  - "%PYTHON%\\python.exe -m tox -e"
+  - "%PYTHON%\\python.exe -m tox -e py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,5 @@ install:
 build_script:
   - "%PYTHON%\\python.exe --version"
 test_script:
+  - "%PYTHON%\\Scripts\\tox --listenvs"
   - "%PYTHON%\\Scripts\\tox -e py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ install:
 build_script:
   - "%PYTHON%\\python.exe --version"
 test_script:
-  - "%PYTHON%\\python.exe -m tox -e py"
+  - "%PYTHON%\\Scripts\\tox -e py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+install:
+  - cmd: pip install tox
+
+build_script:
+  - cmd: python --version
+  - cmd: tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # env names must be a valid python  binary name, unless they have a
 # separate configuration
 envlist =
-    python{2.6,2.7,3.3,3.4,3.5}, pypy{,3}, crosspython{2,3}, docs
+    py, python{2.6,2.7,3.3,3.4,3.5}, pypy{,3}, crosspython{2,3}, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
The result of test run - https://ci.appveyor.com/project/techtonik/virtualenv - this can be tuned later.

Pythons installed on Appveyor - http://www.appveyor.com/docs/installed-software#python

Further guide - http://python-packaging-user-guide.readthedocs.org/en/latest/appveyor/#adding-appveyor-support-to-your-project