### PR TITLE
improve windows python install detection

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -15,11 +15,12 @@ def test_version():
     assert virtualenv.virtualenv_version, "Should have version"
 
 
-@patch('os.path.exists')
-def test_resolve_interpreter_with_absolute_path(mock_exists):
+@patch('virtualenv.is_executable', return_value=True)
+@patch('virtualenv.get_installed_pythons', return_value={'foo': 'bar'})
+@patch('os.path.exists', return_value=True)
+def test_resolve_interpreter_with_absolute_path(
+        mock_exists, mock_get_installed_pythons, mock_is_executable):
     """Should return absolute path if given and exists"""
-    mock_exists.return_value = True
-    virtualenv.is_executable = Mock(return_value=True)
     test_abs_path = os.path.abspath("/usr/bin/python53")
 
     exe = virtualenv.resolve_interpreter(test_abs_path)
@@ -27,32 +28,32 @@ def test_resolve_interpreter_with_absolute_path(mock_exists):
     assert exe == test_abs_path, "Absolute path should return as is"
 
     mock_exists.assert_called_with(test_abs_path)
-    virtualenv.is_executable.assert_called_with(test_abs_path)
+    mock_is_executable.assert_called_with(test_abs_path)
 
 
-@patch('os.path.exists')
-def test_resolve_interpreter_with_nonexistent_interpreter(mock_exists):
+@patch('virtualenv.get_installed_pythons', return_value={'foo': 'bar'})
+@patch('os.path.exists', return_value=False)
+def test_resolve_interpreter_with_nonexistent_interpreter(
+        mock_exists, mock_get_installed_pythons):
     """Should SystemExit with an nonexistent python interpreter path"""
-    mock_exists.return_value = False
-
     with pytest.raises(SystemExit):
         virtualenv.resolve_interpreter("/usr/bin/python53")
 
     mock_exists.assert_called_with("/usr/bin/python53")
 
 
-@patch('os.path.exists')
-def test_resolve_interpreter_with_invalid_interpreter(mock_exists):
+@patch('virtualenv.is_executable', return_value=False)
+@patch('os.path.exists', return_value=True)
+def test_resolve_interpreter_with_invalid_interpreter(mock_exists,
+                                                      mock_is_executable):
     """Should exit when with absolute path if not exists"""
-    mock_exists.return_value = True
-    virtualenv.is_executable = Mock(return_value=False)
     invalid = os.path.abspath("/usr/bin/pyt_hon53")
 
     with pytest.raises(SystemExit):
         virtualenv.resolve_interpreter(invalid)
 
     mock_exists.assert_called_with(invalid)
-    virtualenv.is_executable.assert_called_with(invalid)
+    mock_is_executable.assert_called_with(invalid)
 
 
 def test_activate_after_future_statements():

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -15,6 +15,35 @@ def test_version():
     assert virtualenv.virtualenv_version, "Should have version"
 
 
+@patch('distutils.spawn.find_executable')
+@patch('virtualenv.is_executable', return_value=True)
+@patch('virtualenv.get_installed_pythons')
+@patch('os.path.exists', return_value=True)
+@patch('os.path.abspath')
+def test_resolve_interpreter_with_installed_python(mock_abspath, mock_exists,
+        mock_get_installed_pythons, mock_is_executable, mock_find_executable):
+    test_tag = 'foo'
+    test_path = '/path/to/foo/python.exe'
+    test_abs_path = 'some-abs-path'
+    test_found_path = 'some-found-path'
+    mock_get_installed_pythons.return_value = {
+        test_tag: test_path,
+        test_tag + '2': test_path + '2'}
+    mock_abspath.return_value = test_abs_path
+    mock_find_executable.return_value = test_found_path
+
+    exe = virtualenv.resolve_interpreter('foo')
+
+    assert exe == test_found_path, \
+        "installed python should be accessible by key"
+
+    mock_get_installed_pythons.assert_called_once_with()
+    mock_abspath.assert_called_once_with(test_path)
+    mock_find_executable.assert_called_once_with(test_path)
+    mock_exists.assert_called_once_with(test_found_path)
+    mock_is_executable.assert_called_once_with(test_found_path)
+
+
 @patch('virtualenv.is_executable', return_value=True)
 @patch('virtualenv.get_installed_pythons', return_value={'foo': 'bar'})
 @patch('os.path.exists', return_value=True)


### PR DESCRIPTION
This fixes issue #864.

Updated detecting Windows Python installations:

- now correctly detects current user installation and not just those installed at the system level
- for Python versions 3.5+ (which track 32-bit & 64-bit installations separately), recognize version tags X.Y, X.Y-32 & X.Y-64 where X.Y represents the 64-bit installation if available or 32-bit otherwise

Touched up & improved `resolve_interpreter()` tests:

- tests no longer permanently modify the `virtualenv` module under test (`virtualenv.is_executable` changes were leaking from some tests)
- tests now check that get_installed_python() results unrelated to the given version tag do not affect the result
- simple patch function's return values now given in `@patch` decorators to make the test code more compact

Tested `resolve_interpreter()` with registered python installations.

Tested `get_installed_pythons()` on and off Windows platform.

# Open issues

- [x] look into #582 changes to see if old Python installers perhaps give us a better way to detect 32-bit installations on 64-bit OSs
![image](https://user-images.githubusercontent.com/3112833/33829992-b2daa948-de72-11e7-8460-fd37c08e7aa5.png)
    - looked into this and it seems that nothing relevant gets stored in the `WOW6432Node` registry hive for either 32 or 64-bit installations on a 64-bit OS, at least for Python versions 2.7+, which are the only ones supported by virtualenv atm (tested with 2.7.13, 3.4.0, 3.5.0 & 3.6.3)
- [x] see what the `virtualenv_embedded` stuff is about and whether the changes done in this pull request need to be moved to different location
    - seems `virtualenv.py` is the only source file containing the WIndows installation detection logic