### PR TITLE
travis: remove py33 and added py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,17 @@ language: python
 
 matrix:
   include:
+    # Based on https://docs.python.org/devguide/#status-of-python-branches
     - python: 2.6
       env: TOXENV=python2.6
     - python: 2.7
       env: TOXENV=python2.7
-    - python: 3.3
-      env: TOXENV=python3.3
     - python: 3.4
       env: TOXENV=python3.4
     - python: 3.5
       env: TOXENV=python3.5
+    - python: 3.6
+      env: TOXENV=python3.6
     - python: pypy
       env: TOXENV=pypy
     - python: 3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,14 +6,14 @@ environment:
 
     - PYTHON: "C:\\Python26"
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python26-x64"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python33-x64"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
 
 install:
   # We need tox installed for the tests

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # env names must be a valid python  binary name, unless they have a
 # separate configuration
 envlist =
-    python{2.6,2.7,3.3,3.4,3.5}, pypy{,3}, crosspython{2,3}, docs
+    python{2.6,2.7,3.4,3.5,3.6}, pypy{,3}, crosspython{2,3}, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
py33 reached EOL and the Travis version is broken
as it missing zlib encoder, making impossible
to test bin/build_script.py