### PR TITLE
Copy libs/pythonXY.lib to support building of C extensions without distutils

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1395,6 +1395,20 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
                 elif os.path.exists(python_dll_d_dest):
                     logger.info("Removed %s as the source does not exist", python_dll_d_dest)
                     os.unlink(python_dll_d_dest)
+
+            if not IS_PYPY:
+                # considering that on windows, python import libraries are located in
+                # the  "<root>/libs" directory, the following code will look for and
+                # copy "pythonXY.lib".
+                pythonlib_name = "python{}{}.lib".format(sys.version_info[0], sys.version_info[1])
+                pythonlib = os.path.join(os.path.dirname(sys.executable), "libs", pythonlib_name)
+                pythonlib_dest_dir = os.path.join(lib_dir, "..", "libs")
+                pythonlib_dest = os.path.join(pythonlib_dest_dir, pythonlib_name)
+                if os.path.exists(pythonlib):
+                    logger.info("Also created %s" % pythonlib_name)
+                    mkdir(pythonlib_dest_dir)
+                    shutil.copyfile(pythonlib, pythonlib_dest)
+
         if IS_PYPY:
             # make a symlink python --> pypy-c
             python_executable = os.path.join(os.path.dirname(py_executable), "python")


### PR DESCRIPTION
This issue was discovered while using virtualenv to create an
isolated environment and test that a source distribution would compile
without using the knowledge hardcoded in `distutils.sysconfig` and
`virtualenv/virtualenv_embedded/distutils-init.py`

In other word, without relying on the fact virtualenv monkey patch distutils
to ensure the value associated with `LIBDIR` variable is correct.

This is relevant because the library location is implicitly specified
in PC/pyconfig.h

```
[...]

/* For an MSVC DLL, we can nominate the .lib files used by extensions */
                        /* So MSVC users need not specify the .lib file in
                        their Makefile (other compilers are generally
                        taken care of by distutils.) */

[...]
```

References:
 * https://docs.python.org/2/extending/windows.html#using-dlls-in-practice
 * https://docs.python.org/3.6/extending/windows.html#using-dlls-in-practice