### PR TITLE
Remove invalid quotes and comment

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1370,12 +1370,6 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             else:
                 copyfile(py_executable, full_pth, symlink)
 
-    if is_win and ' ' in py_executable:
-        # There's a bug with subprocess on Windows when using a first
-        # argument that has a space in it.  Instead we have to quote
-        # the value:
-        py_executable = '"%s"' % py_executable
-    # NOTE: keep this check as one line, cmd.exe doesn't cope with line breaks
     cmd = [py_executable, '-c', 'import sys;out=sys.stdout;'
         'getattr(out, "buffer", out).write(sys.prefix.encode("utf-8"))']
     logger.info('Testing executable with %s %s "%s"' % tuple(cmd))


### PR DESCRIPTION
Since CMD is being passed to `Popen(..., shell=False)`, the quotes are not necessary and actually _break_ paths with spaces, since the underlying `CreateProcess` call cannot handle quotes around the process path.

Tested with Python 2.6.6, 2.7.12, 3.2.3 and 3.5.2.