### PR TITLE
install_wheel.SCRIPT: Project names passed through format() instead of sys.args

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -853,6 +853,9 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         return urljoin('file:', pathname2url(os.path.abspath(p)))
     findlinks = ' '.join(space_path2url(d) for d in search_dirs)
 
+    # project names provided through format instead of sys.args usage: https://github.com/pypa/virtualenv/issues/983
+    project_names_string = '[' + ','.join(['"' + name + '"' for name in project_names]) + ']'
+
     SCRIPT = textwrap.dedent("""
         import sys
         import pkgutil
@@ -873,15 +876,15 @@ def install_wheel(project_names, py_executable, search_dirs=None,
             args = ["install", "--ignore-installed"]
             if cert_file is not None:
                 args += ["--cert", cert_file.name]
-            args += sys.argv[1:]
+            args += {project_names}
 
             sys.exit(pip.main(args))
         finally:
             if cert_file is not None:
                 os.remove(cert_file.name)
-    """).encode("utf8")
+    """).format(project_names=project_names_string).encode("utf8")
 
-    cmd = [py_executable, '-'] + project_names
+    cmd = [py_executable]
     logger.start_progress('Installing %s...' % (', '.join(project_names)))
     logger.indent += 2
 


### PR DESCRIPTION
https://github.com/pypa/virtualenv/issues/983
install_wheel.SCRIPT: Project names passed through format() instead of sys.args

When virtualenv was called from other tool, this tool can use input arguments and these arguments will be passed to SCRIPT.
For example, if I call pip repo test from PyCharm I get next command line: 
['install', '--ignore-installed', '--cert', 'c:\\users\\asanko\\appdata\\local\\temp\\tmp0elwlm', 'C:\\Program Files (x86)\\JetBrains\\PyCharm Community Edition 2016.2.3\\helpers\\pydev\\pydevd.py', '--multiproc', '--qt-support', '--client', '127.0.0.1', '--port', '50821', '--file', 'setuptools']   
Instead of expected:
['install', '--ignore-installed', '--cert', 'c:\\users\\asanko\\appdata\\local\\temp\\tmp0elwlm' 'setuptools']   
We have project names and can pass it directly to script.