### PR TITLE
update testing notes and tox configuration

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -56,7 +56,7 @@ and then run the tests with a specific Python version using a call like::
 
     $ python -m tox -e python3.6
 
-See ``tox.ini`` for a list of all supported Python environments or just run the
+Run ``python -m tox -av`` for a list of all supported Python environments or just run the
 tests in all of the available ones by running just ``tox``.
 
 Status and License

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -46,6 +46,19 @@ Or select just a single test file to run::
 
     $ pytest tests/test_virtualenv
 
+You can also run the tests using ``tox`` which will take care of installing all
+the necessary requirements into its constructed Python environments. You just
+need to install ``tox`` in your environment using::
+
+    $ pyp install tox
+
+and then run the tests with a specific Python version using a call like::
+
+    $ tox -e python3.6
+
+See ``tox.ini`` for a list of all supported Python environments or just run the
+tests in all of the available ones by running just ``tox``.
+
 Status and License
 ------------------
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -50,11 +50,11 @@ You can also run the tests using ``tox`` which will take care of installing all
 the necessary requirements into its constructed Python environments. You just
 need to install ``tox`` in your environment using::
 
-    $ pyp install tox
+    $ python -m pip install tox
 
 and then run the tests with a specific Python version using a call like::
 
-    $ tox -e python3.6
+    $ python -m tox -e python3.6
 
 See ``tox.ini`` for a list of all supported Python environments or just run the
 tests in all of the available ones by running just ``tox``.

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -376,3 +376,14 @@ def test_missing_certifi_pem(tmp_path):
     venvdir = tmp_path / "venv"
     search_dirs = [str(wheeldir), str(support_original)]
     virtualenv.create_environment(str(venvdir), search_dirs=search_dirs)
+
+
+def test_create_environment_from_dir_with_spaces(tmpdir):
+    """Should work with wheel sources read from a dir with spaces."""
+    ve_path = str(tmpdir / "venv")
+    spaced_support_dir = str(tmpdir / "support with spaces")
+    from virtualenv_support import __file__ as support_dir
+
+    support_dir = os.path.dirname(os.path.abspath(support_dir))
+    shutil.copytree(support_dir, spaced_support_dir)
+    virtualenv.create_environment(ve_path, search_dirs=[spaced_support_dir])

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -387,3 +387,9 @@ def test_create_environment_from_dir_with_spaces(tmpdir):
     support_dir = os.path.dirname(os.path.abspath(support_dir))
     shutil.copytree(support_dir, spaced_support_dir)
     virtualenv.create_environment(ve_path, search_dirs=[spaced_support_dir])
+
+
+def test_create_environment_in_dir_with_spaces(tmpdir):
+    """Should work with environment path containing spaces."""
+    ve_path = str(tmpdir / 'venv with spaces')
+    virtualenv.create_environment(ve_path)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -391,5 +391,5 @@ def test_create_environment_from_dir_with_spaces(tmpdir):
 
 def test_create_environment_in_dir_with_spaces(tmpdir):
     """Should work with environment path containing spaces."""
-    ve_path = str(tmpdir / 'venv with spaces')
+    ve_path = str(tmpdir / "venv with spaces")
     virtualenv.create_environment(ve_path)


### PR DESCRIPTION
- added docs on running the internal test suite using `tox`
- now you can pass in additional pytest arguments when calling tox by listing them on the command-line after `--`, e.g. `tox -e python3.6 -- -x -v --pdb`
- removed Python 2.6 from all lists of tested Python environments as running virtualenv in that environment will just report an error about that Python version not being supported
- added a test for creating a Python environment in a path with spaces
- added a test for creating a Python environment while locating the needed wheel sources in a path with spaces