### PR TITLE
Include 'enum' module as warnings indirectly imports it since python 3.6

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -155,6 +155,8 @@ elif majver == 3:
             '_collections_abc',
             '_bootlocale',
         ])
+    if minver >= 6:
+        REQUIRED_MODULES.extend(['enum'])
 
 if is_pypy:
     # these are needed to correctly display the exceptions that may happen


### PR DESCRIPTION
Fixes #962

Related CPython change: http://bugs.python.org/issue28082