### PR TITLE
Added a handler to work with unicode and escape sequences inside the prompt

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -700,10 +700,15 @@ def main():
         make_environment_relocatable(home_dir)
         return
 
+    if majver == 2:
+        prompt = options.prompt.decode('UTF-8')
+    else:
+        prompt = options.prompt
+
     create_environment(home_dir,
                        site_packages=options.system_site_packages,
                        clear=options.clear,
-                       prompt=options.prompt,
+                       prompt=prompt,
                        search_dirs=options.search_dirs,
                        download=options.download,
                        no_setuptools=options.no_setuptools,

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -700,7 +700,7 @@ def main():
         make_environment_relocatable(home_dir)
         return
 
-    if majver == 2:
+    if majver == 2 and options.prompt is not None:
         prompt = options.prompt.decode('UTF-8')
     else:
         prompt = options.prompt


### PR DESCRIPTION
There is an issue, happening when processing custom prompts with unicode symbols and escape sequences under python2 environments.

```shell
$ BOLD="$(tput bold)"; RESET="$(tput sgr0)"; MAGENTA="$(tput setaf 5)"
$ cd /tmp; virtualenv --python=/usr/bin/python --prompt="⮎\[${BOLD}${MAGENTA}\]test\[${RESET}\]⮌ " .venv
Running virtualenv with interpreter /usr/bin/python
New python executable in /tmp/.venv/bin/python
Installing setuptools, pip, wheel...done.
```

```python
Traceback (most recent call last):
  File "/home/project/.local/lib/python3.6/site-packages/virtualenv.py", line 2343, in <module>
    main()
  File "/home/project/.local/lib/python3.6/site-packages/virtualenv.py", line 712, in main
    symlink=options.symlink)
  File "/home/project/.local/lib/python3.6/site-packages/virtualenv.py", line 950, in create_environment
    install_activate(home_dir, bin_dir, prompt)
  File "/home/project/.local/lib/python3.6/site-packages/virtualenv.py", line 1477, in install_activate
    install_files(home_dir, bin_dir, prompt, files)
  File "/home/project/.local/lib/python3.6/site-packages/virtualenv.py", line 1484, in install_files
    content = content.replace('__VIRTUAL_PROMPT__', prompt or '')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)
```