### PR TITLE
Only copy tcltk related files if exists and not present.

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1074,7 +1074,8 @@ def copy_tcltk(src, dest, symlink):
     for name in ['tcl', 'tk']:
         srcdir = src + '/tcl/' + name + libver
         dstdir = dest + '/tcl/' + name + libver
-        copyfileordir(srcdir, dstdir, symlink)
+        if os.path.exists(srcdir) and not os.path.exists(dstdir):
+            copyfileordir(srcdir, dstdir, symlink)
 
 def subst_path(prefix_path, prefix, home_dir):
     prefix_path = os.path.normpath(prefix_path)


### PR DESCRIPTION
This PR intent to fix issues, on Windows, related to the copy of tcltk files.
Files will now only be copied if present at the source (Python version without tcltk installed) and not already present at the destination (reinstalling in a previous virtualenv).

Fixes #929