### PR TITLE
Fix: proper installation or use instructions URLs.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,23 +30,19 @@ Or to get the latest unreleased dev version:
  $ [sudo] pip install https://github.com/pypa/virtualenv/tarball/master
 
 
-To install version X.X globally from source:
+To install version ``X.X.X`` globally from source:
 
 ::
 
- $ curl -LO https://pypi.org/packages/source/v/virtualenv/virtualenv-X.X.tar.gz
- $ tar xvfz virtualenv-X.X.tar.gz
- $ cd virtualenv-X.X
- $ [sudo] python setup.py install
-
+ $ [sudo] pip install https://github.com/pypa/virtualenv/tarball/X.X.X
 
 To *use* locally from source:
 
 ::
 
- $ curl -LO https://pypi.org/packages/source/v/virtualenv/virtualenv-X.X.tar.gz
- $ tar xvfz virtualenv-X.X.tar.gz
- $ cd virtualenv-X.X
+ $ curl --location --output virtualenv-X.X.X.tar.gz https://github.com/pypa/virtualenv/tarball/X.X.X
+ $ tar xvfz virtualenv-X.X.X.tar.gz
+ $ cd pypa-virtualenv-YYYYYY
  $ python virtualenv.py myVE
 
 .. note::


### PR DESCRIPTION
See https://github.com/pypa/virtualenv/issues/953 ; the URL in the documentation is wrong, since pypi doesn't offer a permalink to .tar.gz sources.

Replace with a link from github, which seems stable enough for our purposes.