### PR TITLE
Clarify activation is required for environment vars

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -52,10 +52,20 @@ separate activate files for some other shells, like csh and fish.
 This will change your ``$PATH`` so its first entry is the virtualenv's
 ``bin/`` directory. (You have to use ``source`` because it changes your
 shell environment in-place.) This is all it does; it's purely a
-convenience. If you directly run a script or the python interpreter
+convenience.
+
+If you directly run a script or the python interpreter
 from the virtualenv's ``bin/`` directory (e.g. ``path/to/ENV/bin/pip``
-or ``/path/to/ENV/bin/python-script.py``) there's no need for
-activation.
+or ``/path/to/ENV/bin/python-script.py``) then ``sys.path`` will
+automatically be set to use the Python libraries associated with the
+virtualenv. But, unlike the activation scripts, the environment variables
+``PATH`` and ``VIRTUAL_ENV`` will *not* be modified. This means that if
+your Python script uses e.g. ``subprocess`` to run another Python script
+(e.g. via a ``#!/usr/bin/env python`` shebang line) the second script
+*may not be executed with the same Python binary as the first* nor have 
+the same libraries available to it. To avoid this happening your first
+script will need to modify the environment variables in the same manner
+as the activation scripts, before the second script is executed.
 
 The ``activate`` script will also modify your shell prompt to indicate
 which environment is currently active. To disable this behaviour, see


### PR DESCRIPTION
After spending many hours trying to work out why Ansible inventory scripts do not work correctly when Ansible is installed via a recent version of Homebrew (which uses virtualenv) I believe at least part of the underlying cause is the result of a lack of clarity in this section of the documentation.

As I understand it, saying "...there's no need for activation" is incorrect if a Python script spawns subprocesses or otherwise relies on `PATH` and `VIRTUAL_ENV` environment variables being modified in the same manner as the activation scripts.

When Ansible is installed within a virtualenv, inventory scripts featuring a `#!/usr/bin/env python` shebang end up using a non-virtualenv Python binary which can then not find required library files.

The original wording implies that using an activation script and then executing `python` is the same as running `/<virtualenv>/bin/python` directly--which is not the case.

I eventually discovered that according to https://github.com/pypa/virtualenv/issues/906#issuecomment-244394963 this behavior is intentional:

>  the Python executable doesn't set the PATH or VIRTUAL_ENV environment variables. That's by design, and is not a bug.

I note that is followed by the remark:

> The only thing you might be able to get support for is adding some comments to the documentation to clarify that you shouldn't be writing scripts that assume sys.executable is on $PATH, or that VIRTUAL_ENV is set 

Hence why I am proposing this patch.

### Specific example

I was trying to use the Amazon EC2 inventory script (per <http://docs.ansible.com/ansible/latest/intro_dynamic_inventory.html#example-aws-ec2-external-inventory-script>) like so:

       ansible -i ec2.py --list-hosts all

The result was an error like this (because `ec2.py` was executed via a non-virtualenv Python binary which did not have the `ansible` module installed):

       ERROR! Attempted to execute "ec2.py" as inventory script: Inventory script (ec2.py) had an execution error: Traceback (most recent call last):
         File "/<path>/ec2.py", line 135, in <module>
           from ansible.module_utils import ec2 as ec2_utils
       ImportError: No module named ansible.module_utils

### Possible approach for adding the implied functionality

Additional research suggests the implied functionality is possible without modification of the Python binary nor the use a wrapper script via the addition of a `sitecustomize.py` file but I'll discuss that in another issue later.