### PR TITLE
Print error message when DEST_DIR exists and is a file

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -677,6 +677,11 @@ def main():
 
     home_dir = args[0]
 
+    if os.path.exists(home_dir) and os.path.isfile(home_dir):
+        logger.fatal('ERROR: File already exists and is not a directory.')
+        logger.fatal('Please provide a different path or delete the file.')
+        sys.exit(3)
+
     if os.environ.get('WORKING_ENV'):
         logger.fatal('ERROR: you cannot run virtualenv while in a workingenv')
         logger.fatal('Please deactivate your workingenv, then re-run this script')


### PR DESCRIPTION
Consider following:
```
> $ virtualenv --version                                                       
15.0.0
> $ touch scripts
> $ virtualenv scripts                                                         
Traceback (most recent call last):
  File "/home/rkuska/.local/bin/virtualenv", line 11, in <module>
    sys.exit(main())
  File "/home/rkuska/.local/lib/python2.7/site-packages/virtualenv.py", line 703, in main
    symlink=options.symlink)
  File "/home/rkuska/.local/lib/python2.7/site-packages/virtualenv.py", line 916, in create_environment
    site_packages=site_packages, clear=clear, symlink=symlink))
  File "/home/rkuska/.local/lib/python2.7/site-packages/virtualenv.py", line 1091, in install_python
    mkdir(lib_dir)
  File "/home/rkuska/.local/lib/python2.7/site-packages/virtualenv.py", line 318, in mkdir
    os.makedirs(path)
  File "/usr/lib64/python2.7/os.py", line 150, in makedirs
    makedirs(head, mode)
  File "/usr/lib64/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 20] Not a directory: '/tmp/scripts/lib'
```