### PR TITLE
Copy libs/pythonXY.lib to support building of C extensions

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1261,6 +1261,20 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             elif os.path.exists(pythondll_d_dest):
                 logger.info('Removed %s as the source does not exist' % pythondll_d_dest)
                 os.unlink(pythondll_d_dest)
+            # we also need to copy the static library to support the case where
+            # the interpreter is statically linked.
+            # considering that on windows, python static libraries are located in
+            # the  "<root>/libs" directory, the following code will look for and
+            # copy "pythonXY.lib".
+            pythonlib_name = "python%s%s.lib" % (
+                sys.version_info[0], sys.version_info[1])
+            pythonlib = os.path.join(os.path.dirname(sys.executable), "libs", pythonlib_name)
+            pythonlib_dest_dir = os.path.join(lib_dir, "..", "libs")
+            pythonlib_dest = os.path.join(pythonlib_dest_dir, pythonlib_name)
+            if os.path.exists(pythonlib):
+                logger.info('Also created %s' % pythonlib_name)
+                mkdir(pythonlib_dest_dir)
+                shutil.copyfile(pythonlib, pythonlib_dest)
         if is_pypy:
             # make a symlink python --> pypy-c
             python_executable = os.path.join(os.path.dirname(py_executable), 'python')


### PR DESCRIPTION
This issue was discovered while using pytest-virtualenv to create an
isolated environment and test that a source distribution would compile.

References:
 * https://docs.python.org/2/extending/windows.html#using-dlls-in-practice
 * https://docs.python.org/3.6/extending/windows.html#using-dlls-in-practice