### PR TITLE
Handling Windows' case-insensitivity

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -936,8 +936,8 @@ def change_prefix(filename, dst_prefix):
     prefixes = sorted(prefixes, key=len, reverse=True)
     filename = os.path.abspath(filename)
     for src_prefix in prefixes:
-        if filename.startswith(src_prefix):
-            _, relpath = filename.split(src_prefix, 1)
+        if (is_win and filename.lower().startswith(src_prefix.lower())) or (filename.startswith(src_prefix)):
+            relpath = filename[len(src_prefix):]
             if src_prefix != os.sep: # sys.prefix == "/"
                 assert relpath[0] == os.sep
                 relpath = relpath[1:]


### PR DESCRIPTION
This small commit is made to fix a bug on Windows where the prefix comparison doesn't work because of windows' case insensitivity.

For example:

$ python virtualenv.py amir
Traceback (most recent call last):
  File "virtualenv.py", line 2240, in <module>
    main()
  File "virtualenv.py", line 689, in main
    symlink=options.symlink)
  File "virtualenv.py", line 852, in create_environment
    site_packages=site_packages, clear=clear, symlink=symlink))
  File "virtualenv.py", line 1043, in install_python
    copy_required_modules(home_dir, symlink)
  File "virtualenv.py", line 981, in copy_required_modules
    dst_filename = change_prefix(filename, dst_prefix)
  File "virtualenv.py", line 946, in change_prefix
    (filename, prefixes)
AssertionError: Filename C:\Python27\Lib\os.py does not start with any of these prefixes: ['c:\python27']

The double backslash is just Python's representation of a single backslash, the problem is the lowercase 'C' and 'P'.

---

_This was automatically migrated from pypa/virtualenv#808 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @amirbaer_
