### PR TITLE
Allow activate.fish to cooperate with POSIX activate

### DIFF
--- a/virtualenv_embedded/activate.fish
+++ b/virtualenv_embedded/activate.fish
@@ -4,7 +4,7 @@
 function deactivate -d 'Exit virtualenv mode and return to the normal environment.'
     # reset old environment variables
     if test -n "$_OLD_VIRTUAL_PATH"
-        set -gx PATH $_OLD_VIRTUAL_PATH
+        set -gx PATH (echo $_OLD_VIRTUAL_PATH | tr : \n)
         set -e _OLD_VIRTUAL_PATH
     end
 
@@ -38,7 +38,7 @@ deactivate nondestructive
 
 set -gx VIRTUAL_ENV "__VIRTUAL_ENV__"
 
-set -gx _OLD_VIRTUAL_PATH $PATH
+set -gx _OLD_VIRTUAL_PATH (sh -c 'echo $PATH')
 set -gx PATH "$VIRTUAL_ENV/__BIN_NAME__" $PATH
 
 # Unset `$PYTHONHOME` if set.


### PR DESCRIPTION
Because Fish treats `$PATH` as an array, weird things can happen when attempting to deactivate an environment activated by Fish, from another shell, such as Bash:

```
james@james-laptop ~/workspace> source venv/bin/activate.fish 
(venv) james@james-laptop ~/workspace> bash
james@james-laptop:~/workspace$ source venv/bin/activate
Command 'basename' is available in '/usr/bin/basename'
The command could not be located because '/usr/bin' is not included in the PATH environment variable.
basename: command not found
() james@james-laptop:~/workspace/virtualenv$
```

This change ensures that `$PATH` is converted to colon delimited format before being exported to `$_OLD_VIRTUAL_PATH`, and converted back to an array before being restored. This ensures that virtualenvs activated by Fish can be deactivated by Bash, and vice versa