### PR TITLE
Remove deprecated Universal mode

### DIFF
--- a/virtualenv_embedded/site.py
+++ b/virtualenv_embedded/site.py
@@ -162,7 +162,7 @@ def addpackage(sitedir, name, known_paths):
         reset = 0
     fullname = os.path.join(sitedir, name)
     try:
-        f = open(fullname, "rU")
+        f = open(fullname, "r")
     except IOError:
         return
     try:
@@ -426,7 +426,7 @@ class _Printer(object):
             for filename in self.__files:
                 filename = os.path.join(dir, filename)
                 try:
-                    fp = open(filename, "rU")
+                    fp = open(filename, "r")
                     data = fp.read()
                     fp.close()
                     break


### PR DESCRIPTION
The `U` mode has been deprecated and Python 3.4+ will complain about this, and `-W error` mode will turn this into an exception. Follow CPython and remove the mode altogether (see python/cpython@4e86d5b).

This would fix #1120 