### PR TITLE
Adapt for changes in next pip release

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -858,7 +858,10 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         import tempfile
         import os
 
-        import pip
+        try:
+            from pip._internal import main as _main
+        except ImportError:
+            from pip import main as _main
 
         cert_data = pkgutil.get_data("pip._vendor.requests", "cacert.pem")
         if cert_data is not None:
@@ -874,7 +877,7 @@ def install_wheel(project_names, py_executable, search_dirs=None,
                 args += ["--cert", cert_file.name]
             args += sys.argv[1:]
 
-            sys.exit(pip.main(args))
+            sys.exit(_main(args))
         finally:
             if cert_file is not None:
                 os.remove(cert_file.name)

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -860,10 +860,11 @@ def install_wheel(project_names, py_executable, search_dirs=None,
 
         try:
             from pip._internal import main as _main
+            cert_data = pkgutil.get_data("pip._vendor.certifi", "cacert.pem")
         except ImportError:
             from pip import main as _main
+            cert_data = pkgutil.get_data("pip._vendor.requests", "cacert.pem")
 
-        cert_data = pkgutil.get_data("pip._vendor.requests", "cacert.pem")
         if cert_data is not None:
             cert_file = tempfile.NamedTemporaryFile(delete=False)
             cert_file.write(cert_data)


### PR DESCRIPTION
Fixes #1093 

This is really a special case hack. The only reason that I'm okay with importing from pip's internals here is because we're using pip to install pip and this is really the cleanest way to allow for the bootstrapping to work. Further, the script doesn't break any of pip's internal assumptions (like sole control of logging) so this is fine.
