### PR TITLE
Handling encodings correctly

### DIFF
--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import sys
 import subprocess
 import virtualenv
@@ -20,6 +21,14 @@ def test_commandline_explicit_interp(tmpdir):
         VIRTUALENV_SCRIPT,
         '-p', sys.executable,
         str(tmpdir.join('venv'))
+    ])
+
+def test_commandline_non_ascii_path(tmpdir):
+    subprocess.check_call([
+        sys.executable,
+        VIRTUALENV_SCRIPT,
+        '-p', sys.executable,
+        str(tmpdir.join('venv中文'))
     ])
 
 # The registry lookups to support the abbreviated "-p 3.5" form of specifying

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -227,7 +227,9 @@ class Logger(object):
                     else:
                         rendered = msg
                     rendered = ' '*self.indent + rendered
-                if hasattr(consumer, 'write'):
+                if hasattr(consumer, 'buffer'):
+                    consumer.buffer.write(rendered.encode('utf-8')+b'\n')
+                elif hasattr(consumer, 'write'):
                     consumer.write(rendered+'\n')
                 else:
                     consumer(rendered)

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -731,6 +731,7 @@ def call_subprocess(cmd, show_stdout=True,
                 part = part.decode(sys.getfilesystemencoding())
         cmd_parts.append(part)
     cmd_desc = ' '.join(cmd_parts)
+    cmd_desc = cmd_desc.encode('utf-8')
     if show_stdout:
         stdout = None
     else:
@@ -1378,8 +1379,9 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         # the value:
         py_executable = '"%s"' % py_executable
     # NOTE: keep this check as one line, cmd.exe doesn't cope with line breaks
-    cmd = [py_executable, '-c', 'import sys;out=sys.stdout;'
-        'getattr(out, "buffer", out).write(sys.prefix.encode("utf-8"))']
+    cmd = [py_executable, '-c', 'import sys;out=sys.stdout;prefix=sys.prefix;'
+        'prefix=prefix.encode("utf-8") if sys.version_info[0]==3 else prefix;'
+        'getattr(out, "buffer", out).write(prefix)']
     logger.info('Testing executable with %s %s "%s"' % tuple(cmd))
     try:
         proc = subprocess.Popen(cmd,


### PR DESCRIPTION
Fixes #457 

This depends on the latest fix in pypa/distlib. Here are my steps:
```Sh
$ wget https://pypi.python.org/packages/source/p/pip/pip-8.0.2.tar.gz
$ tar xf pip-8.0.2.tar.gz
$ cd pip-8.0.2
$ pushd pip/_vendor/distlib
$ patch -i distlib-encoding.patch -p2
$ popd
$ python setup.py bdist_wheel
```
Where distlib-encoding.patch is from https://bitbucket.org/pypa/distlib/commits/1b082cb:
```Diff
diff --git a/distlib/util.py b/distlib/util.py
--- a/distlib/util.py
+++ b/distlib/util.py
@@ -33,7 +33,8 @@
                      cache_from_source, urlopen, urljoin, httplib, xmlrpclib,
                      splittype, HTTPHandler, HTTPSHandler as BaseHTTPSHandler,
                      BaseConfigurator, valid_ident, Container, configparser,
-                     URLError, match_hostname, CertificateError, ZipFile)
+                     URLError, match_hostname, CertificateError, ZipFile,
+                     fsdecode)
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,10 @@
 #    else:
 #        result = sys.executable
 #    return result
-    return os.path.normcase(sys.executable)
+    result = os.path.normcase(sys.executable)
+    if not isinstance(result, text_type):
+        result = fsdecode(result)
+    return result
 
 
 def proceed(prompt, allowed_chars, error_prompt=None, default=None):
```
When things are done, replace ```virtualenv_support/pip-8.0.2-py2.py3-none-any.whl``` with ```../pip-8.0.2/dist/pip-8.0.2-py2.py3-none-any.whl```