### PR TITLE
FIX for virtualenv is not compatible with this system or executable

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1110,6 +1110,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         prefix = sys.base_prefix
     else:
         prefix = sys.prefix
+    prefix = os.path.abspath(prefix)
     mkdir(lib_dir)
     fix_lib64(lib_dir, symlink)
     stdlib_dirs = [os.path.dirname(os.__file__)]


### PR DESCRIPTION
When using tox on MacOS it makes impossible to create a new "custom" venv. This tiny fix should solve that issue. Here is what I am getting from tox:

```
actionid: py36
msg: getenv
cmdargs: '/home/veselin/repo/venv/bin/python3.6 -m virtualenv --python /home/veselin/repo/venv/bin/python3.6 py36'

Already using interpreter /home/veselin/repo/venv/bin/python3.6
Using base prefix '/usr/local/bin/../Cellar/python/3.6.5/bin/../Frameworks/Python.framework/Versions/3.6'
New python executable in /home/veselin/repo/.tox/py36/bin/python3.6
Also creating executable in /home/veselin/repo/.tox/py36/bin/python
ERROR: The executable /home/veselin/repo/.tox/py36/bin/python3.6 is not functioning
ERROR: It thinks sys.prefix is '/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6' (should be '/home/veselin/repo/.tox/py36')
ERROR: virtualenv is not compatible with this system or executable
```

I saw many other similar reports in the web and decided to create that Pull Request to fix it.
