### PR TITLE
travis: enable use of test_activate.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ docs/_build
 .eggs
 .tox
 .cache
-tests/test_activate_actual.output
+/tests/test_activate_output.actual
+/tests/test_activate_output.expected

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,18 @@ matrix:
 
 install: pip install tox
 
-script: tox
+script:
+ - ./bin/rebuild-script.py
+ - tox
+ - ./tests/test_activate.sh
+ - |-
+   function check_status() {
+     if ! git diff-index --quiet --ignore-submodules=all HEAD --; then
+       echo 'Uncommitted changes detected:';
+       git diff-index HEAD --;
+       return 1;
+     fi;
+   }
 
 sudo: false # Use container based builds
 

--- a/tests/test_activate_output.expected
+++ b/tests/test_activate_output.expected
@@ -1,2 +1,0 @@
-New python executable in /tmp/test_virtualenv_activate.venv/bin/python
-Installing setuptools, pip, wheel...done.


### PR DESCRIPTION
This will also run test_activate.sh which is an essential part of the testing, obviously outside tox because inside would not work.