### PR TITLE
Document when --always-copy was introduced (in PR #409)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -115,6 +115,8 @@ Release History
 
 * Added support for PyPy3k
 
+* Added ``--always-copy`` option to suppress use of symlinks (Pull #409)
+
 * Added the option to use a version number with the ``-p`` option to get the
   system copy of that Python version (Windows only)
 


### PR DESCRIPTION
Manually port change from PR #662.

---

_This was automatically migrated from pypa/virtualenv#686 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @techtonik_
