### PR TITLE
travis: fail fast if rebuild-script was not called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ matrix:
     - python: 2.7
       env: TOXENV=docs
 
-install: pip install tox
+install:
+  # detecting invalid commits that missed rebuild-script.
+  - ./bin/rebuild-script.py && git diff-files --quiet || { >&2 echo "Code submitted without running ./bin/rebuild-script.py first."; exit 1; }
+  - pip install tox
 
 script: tox
 


### PR DESCRIPTION
Avoid running tests if rebuild-script is making repository
dirty because this means that code was commited
without rebuilding first.

This prevents wasted time on reviews.