### PR TITLE
Do not add /usr/lib64 to sys.path if it is a symlink of /usr/lib

### DIFF
--- a/virtualenv_embedded/site.py
+++ b/virtualenv_embedded/site.py
@@ -584,7 +584,7 @@ def virtual_install_main_packages():
         paths = [os.path.join(sys.real_prefix, 'lib', 'python'+sys.version[:3])]
         hardcoded_relative_dirs = paths[:] # for the special 'darwin' case below
         lib64_path = os.path.join(sys.real_prefix, 'lib64', 'python'+sys.version[:3])
-        if os.path.exists(lib64_path):
+        if os.path.exists(lib64_path) and not os.path.realpath(lib64_path) in paths:
             if _is_64bit:
                 paths.insert(0, lib64_path)
             else:


### PR DESCRIPTION
Under arch linux, `/usr/lib64` is a symlink of `/usr/lib`.
currently `site.py` will cause the inclusion of both of them in sys.path.

CAUTION: This patch was tested ONLY on arch linux, and not on any other platform.