### PR TITLE
enable pip cache in appveyor and travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install: pip install tox
 script: tox
 
 sudo: false # Use container based builds
+cache: pip
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,5 +21,8 @@ install:
 
 build: off
 
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+
 test_script:
   - "%PYTHON%\\Scripts\\tox.exe -e py"


### PR DESCRIPTION
The reason for this pull request is the same reason caching was added to pip: we want to minimze the amount of traffic and load on the pypi site. Downloading any package(s) from pypi more than once is a waste of resources.