### PR TITLE
Fix Tcl inside a virtualenv on Windows (issue #93)

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1191,6 +1191,9 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
     site_filename_dst = change_prefix(site_filename, home_dir)
     site_dir = os.path.dirname(site_filename_dst)
     writefile(site_filename_dst, SITE_PY)
+    if is_win:
+        fixtk_filename = join(site_dir, 'FixTk.py')
+        writefile(fixtk_filename, FIXTK_PY)    
     writefile(join(site_dir, 'orig-prefix.txt'), prefix)
     site_packages_filename = join(site_dir, 'no-global-site-packages.txt')
     if not site_packages:
@@ -1999,6 +2002,31 @@ n6kJTcsp4tG42yeT7nQbtdUFwgVJjwDSUYEAC8F0dKOTILrlLO/xC70bnNd0Ha97whQ6UkHJYj5H
 cA/j+zX4tbtTIfGjujOKpj83aHOgXnIQbvYduNXEC4UMm4T21Bs+GHABuCa7v//LR/TvpjHa7oe7
 /Grb6lVvHSD7spj5iplBLRKZxxEYGdCbY9LWWC5hBB2voWno6DJUMzfkC3T8KJsWL9umDQY5szPt
 AVijEPwfucjncQ==
+""")
+
+##file FixTk.py
+FIXTK_PY = convert("""
+eJy9VltP4zgUfq/U/3AUHkg12dCB1e4ILbMqpTARTEGlMLOiKHJTl3rr2pXtlObf77GTtAlQlofV
++qFK7XP9zpUtllIZ0JkOQOpmo9nYgzPKSQYsf4nNnAlDFaTCMA7PFGZkRUFTA8PuVXwVnQ46g78C
+y6clmBnB+4TH50xMemuapIaMueXRQCCZEZFQMBK4TIihwIy2jFQkcsLEE0yYoomRKgtzS+7EFG1I
+BdLyLLDKEyKENDAX8hmV0aoNW27LyqaWfCLFfoXaJBxWVGkmBUqbsWRWkTlFk0GmxnI/MzPDzxIE
+9CiE86opeINEnFsXKJ+iQ3IOTFjePyo2fR2F4Qi1urv73uA2uu5/DSxSRGRmZn1OuNQWE8tqbVSU
+cCees7EiKsvVTGQBSW+9JGinzhZjyVmCVGKuQQq4Z9qQZsOo7LjZADyF7YnJllTnV/l3+Iyech7O
+qRKUHx2GF9RgvAi/IWbWJwt6mn1DHZz+aDboOqFLA37khPWUkiqAjjGKjVND3f9WoW9Cp5BIgfia
+eImSfF2+2KOoSZUANIRyTT/EQrTGB2CaCXQNM8fHJNVGtfBtz6ZsuFR0ytZWhCFIhDDwDMaZKf21
+J8W0gBPQ4YRillHfW4wT7bW2BLOcYAc2oy2hPV0Mj6HnDMHxreQA2usv7QDtOY+uevGg1zmLO8Ph
+IDq9G/Zu67zV8znYfhe8t986g1zCbra+FDSAoyBnu77p9ePez+h2GPUvdjO11+3DtjsbO8+vOhfx
+aad7eXcT3/a+d/rDqPuOtVZtBTGsrRy0E/jl83GdbQ+6eTnJJRXbkgzgiWHbSJd16m1WlDfjdLoN
+RuLQjlPBbOhifJtS5aeehxgc/v7bl1Y1v/SHg7gz3/2ZCynqCYBT4eNHK9gNywuYW+j8/fXV3fde
+3O/gz9l1BdIdlnVt9efanfI6ys6pE2i/xtgVje1jMCWYjBPwafgUgqDmWap53l/xtfVvcFvQ0MuH
+Y1T1GLpG/EaJ7EH0JKSiCApxjXo0+nNUs1SHWKLKaNs4fW80sgQjr/XCcKtNP/x6/PgO712/+yYf
+CvXgE7IfVdm3HjUbRTc4wUEW2m4S/i2Z8G2fsD01zp8DD9ux9Q0VuzQtaOka+6f2c6JS/x52qBVG
+5SAMD5DNzA+wKedPH1O2eV0S5VLLc2Iwfz2UVEL8ShYZa9cOC2uKeYbzQuMgwJywhjuDA/yEaapw
+cCicyUThREMiQemETpyP7/q3UVxrwhutRXy8ykDznG4mrFwqVkxJUYkVTmsQWFAFAUeV6PULpZXI
+W9pa8F1sjl9XHN7nXbqGdgGyldJ6zVNxnmlrRi7kLfH2bB16qDn8iFpzzjInunKxxOEHw8vN+uNW
+DFsYbgFixi08dppri0ZRqiU/PuF8rw3pcsvKL5HeFopRfnkfVvaHamAuPxaX1Q7kYN/M9z+hunrb
+eZEzNc5VnsORmNC113oJZgXE/a1x+xbDVen+j1dr2RBzcLOW4W6EO9ki1aZMaEtCcftUdFOV201v
+A0X08//KUbZ+O0fZ+j/IUSfkQzlacdjlqONsNv4BOP1jtw==
 """)
 
 ##file activate.sh

--- a/virtualenv_embedded/FixTk.py
+++ b/virtualenv_embedded/FixTk.py
@@ -1,0 +1,78 @@
+import sys, os
+
+# Delay import _tkinter until we have set TCL_LIBRARY,
+# so that Tcl_FindExecutable has a chance to locate its
+# encoding directory.
+
+# Unfortunately, we cannot know the TCL_LIBRARY directory
+# if we don't know the tcl version, which we cannot find out
+# without import Tcl. Fortunately, Tcl will itself look in
+# <TCL_LIBRARY>\..\tcl<TCL_VERSION>, so anything close to
+# the real Tcl library will do.
+
+# Expand symbolic links on Vista
+try:
+    import ctypes
+    ctypes.windll.kernel32.GetFinalPathNameByHandleW
+except (ImportError, AttributeError):
+    def convert_path(s):
+        return s
+else:
+    def convert_path(s):
+        assert isinstance(s, str)   # sys.prefix contains only bytes
+        udir = s.decode("mbcs")
+        hdir = ctypes.windll.kernel32.\
+            CreateFileW(udir, 0x80, # FILE_READ_ATTRIBUTES
+                        1,          # FILE_SHARE_READ
+                        None, 3,    # OPEN_EXISTING
+                        0x02000000, # FILE_FLAG_BACKUP_SEMANTICS
+                        None)
+        if hdir == -1:
+            # Cannot open directory, give up
+            return s
+        buf = ctypes.create_unicode_buffer(u"", 32768)
+        res = ctypes.windll.kernel32.\
+            GetFinalPathNameByHandleW(hdir, buf, len(buf),
+                                      0) # VOLUME_NAME_DOS
+        ctypes.windll.kernel32.CloseHandle(hdir)
+        if res == 0:
+            # Conversion failed (e.g. network location)
+            return s
+        s = buf[:res].encode("mbcs")
+        # Ignore leading \\?\
+        if s.startswith("\\\\?\\"):
+            s = s[4:]
+        if s.startswith("UNC"):
+            s = "\\" + s[3:]
+        return s
+
+prefix = os.path.join(sys.real_prefix,"tcl")
+if not os.path.exists(prefix):
+    # devdir/../tcltk/lib
+    prefix = os.path.join(sys.real_prefix, os.path.pardir, "tcltk", "lib")
+    prefix = os.path.abspath(prefix)
+# if this does not exist, no further search is needed
+if os.path.exists(prefix):
+    prefix = convert_path(prefix)
+    if "TCL_LIBRARY" not in os.environ:
+        for name in os.listdir(prefix):
+            if name.startswith("tcl"):
+                tcldir = os.path.join(prefix,name)
+                if os.path.isdir(tcldir):
+                    os.environ["TCL_LIBRARY"] = tcldir
+    # Compute TK_LIBRARY, knowing that it has the same version
+    # as Tcl
+    import _tkinter
+    ver = str(_tkinter.TCL_VERSION)
+    if "TK_LIBRARY" not in os.environ:
+        v = os.path.join(prefix, 'tk'+ver)
+        if os.path.exists(os.path.join(v, "tclIndex")):
+            os.environ['TK_LIBRARY'] = v
+    # We don't know the Tix version, so we must search the entire
+    # directory
+    if "TIX_LIBRARY" not in os.environ:
+        for name in os.listdir(prefix):
+            if name.startswith("tix"):
+                tixdir = os.path.join(prefix,name)
+                if os.path.isdir(tixdir):
+                    os.environ["TIX_LIBRARY"] = tixdir


### PR DESCRIPTION
See issue #93 for details and alternative solutions. One suggestion was to bring code from Lib\lib-tk\FixTk.py into site.py, but leaving site.py alone and copying a minimally modified FixTk.py to the Lib directory when the virtualenv is created seems cleaner to me. The only changes to FixTk.py were to replace sys.prefix with sys.real_prefix at lines 49 and 52. 

Fixing this is really important because it affects matplotlib.

All nosetests pass and matplotlib and Tkinter work on python 2.6 and 2.7. Issue #93 referred to Python 2.6 so this would close it. A quick test importing tkinter and calling tkinter._test() in a Python 3.4 virtualenv shows the problem is unresolved there, but it probably doesn't matter anyway since Python 3.3 and venv.

---

*This was automatically migrated from pypa/virtualenv#627 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.*

*Original Submitter: @citterio*