### PR TITLE
Symlink the python interpreter unless --always-copy is specified

### DIFF
--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -3,7 +3,6 @@ import optparse
 import os
 import shutil
 import sys
-import sysconfig
 import tempfile
 import pytest
 import platform  # noqa
@@ -151,7 +150,12 @@ def test_no_always_copy_option():
         virtualenv.create_environment(ve_path, symlink=True)
 
         assert (sys.version_info[0:2] < (3,3)) ^ os.path.islink(os.path.join(ve_path, 'bin', os.path.basename(sys.executable)))
-        assert os.path.islink(os.path.join(ve_path, 'lib', os.path.basename(sysconfig.get_path('stdlib')), 'os.py'))
+        try:
+            import sysconfig
+        except ImportError:
+            pass
+        else:
+            assert os.path.islink(os.path.join(ve_path, 'lib', os.path.basename(sysconfig.get_path('stdlib')), 'os.py'))
 
     finally:
         shutil.rmtree(tmp_virtualenv)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -143,7 +143,7 @@ def test_always_copy_option():
 
 @pytest.mark.skipif("platform.python_implementation() == 'PyPy'")
 def test_no_always_copy_option():
-    """Python standard library and interpreter should be symlinks"""
+    """Python standard library and interpreter should be symlinks (since Python 3.3)"""
     tmp_virtualenv = tempfile.mkdtemp()
     ve_path = os.path.join(tmp_virtualenv, 'venv')
     try:


### PR DESCRIPTION
Support for symlinking the python interpreter alongside the standard library, albeit only for Python 3.3 and higher.

I'm not totally sure that using `sys.executable` and `sysconfig.get_path('stdlib')` will cover all cases for testing, but hopefully the general approach makes sense.

This works for me if I directly invoke `python{2,7,3.6} setup.py test`, but when I run `tox` all versions fail with variations on the following:

```
ERROR: The executable /tmp/tmp8_vprfxd/venv/bin/python3 is not functioning
ERROR: It thinks sys.prefix is '/home/sam/src/virtualenv/.tox/python3.6' (should be '/tmp/tmp8_vprfxd/venv')
ERROR: virtualenv is not compatible with this system or executable
```

I'm not sure why yet, if you have any idea feel free to suggest...