### PR TITLE
Fix instructions for download of virtualenv.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ virtualenv
 A tool for creating isolated 'virtual' python environments.
 
 .. image:: https://img.shields.io/pypi/v/virtualenv.svg
-        :target: https://pypi.python.org/pypi/virtualenv
+        :target: https://pypi.org/project/virtualenv
 
 .. image:: https://img.shields.io/travis/pypa/virtualenv/develop.svg
    :target: http://travis-ci.org/pypa/virtualenv
@@ -13,7 +13,7 @@ A tool for creating isolated 'virtual' python environments.
 * `Documentation <https://virtualenv.pypa.io/>`_
 * `Changelog <https://virtualenv.pypa.io/en/latest/changes.html>`_
 * `Issues <https://github.com/pypa/virtualenv/issues>`_
-* `PyPI <https://pypi.python.org/pypi/virtualenv/>`_
+* `PyPI <https://pypi.org/project/virtualenv/>`_
 * `Github <https://github.com/pypa/virtualenv>`_
 * `User mailing list <http://groups.google.com/group/python-virtualenv>`_
 * `Dev mailing list <http://groups.google.com/group/pypa-dev>`_

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,7 @@ Release History
 16.1.0 (unreleased)
 -------------------
 
+* Fixed documentation to use pypi.org and correct curl options; :issue:`1042`
 
 16.0.0 (2018-05-16)
 -------------------
@@ -409,7 +410,7 @@ Release History
 
 * Fixed issue with readline on Windows.
 
-.. _Distribute: https://pypi.python.org/pypi/distribute
+.. _Distribute: https://pypi.org/project/distribute
 
 1.9.1 (2013-03-08)
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Virtualenv
 `Mailing list <http://groups.google.com/group/python-virtualenv>`_ |
 `Issues <https://github.com/pypa/virtualenv/issues>`_ |
 `Github <https://github.com/pypa/virtualenv>`_ |
-`PyPI <https://pypi.python.org/pypi/virtualenv/>`_ |
+`PyPI <https://pypi.org/project/virtualenv/>`_ |
 User IRC: #pypa
 Dev IRC: #pypa-dev
 
@@ -64,14 +64,14 @@ Other Documentation and Links
   your workflow with many virtualenvs even easier. `His initial blog post on it`__.
   He also wrote `an example of using virtualenv to try IPython`__.
 
-  .. _virtualenvwrapper: https://pypi.python.org/pypi/virtualenvwrapper/
+  .. _virtualenvwrapper: https://pypi.org/project/virtualenvwrapper/
   .. __: https://doughellmann.com/blog/2008/05/01/virtualenvwrapper/
   .. __: https://doughellmann.com/blog/2008/02/01/ipython-and-virtualenv/
 
 * `Pew`_ is another wrapper for virtualenv that makes use of a different
   activation technique.
 
-  .. _Pew: https://pypi.python.org/pypi/pew/
+  .. _Pew: https://pypi.org/project/pew/
 
 * `Using virtualenv with mod_wsgi
   <http://code.google.com/p/modwsgi/wiki/VirtualEnvironments>`_.
@@ -113,7 +113,7 @@ There are several alternatives that create isolated environments:
   Setuptools automatically, saving a step and avoiding the need for
   network access.
 
-* `zc.buildout <http://pypi.python.org/pypi/zc.buildout>`_ doesn't
+* `zc.buildout <http://pypi.org/project/zc.buildout>`_ doesn't
   create an isolated Python environment in the same style, but
   achieves similar results through a declarative config file that sets
   up scripts with very particular packages. As a declarative system,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,7 @@ To install version X.X globally from source:
 
 ::
 
- $ curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-X.X.tar.gz
+ $ curl -LO https://pypi.org/packages/source/v/virtualenv/virtualenv-X.X.tar.gz
  $ tar xvfz virtualenv-X.X.tar.gz
  $ cd virtualenv-X.X
  $ [sudo] python setup.py install
@@ -44,7 +44,7 @@ To *use* locally from source:
 
 ::
 
- $ curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-X.X.tar.gz
+ $ curl -LO https://pypi.org/packages/source/v/virtualenv/virtualenv-X.X.tar.gz
  $ tar xvfz virtualenv-X.X.tar.gz
  $ cd virtualenv-X.X
  $ python virtualenv.py myVE

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -111,8 +111,8 @@ Options
    virtualenv. Distribute has now been merged into Setuptools, and the
    latter is always installed.
 
-.. _Distribute: https://pypi.python.org/pypi/distribute
-.. _Setuptools: https://pypi.python.org/pypi/setuptools
+.. _Distribute: https://pypi.org/project/distribute
+.. _Setuptools: https://pypi.org/project/setuptools
 
 
 Configuration

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -27,8 +27,8 @@ a number of usual effects (modifiable by many :ref:`options`):
 The python in your new virtualenv is effectively isolated from the python that
 was used to create it.
 
-.. _pip: https://pypi.python.org/pypi/pip
-.. _setuptools: https://pypi.python.org/pypi/setuptools
+.. _pip: https://pypi.org/project/pip
+.. _setuptools: https://pypi.org/project/setuptools
 
 
 .. _activate:


### PR DESCRIPTION
Replaced pypi.python.org with pypi.org in the download URL.
Added `-L` option to `curl` to follow redirects from randomized hash
URLS.

Also, replaced pypi.python.org/pypi with pypi.org/project throughout the
docs.

This fix addresses the most important part of #1042.