### PR TITLE
install_wheel.SCRIPT: Project names passed through format() instead o…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
 deps =
     mock
     pytest
+    pip
 commands =
     py.test
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
 deps =
     mock
     pytest
-    pip
 commands =
     py.test
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -746,16 +746,17 @@ def call_subprocess(cmd, show_stdout=True,
     else:
         env = None
     try:
-        print ("#################")
-        print(cmd)
-        print ("#################")
-        proc = subprocess.Popen(
-            cmd, stderr=subprocess.STDOUT,
-            stdin=None if stdin is None else subprocess.PIPE,
-            stdout=stdout,
-            cwd=cwd, env=env)
+        p = subprocess.Popen(['grep', 'f'], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
+        grep_stdout = p.communicate(input=stdin)
+        print(grep_stdout)
+        raise BaseException("$$$$$$$$$$$$$$$$$$$$$")
+
+        # proc = subprocess.Popen(
+        #     cmd, stderr=subprocess.STDOUT,
+        #     stdin=None if stdin is None else subprocess.PIPE,
+        #     stdout=stdout,
+        #     cwd=cwd, env=env)
     except Exception:
-        print("############ FATAL")
         e = sys.exc_info()[1]
         logger.fatal(
             "Error %s while executing command %s" % (e, cmd_desc))
@@ -771,7 +772,6 @@ def call_subprocess(cmd, show_stdout=True,
         fs_encoding = sys.getfilesystemencoding()
         while 1:
             line = stdout.readline()
-            print ("@@@@@@@@ " +str(line))
             try:
                 line = line.decode(encoding)
             except UnicodeDecodeError:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -719,15 +719,6 @@ def call_subprocess(cmd, show_stdout=True,
                     raise_on_returncode=True, extra_env=None,
                     remove_from_env=None, stdin=None):
     cmd_parts = []
-    #####
-    root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
-    ch = logging.StreamHandler(sys.stdout)
-    ch.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    ch.setFormatter(formatter)
-    root.addHandler(ch)
-    #####
     for part in cmd:
         if len(part) > 45:
             part = part[:20]+"..."+part[-20:]
@@ -755,12 +746,16 @@ def call_subprocess(cmd, show_stdout=True,
     else:
         env = None
     try:
+        print ("#################")
+        print(cmd)
+        print ("#################")
         proc = subprocess.Popen(
             cmd, stderr=subprocess.STDOUT,
             stdin=None if stdin is None else subprocess.PIPE,
             stdout=stdout,
             cwd=cwd, env=env)
     except Exception:
+        print("############ FATAL")
         e = sys.exc_info()[1]
         logger.fatal(
             "Error %s while executing command %s" % (e, cmd_desc))
@@ -776,6 +771,7 @@ def call_subprocess(cmd, show_stdout=True,
         fs_encoding = sys.getfilesystemencoding()
         while 1:
             line = stdout.readline()
+            print ("@@@@@@@@ " +str(line))
             try:
                 line = line.decode(encoding)
             except UnicodeDecodeError:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -858,8 +858,6 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         return urljoin('file:', pathname2url(os.path.abspath(p)))
     findlinks = ' '.join(space_path2url(d) for d in search_dirs)
 
-    project_names_string = '[' + ','.join(['"' + name + '"' for name in project_names]) + ']'
-
     SCRIPT = textwrap.dedent("""
         import sys
         import pkgutil
@@ -880,15 +878,15 @@ def install_wheel(project_names, py_executable, search_dirs=None,
             args = ["install", "--ignore-installed"]
             if cert_file is not None:
                 args += ["--cert", cert_file.name]
-            args += {project_names}
+            args += sys.argv[1:]
 
             sys.exit(pip.main(args))
         finally:
             if cert_file is not None:
                 os.remove(cert_file.name)
-    """).format(project_names=project_names_string).encode("utf8")
+    """).encode("utf8")
 
-    cmd = [py_executable]
+    cmd = [py_executable, '-'] + project_names
     logger.start_progress('Installing %s...' % (', '.join(project_names)))
     logger.indent += 2
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -881,7 +881,7 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         finally:
             if cert_file is not None:
                 os.remove(cert_file.name)
-    """).encode("utf8").format(project_names=project_names_string)
+    """).format(project_names=project_names_string).encode("utf8")
 
     cmd = [py_executable]
     logger.start_progress('Installing %s...' % (', '.join(project_names)))

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -905,6 +905,8 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         print (env)
         print (cmd)
         print ("###################################################")
+        print (SCRIPT)
+        print ("###################################################")
         call_subprocess(cmd, show_stdout=True, extra_env=env, stdin=SCRIPT)
 #         call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
     finally:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -853,6 +853,7 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         return urljoin('file:', pathname2url(os.path.abspath(p)))
     findlinks = ' '.join(space_path2url(d) for d in search_dirs)
 
+    # project names provided through format instead of sys.args usage
     project_names_string = '[' + ','.join(['"' + name + '"' for name in project_names]) + ']'
 
     SCRIPT = textwrap.dedent("""

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -719,6 +719,15 @@ def call_subprocess(cmd, show_stdout=True,
                     raise_on_returncode=True, extra_env=None,
                     remove_from_env=None, stdin=None):
     cmd_parts = []
+    #####
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    root.addHandler(ch)
+    #####
     for part in cmd:
         if len(part) > 45:
             part = part[:20]+"..."+part[-20:]
@@ -901,14 +910,7 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         env["PIP_NO_INDEX"] = "1"
 
     try:
-        print ("###################################################")
-        print (env)
-        print (cmd)
-        print ("###################################################")
-        print (SCRIPT)
-        print ("###################################################")
-        call_subprocess(cmd, show_stdout=True, extra_env=env, stdin=SCRIPT)
-#         call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
+        call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
     finally:
         logger.indent -= 2
         logger.end_progress()

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -746,22 +746,14 @@ def call_subprocess(cmd, show_stdout=True,
     else:
         env = None
     try:
-        print("#######")
-        print(env)
-        print("#######")
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, env=env)
-        grep_stdout = p.communicate(input=stdin)
-        print("#######")
-        print(grep_stdout)
-        print("#######")
-        raise BaseException("$$$$$$$$$$$$$$$$$$$$$")
-
-        # proc = subprocess.Popen(
-        #     cmd, stderr=subprocess.STDOUT,
-        #     stdin=None if stdin is None else subprocess.PIPE,
-        #     stdout=stdout,
-        #     cwd=cwd, env=env)
+        # temp empty comment
+        proc = subprocess.Popen(
+            cmd, stderr=subprocess.STDOUT,
+            stdin=None if stdin is None else subprocess.PIPE,
+            stdout=stdout,
+            cwd=cwd, env=env)
     except Exception:
+
         e = sys.exc_info()[1]
         logger.fatal(
             "Error %s while executing command %s" % (e, cmd_desc))

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -746,7 +746,7 @@ def call_subprocess(cmd, show_stdout=True,
     else:
         env = None
     try:
-        p = subprocess.Popen(['grep', 'f'], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
         grep_stdout = p.communicate(input=stdin)
         print(grep_stdout)
         raise BaseException("$$$$$$$$$$$$$$$$$$$$$")

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -746,14 +746,12 @@ def call_subprocess(cmd, show_stdout=True,
     else:
         env = None
     try:
-        # temp empty comment
         proc = subprocess.Popen(
             cmd, stderr=subprocess.STDOUT,
             stdin=None if stdin is None else subprocess.PIPE,
             stdout=stdout,
             cwd=cwd, env=env)
     except Exception:
-
         e = sys.exc_info()[1]
         logger.fatal(
             "Error %s while executing command %s" % (e, cmd_desc))
@@ -855,6 +853,8 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         return urljoin('file:', pathname2url(os.path.abspath(p)))
     findlinks = ' '.join(space_path2url(d) for d in search_dirs)
 
+    project_names_string = '[' + ','.join(['"' + name + '"' for name in project_names]) + ']'
+
     SCRIPT = textwrap.dedent("""
         import sys
         import pkgutil
@@ -875,15 +875,15 @@ def install_wheel(project_names, py_executable, search_dirs=None,
             args = ["install", "--ignore-installed"]
             if cert_file is not None:
                 args += ["--cert", cert_file.name]
-            args += sys.argv[1:]
+            args += {project_names}
 
             sys.exit(pip.main(args))
         finally:
             if cert_file is not None:
                 os.remove(cert_file.name)
-    """).encode("utf8")
+    """).format(project_names=project_names_string).encode("utf8")
 
-    cmd = [py_executable, '-'] + project_names
+    cmd = [py_executable]
     logger.start_progress('Installing %s...' % (', '.join(project_names)))
     logger.indent += 2
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -901,10 +901,10 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         env["PIP_NO_INDEX"] = "1"
 
     try:
-        print "###################################################"
-        print env
-        print cmd
-        print "###################################################"
+        print ("###################################################")
+        print (env)
+        print (cmd)
+        print ("###################################################")
         call_subprocess(cmd, show_stdout=True, extra_env=env, stdin=SCRIPT)
 #         call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
     finally:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -901,7 +901,12 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         env["PIP_NO_INDEX"] = "1"
 
     try:
-        call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
+        print "###################################################"
+        print env
+        print cmd
+        print "###################################################"
+        call_subprocess(cmd, show_stdout=True, extra_env=env, stdin=SCRIPT)
+#         call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
     finally:
         logger.indent -= 2
         logger.end_progress()

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -853,6 +853,8 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         return urljoin('file:', pathname2url(os.path.abspath(p)))
     findlinks = ' '.join(space_path2url(d) for d in search_dirs)
 
+    project_names_string = '[' + ','.join(['"' + name + '"' for name in project_names]) + ']'
+
     SCRIPT = textwrap.dedent("""
         import sys
         import pkgutil
@@ -873,15 +875,15 @@ def install_wheel(project_names, py_executable, search_dirs=None,
             args = ["install", "--ignore-installed"]
             if cert_file is not None:
                 args += ["--cert", cert_file.name]
-            args += sys.argv[1:]
+            args += {project_names}
 
             sys.exit(pip.main(args))
         finally:
             if cert_file is not None:
                 os.remove(cert_file.name)
-    """).encode("utf8")
+    """).encode("utf8").format(project_names=project_names_string)
 
-    cmd = [py_executable, '-'] + project_names
+    cmd = [py_executable]
     logger.start_progress('Installing %s...' % (', '.join(project_names)))
     logger.indent += 2
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -746,9 +746,14 @@ def call_subprocess(cmd, show_stdout=True,
     else:
         env = None
     try:
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
+        print("#######")
+        print(env)
+        print("#######")
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, env=env)
         grep_stdout = p.communicate(input=stdin)
+        print("#######")
         print(grep_stdout)
+        print("#######")
         raise BaseException("$$$$$$$$$$$$$$$$$$$$$")
 
         # proc = subprocess.Popen(


### PR DESCRIPTION
…f sys.args

When virtualenv was called from other tool, this tool can use input arguments and these arguments will be passed to SCRIPT.
For example, if I call pip repo test from PyCharm I get next command line: 
['install', '--ignore-installed', '--cert', 'c:\\users\\asanko\\appdata\\local\\temp\\tmp0elwlm', 'C:\\Program Files (x86)\\JetBrains\\PyCharm Community Edition 2016.2.3\\helpers\\pydev\\pydevd.py', '--multiproc', '--qt-support', '--client', '127.0.0.1', '--port', '50821', '--file', 'setuptools']   
Instead of expected:
['install', '--ignore-installed', '--cert', 'c:\\users\\asanko\\appdata\\local\\temp\\tmp0elwlm' 'setuptools']   
We have project names and can pass it directly to script.