### PR TITLE
Refactor sys.stdout.write to print

### DIFF
--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Create a "virtual" Python installation"""
-from __future__ import print_function
 
 # fmt: off
 import os  # isort:skip
@@ -276,7 +275,8 @@ class Logger(object):
             if self.level_matches(level, consumer_level):
                 if self.in_progress_hanging and consumer in (sys.stdout, sys.stderr):
                     self.in_progress_hanging = False
-                    print("", flush=True)
+                    print("\n", end="")
+                    sys.stdout.flush()
                 if rendered is None:
                     if args:
                         rendered = msg % args
@@ -293,7 +293,8 @@ class Logger(object):
             msg, self.in_progress
         )
         if self.level_matches(self.NOTIFY, self._stdout_level()):
-            print(msg, flush=True)
+            print(msg)
+            sys.stdout.flush()
             self.in_progress_hanging = True
         else:
             self.in_progress_hanging = False
@@ -304,9 +305,11 @@ class Logger(object):
         if self.stdout_level_matches(self.NOTIFY):
             if not self.in_progress_hanging:
                 # Some message has been printed out since start_progress
-                print("...{0}{1}".format(self.in_progress, msg), flush=True)
+                print("...%s%s" % (self.in_progress, msg))
+                sys.stdout.flush()
             else:
-                print(msg, flush=True)
+                print(msg)
+                sys.stdout.flush()
         self.in_progress = None
         self.in_progress_hanging = False
 
@@ -314,7 +317,8 @@ class Logger(object):
         """If we are in a progress scope, and no log messages have been
         shown, write out another '.'"""
         if self.in_progress_hanging:
-            print(".", flush=True)
+            print(".")
+            sys.stdout.flush()
 
     def stdout_level_matches(self, level):
         """Returns true if a message at this level will go to stdout"""

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -275,8 +275,7 @@ class Logger(object):
             if self.level_matches(level, consumer_level):
                 if self.in_progress_hanging and consumer in (sys.stdout, sys.stderr):
                     self.in_progress_hanging = False
-                    sys.stdout.write("\n")
-                    sys.stdout.flush()
+                    print("\n", flush=True)
                 if rendered is None:
                     if args:
                         rendered = msg % args
@@ -293,8 +292,7 @@ class Logger(object):
             msg, self.in_progress
         )
         if self.level_matches(self.NOTIFY, self._stdout_level()):
-            sys.stdout.write(msg)
-            sys.stdout.flush()
+            print(msg, flush=True)
             self.in_progress_hanging = True
         else:
             self.in_progress_hanging = False
@@ -305,11 +303,9 @@ class Logger(object):
         if self.stdout_level_matches(self.NOTIFY):
             if not self.in_progress_hanging:
                 # Some message has been printed out since start_progress
-                sys.stdout.write("..." + self.in_progress + msg + "\n")
-                sys.stdout.flush()
+                print("..." + self.in_progress + msg, flush=True)
             else:
-                sys.stdout.write(msg + "\n")
-                sys.stdout.flush()
+                print(msg, flush=True)
         self.in_progress = None
         self.in_progress_hanging = False
 
@@ -317,8 +313,7 @@ class Logger(object):
         """If we are in a progress scope, and no log messages have been
         shown, write out another '.'"""
         if self.in_progress_hanging:
-            sys.stdout.write(".")
-            sys.stdout.flush()
+            print(".", flush=True)
 
     def stdout_level_matches(self, level):
         """Returns true if a message at this level will go to stdout"""

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -304,7 +304,7 @@ class Logger(object):
         if self.stdout_level_matches(self.NOTIFY):
             if not self.in_progress_hanging:
                 # Some message has been printed out since start_progress
-                print("..." + self.in_progress + msg, flush=True)
+                print("...{0}{1}".format(self.in_progress, msg), flush=True)
             else:
                 print(msg, flush=True)
         self.in_progress = None

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -14,6 +14,7 @@ if os.environ.get("VIRTUALENV_INTERPRETER_RUNNING"):
         if os.path.realpath(os.path.dirname(__file__)) == os.path.realpath(path):
             sys.path.remove(path)
 # fmt: on
+from __future__ import print_function
 
 import base64
 import codecs
@@ -275,7 +276,7 @@ class Logger(object):
             if self.level_matches(level, consumer_level):
                 if self.in_progress_hanging and consumer in (sys.stdout, sys.stderr):
                     self.in_progress_hanging = False
-                    print("\n", flush=True)
+                    print("", flush=True)
                 if rendered is None:
                     if args:
                         rendered = msg % args

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -275,7 +275,7 @@ class Logger(object):
             if self.level_matches(level, consumer_level):
                 if self.in_progress_hanging and consumer in (sys.stdout, sys.stderr):
                     self.in_progress_hanging = False
-                    print("\n", end="")
+                    print("")
                     sys.stdout.flush()
                 if rendered is None:
                     if args:

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Create a "virtual" Python installation"""
+from __future__ import print_function
 
 # fmt: off
 import os  # isort:skip
@@ -14,7 +15,6 @@ if os.environ.get("VIRTUALENV_INTERPRETER_RUNNING"):
         if os.path.realpath(os.path.dirname(__file__)) == os.path.realpath(path):
             sys.path.remove(path)
 # fmt: on
-from __future__ import print_function
 
 import base64
 import codecs

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -305,7 +305,7 @@ class Logger(object):
         if self.stdout_level_matches(self.NOTIFY):
             if not self.in_progress_hanging:
                 # Some message has been printed out since start_progress
-                print("...%s%s" % (self.in_progress, msg))
+                print("...{}{}".format(self.in_progress, msg))
                 sys.stdout.flush()
             else:
                 print(msg)


### PR DESCRIPTION
there were a number of print statements in `virtualenv.py`. Converted them to sys.stdout.write.
This PR refactor print statements into sys.stdout.write to be consistent to remaining code base.

**reverse**
This PR refactors all sys.stdout.write to print for brevity and readability.