### PR TITLE
Fixed failure to copy on platforms that use lib64

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Release History
 * upgrade setuptools from ``39.1.0`` to ``40.5.0``
 * upgrade wheel from ``0.31.1`` to ``0.32.2``
 * upgrade pip from ``10.0.1`` to ``18.1``
+* fix failure to copy on platforms that use lib64 :issue:`11189`
 
 16.0.0 (2018-05-16)
 -------------------

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -1619,9 +1619,9 @@ def fix_lib64(lib_dir, symlink=True):
     if os.path.lexists(lib64_link):
         return
     if symlink:
-        os.symlink("lib", lib64_link)
+        os.symlink(lib_dir, lib64_link)
     else:
-        copyfile("lib", lib64_link)
+        copyfile(lib_dir, lib64_link)
 
 
 def resolve_interpreter(exe):


### PR DESCRIPTION
The current behaviour attempts to copy a "lib" folder from the current directory, instead of copying the "lib" folder inside the virtualenv. Therefore the copying would fail.
This fixes that by always copying the "lib" folder from the virtualenv.