### PR TITLE
Don't set PIP_PRE to 1 during install

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -891,7 +891,6 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         "PIP_FIND_LINKS": findlinks,
         "PIP_USE_WHEEL": "1",
         "PIP_ONLY_BINARY": ":all:",
-        "PIP_PRE": "1",
         "PIP_USER": "0",
     }
 


### PR DESCRIPTION
We don't want to pull down pre-releases of setuptools/wheel/pip from PyPI by default.