### PR TITLE
Check if py_executable is a symlink.  If not, continue to symlink it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ branches:
     - master
     - develop
     - rewrite
+    - chksymlinks
 
 notifications:
   irc:

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -142,12 +142,13 @@ def test_install_python_bin_existing_symlink():
             required_executables = [ py_exe_no_version, py_exe_version_major,
                                      py_exe_version_major_minor ]
 
-        req_path = os.path.join(bin_dir, required_executables[0])
+        req_path = os.path.join(bin_dir, required_executables[1])
         if not os.path.exists(bin_dir):
             os.makedirs(bin_dir)
 
         with open(req_path, 'w') as fp:
             fp.write('\n')
+
         os.symlink(req_path, exist_python)
         virtualenv.install_python(home_dir, lib_dir, inc_dir, bin_dir, False,
                                   False)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -122,6 +122,38 @@ def test_install_python_bin():
         shutil.rmtree(tmp_virtualenv)
 
 
+def test_install_python_bin_existing_symlink():
+    """Should create the right python executables and links"""
+    tmp_virtualenv = tempfile.mkdtemp()
+    try:
+        home_dir, lib_dir, inc_dir, bin_dir = \
+                                virtualenv.path_locations(tmp_virtualenv)
+        exist_python = os.path.join(bin_dir, 'python')
+
+        if virtualenv.is_win:
+            required_executables = [ 'python.exe', 'pythonw.exe']
+            exist_python_exe =  exist_python + '.exe'
+        else:
+            exist_python_exe = exist_python
+            py_exe_no_version = 'python'
+            py_exe_version_major = 'python%s' % sys.version_info[0]
+            py_exe_version_major_minor = 'python%s.%s' % (
+                sys.version_info[0], sys.version_info[1])
+            required_executables = [ py_exe_no_version, py_exe_version_major,
+                                     py_exe_version_major_minor ]
+
+        req_path = os.path.join(bin_dir, required_executables[0])
+        with open(req_path, 'w') as fp:
+            fp.write('\n')
+        os.symlink(req_path, exist_python)
+        virtualenv.install_python(home_dir, lib_dir, inc_dir, bin_dir, False,
+                                  False)
+
+        assert os.path.islink(exist_python) and os.readlink(exist_python) == req_path
+    finally:
+        shutil.rmtree(tmp_virtualenv)
+
+
 @pytest.mark.skipif("platform.python_implementation() == 'PyPy'")
 def test_always_copy_option():
     """Should be no symlinks in directory tree"""

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -143,6 +143,9 @@ def test_install_python_bin_existing_symlink():
                                      py_exe_version_major_minor ]
 
         req_path = os.path.join(bin_dir, required_executables[0])
+        if not os.path.exists(bin_dir):
+            os.makedirs(bin_dir)
+
         with open(req_path, 'w') as fp:
             fp.write('\n')
         os.symlink(req_path, exist_python)

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1263,7 +1263,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             if sys.platform in ('win32', 'cygwin'):
                 python_executable += '.exe'
             if (not os.path.exists(python_executable) and
-                not os.islink(python_executable)):
+                not os.path.islink(python_executable)):
                 logger.info('Also created executable %s' % python_executable)
                 copyfile(py_executable, python_executable, symlink)
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1225,7 +1225,8 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         ## FIXME: could I just hard link?
         executable = sys.executable
         if (not os.path.islink(py_executable) and
-            os.readlink(py_executable) != executable):
+            os.readlink(py_executable) != executable and
+            os.path.exists(py_executable)):
             shutil.copyfile(executable, py_executable)
             make_exe(py_executable)
         if is_win or is_cygwin:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1364,12 +1364,13 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         if not os.path.islink(py_executable):
             for pth in required_symlinks:
                 full_pth = join(bin_dir, pth)
