### PR TITLE
Allow sourcing activate.sh in shells "exit on error" mode

### DIFF
--- a/virtualenv_embedded/activate.sh
+++ b/virtualenv_embedded/activate.sh
@@ -64,7 +64,7 @@ if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
 fi
 
 # Make sure to unalias pydoc if it's already there
-alias pydoc 2>/dev/null >/dev/null && unalias pydoc
+alias pydoc 2>/dev/null >/dev/null && unalias pydoc || true
 
 pydoc () {
     python -m pydoc "$@"


### PR DESCRIPTION
The newly added `pydoc` unaliasing command ends with exit code 1 if `pydoc` alias is not set; this in turn means that sourcing `activate.sh` in a shell that had been set to exit on first error, upon sourcing that file, will exit on that line. And thanks to suppressing the output of `pydoc` there is no error message being displayed. Simply adding `|| true` should ensure that the command ends successfully.

Fixes  #958
