### PR TITLE
Generalize Windows Tcl/Tk search; handle case where it's missing.

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1065,16 +1065,18 @@ def copy_required_modules(dst_prefix, symlink):
                 if os.path.exists(pyfile):
                     copyfile(pyfile, dst_filename[:-1], symlink)
 
+
 def copy_tcltk(src, dest, symlink):
     """ copy tcl/tk libraries on Windows (issue #93) """
-    if majver == 2:
-        libver = '8.5'
-    else:
-        libver = '8.6'
-    for name in ['tcl', 'tk']:
-        srcdir = src + '/tcl/' + name + libver
-        dstdir = dest + '/tcl/' + name + libver
-        copyfileordir(srcdir, dstdir, symlink)
+    for libver in ['8.5', '8.6']:
+        for name in ['tcl', 'tk']:
+            libdir = name + libver
+            srcdir = os.path.join(src, 'tcl', libdir)
+            dstdir = os.path.join(dest, 'tcl', libdir)
+            # Tcl/Tk is an optional install component and may not be present.
+            if os.path.exists(srcdir):
+                copyfileordir(srcdir, dstdir, symlink)
+
 
 def subst_path(prefix_path, prefix, home_dir):
     prefix_path = os.path.normpath(prefix_path)


### PR DESCRIPTION
This change copies over Tcl/Tk libraries on Windows into the virtualenv, but adds a check so handle the case where the libraries aren't present. Tcl/Tk is an optional component of the installation of Python 2 and 3. This also generalizes the search so either 8.5 or 8.6 are picked up, without needing to be aware of which Python versions ship with which Tcl/Tk version.

The goal here is to combine the solutions of #926 and #931 as a follow-up to #888 and #93.

I looked at the contributing guidelines and see that I should be making pull requests against `develop`, but that branch seems to have disappeared.