### PR TITLE
in win32 pypy the dlls live next to the exe, not at toplevel

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1316,10 +1316,11 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             copyfile(py_executable, python_executable, symlink)
 
             if is_win:
+                old_bin_dir = os.path.dirname(sys.executable)
                 for name in ['libexpat.dll', 'libpypy.dll', 'libpypy-c.dll',
                             'libeay32.dll', 'ssleay32.dll', 'sqlite3.dll',
                             'tcl85.dll', 'tk85.dll']:
-                    src = join(prefix, name)
+                    src = join(old_bin_dir, name)
                     if os.path.exists(src):
                         copyfile(src, join(bin_dir, name), symlink)
 


### PR DESCRIPTION
Usually the exe is found in the toplevel "prefix" directory, but the installer may choose to put the exe in a subdirectory, together with any dlls. The two most common use cases are on our buildbots (old_bin_dir is pypy/goal ) or in a virtualenv (old_bin_dir is Scripts)

---

*This was automatically migrated from pypa/virtualenv#729 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.*

*Original Submitter: @mattip*