### PR TITLE
use relative paths in symlinks

### DIFF
--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -401,7 +401,9 @@ def copyfile(src, dest, symlink=True):
     if symlink and hasattr(os, "symlink") and not is_win:
         logger.info("Symlinking %s", dest)
         try:
-            os.symlink(os.path.realpath(src), dest)
+            srcpath = os.path.realpath(src)
+            srcpath = os.path.relpath(srcpath, os.path.dirname(os.path.abspath(dest)))
+            os.symlink(srcpath, dest)
         except (OSError, NotImplementedError):
             logger.info("Symlinking failed, copying to %s", dest)
             copyfileordir(src, dest, symlink)


### PR DESCRIPTION
Hi, I don't know how much this is related with #473, but this makes all symlinks relative.

I meet this problem because the symlinks break when I want to use printed paths outside the LXC container (much like a chroot if you don't know it) in which I use virtualenv. If all symlinks are relative, I can simply prepend the path to the LXC root to refer to the files.

---

_This was automatically migrated from pypa/virtualenv#758 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @lilydjwg_
