### PR TITLE
Fix issue #93 - Tcl doesn't work inside a virtualenv on Windows

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1062,6 +1062,16 @@ def copy_required_modules(dst_prefix, symlink):
                 if os.path.exists(pyfile):
                     copyfile(pyfile, dst_filename[:-1], symlink)
 
+def copy_tcltk(src, dest, symlink):
+    """ copy tcl/tk libraries on Windows (issue #93) """
+    if majver == 2:
+        libver = '8.5'
+    else:
+        libver = '8.6'
+    for name in ['tcl', 'tk']:
+        srcdir = src + '/tcl/' + name + libver
+        dstdir = dest + '/tcl/' + name + libver
+        copyfileordir(srcdir, dstdir, symlink)
 
 def subst_path(prefix_path, prefix, home_dir):
     prefix_path = os.path.normpath(prefix_path)
@@ -1118,6 +1128,9 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         copy_required_modules(home_dir, symlink)
     finally:
         logger.indent -= 2
+    # ...copy tcl/tk
+    if is_win:
+        copy_tcltk(prefix, home_dir, symlink)
     mkdir(join(lib_dir, 'site-packages'))
     import site
     site_filename = site.__file__


### PR DESCRIPTION
Copies:
```
C:\Python27\tcl\tcl8.5
C:\Python27\tcl\tk8.5
```

```
C:\Python35\tcl\tcl8.6
C:\Python35\tcl\tk8.6
```

Checked that Python 3.4 contains the same dirs as 3.5.