-                if os.path.exists(full_pth):
-                    os.unlink(full_pth)
-                if symlink:
-                    os.symlink(py_executable_base, full_pth)
-                else:
-                    copyfile(py_executable, full_pth, symlink)
+                if (not os.path.islink(full_pth) and os.readlink(full_pth) != py_executable):
+                    if os.path.exists(full_pth):
+                        os.unlink(full_pth)
+                    if symlink:
+                        os.symlink(py_executable_base, full_pth)
+                    else:
+                        copyfile(py_executable, full_pth, symlink)
 
     if is_win and ' ' in py_executable:
         # There's a bug with subprocess on Windows when using a first

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1263,7 +1263,8 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             if sys.platform in ('win32', 'cygwin'):
                 python_executable += '.exe'
             if (not os.path.exists(python_executable) and
-                not os.path.islink(python_executable)):
+                not os.path.islink(python_executable) and
+                os.path.readlink(python_executable) != py_executable):
                 logger.info('Also created executable %s' % python_executable)
                 copyfile(py_executable, python_executable, symlink)
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1224,8 +1224,10 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
     if sys.executable != py_executable:
         ## FIXME: could I just hard link?
         executable = sys.executable
-        shutil.copyfile(executable, py_executable)
-        make_exe(py_executable)
+        if (not os.path.islink(py_executable) and
+            os.readlink(py_executable) != executable):
+            shutil.copyfile(executable, py_executable)
+            make_exe(py_executable)
         if is_win or is_cygwin:
             pythonw = os.path.join(os.path.dirname(sys.executable), 'pythonw.exe')
             if os.path.exists(pythonw):
@@ -1262,6 +1264,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             python_executable = os.path.join(os.path.dirname(py_executable), 'python')
             if sys.platform in ('win32', 'cygwin'):
                 python_executable += '.exe'
+
             if (not os.path.exists(python_executable) and
                 not os.path.islink(python_executable) and
                 os.readlink(python_executable) != py_executable):

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1264,7 +1264,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
                 python_executable += '.exe'
             if (not os.path.exists(python_executable) and
                 not os.path.islink(python_executable) and
-                os.path.readlink(python_executable) != py_executable):
+                os.readlink(python_executable) != py_executable):
                 logger.info('Also created executable %s' % python_executable)
                 copyfile(py_executable, python_executable, symlink)
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1364,8 +1364,8 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         if not os.path.islink(py_executable):
             for pth in required_symlinks:
                 full_pth = join(bin_dir, pth)
-                if (not os.path.islink(full_pth) and os.readlink(full_pth) != py_executable):
-                    if os.path.exists(full_pth):
+                if os.path.exists(full_pth):
+                    if (not os.path.islink(full_pth) and os.readlink(full_pth) != py_executable):
                         os.unlink(full_pth)
                     if symlink:
                         os.symlink(py_executable_base, full_pth)

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1358,14 +1358,15 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             # Don't try to symlink to yourself.
             required_symlinks.remove(py_executable_base)
 
-        for pth in required_symlinks:
-            full_pth = join(bin_dir, pth)
-            if os.path.exists(full_pth):
-                os.unlink(full_pth)
-            if symlink:
-                os.symlink(py_executable_base, full_pth)
-            else:
-                copyfile(py_executable, full_pth, symlink)
+        if not os.path.islink(py_executable):
+            for pth in required_symlinks:
+                full_pth = join(bin_dir, pth)
+                if os.path.exists(full_pth):
+                    os.unlink(full_pth)
+                if symlink:
+                    os.symlink(py_executable_base, full_pth)
+                else:
+                    copyfile(py_executable, full_pth, symlink)
 
     if is_win and ' ' in py_executable:
         # There's a bug with subprocess on Windows when using a first

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1262,8 +1262,10 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             python_executable = os.path.join(os.path.dirname(py_executable), 'python')
             if sys.platform in ('win32', 'cygwin'):
                 python_executable += '.exe'
-            logger.info('Also created executable %s' % python_executable)
-            copyfile(py_executable, python_executable, symlink)
+            if (not os.path.exists(python_executable) and
+                not os.islink(python_executable)):
+                logger.info('Also created executable %s' % python_executable)
+                copyfile(py_executable, python_executable, symlink)
 
             if is_win:
                 for name in ['libexpat.dll', 'libpypy.dll', 'libpypy-c.dll',


### PR DESCRIPTION
Current behaviour of install_python() overwrites py_executable without checking if py_executable is a symlink itself (especially to one of the mentioned symlinks in required_symlinks).  Right now,
while building Thunderbird (which symlinks python to python2.7 and python2), this situation
creates a circular symlink issue because it removes the python and symlinks it to python2.7
without removing the python2.7 symlink (which is symlinked to python).

This patch at least checks if py_executable is a symlink.  If so, it doesn't do anything to
it. If not, it does the usual for loop.