### PR TITLE
Fix symlink fallback

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -351,7 +351,7 @@ def copyfile(src, dest, symlink=True):
             os.symlink(srcpath, dest)
         except (OSError, NotImplementedError):
             logger.info('Symlinking failed, copying to %s', dest)
-            copyfileordir(src, dest, symlink)
+            copyfileordir(src, dest, False)
     else:
         logger.info('Copying to %s', dest)
         copyfileordir(src, dest, symlink)


### PR DESCRIPTION
When symlinking fails in the `try:` clause, the files should actually be copied, not symlinked again. Otherwise, this yields the following error with Virtualbox (Windows Host, Ubuntu Guest) in a shared folder:

```
Traceback (most recent call last):
  File "/home/user/venv/lib/python3.5/site-packages/virtualenv.py", line 351, in copyfile
    os.symlink(srcpath, dest)
OSError: [Errno 30] Read-only file system: '/usr/lib/python3.5/config-3.5m-x86_64-linux-gnu' -> '/media/sf_git/mitmproxy/release/build/venv/lib/python3.5/config-3.5m-x86_64-linux-gnu'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/user/venv/lib/python3.5/site-packages/virtualenv.py", line 2328, in <module>
    main()
  File "/home/user/venv/lib/python3.5/site-packages/virtualenv.py", line 713, in main
    symlink=options.symlink)
  File "/home/user/venv/lib/python3.5/site-packages/virtualenv.py", line 925, in create_environment
    site_packages=site_packages, clear=clear, symlink=symlink))
  File "/home/user/venv/lib/python3.5/site-packages/virtualenv.py", line 1130, in install_python
    copyfile(join(stdlib_dir, fn), join(lib_dir, fn), symlink)
  File "/home/user/venv/lib/python3.5/site-packages/virtualenv.py", line 354, in copyfile
    copyfileordir(src, dest, symlink)
  File "/home/user/venv/lib/python3.5/site-packages/virtualenv.py", line 329, in copyfileordir
    shutil.copytree(src, dest, symlink)
  File "/home/user/venv/lib/python3.5/shutil.py", line 353, in copytree
    raise Error(errors)
shutil.Error: [('/home/user/venv/lib/python3.5/config-3.5m-x86_64-linux-gnu/libpython3.5m.so', '/media/sf_git/mitmproxy/release/build/venv/lib/python3.5/config-3.5m-x86_64-linux-gnu/libpython3.5m.so', "[Errno 30] Read-only file system: '../../x86_64-linux-gnu/libpython3.5m.so.1' -> '/media/sf_git/mitmproxy/release/build/venv/lib/python3.5/config-3.5m-x86_64-linux-gnu/libpython3.5m.so'"), ('/home/user/venv/lib/python3.5/config-3.5m-x86_64-linux-gnu/libpython3.5.so', '/media/sf_git/mitmproxy/release/build/venv/lib/python3.5/config-3.5m-x86_64-linux-gnu/libpython3.5.so', "[Errno 30] Read-only file system: '../../x86_64-linux-gnu/libpython3.5m.so.1' -> '/media/sf_git/mitmproxy/release/build/venv/lib/python3.5/config-3.5m-x86_64-linux-gnu/libpython3.5.so'")]
```