### PR TITLE
Add check if exec_dir exists before listing it's content

### DIFF
--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -1262,8 +1262,9 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             exec_dir = join(sys.exec_prefix, "Lib")
         else:
             exec_dir = join(sys.exec_prefix, "lib", py_version)
-        for fn in os.listdir(exec_dir):
-            copyfile(join(exec_dir, fn), join(lib_dir, fn), symlink)
+        if os.path.isdir(exec_dir):
+            for fn in os.listdir(exec_dir):
+                copyfile(join(exec_dir, fn), join(lib_dir, fn), symlink)
 
     if is_jython:
         # Jython has either jython-dev.jar and javalib/ dir, or just


### PR DESCRIPTION
install_python() no longer fails if the exec_dir directory doesn't
exist.

Patch source:
https://src.fedoraproject.org/rpms/python-virtualenv/blame/check-exec_dir.patch?identifier=master

Patch added in this Fedora change:
https://src.fedoraproject.org/rpms/python-virtualenv/c/6b9ab1f32bfd159a7b78a34e2c80687b4bc7447c

Co-Authored-By: Michal Cyprian <michal@platform.sh>