### PR TITLE
Don't fail on missing pip/certifi's cacert.pem

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Release History
 -------------------
 * The xonsh shell is now supported :pull:`1206`
 * bug fix: make lib64 symlink relative (as in <``16.1.0``) > :issue:`1248`
+* pip wheels with removed certifi's cacert.pem are now supported :pull:`1252`
 
 16.1.0 (2018-10-31)
 -------------------

--- a/src/virtualenv.py
+++ b/src/virtualenv.py
@@ -924,6 +924,8 @@ def install_wheel(project_names, py_executable, search_dirs=None, download=False
         except ImportError:
             from pip import main as _main
             cert_data = pkgutil.get_data("pip._vendor.requests", "cacert.pem")
+        except IOError:
+            cert_data = None
 
         if cert_data is not None:
             cert_file = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
See https://github.com/pypa/pip/blob/master/src/pip/_vendor/README.rst

It is acceptable to remove the pip/_vendor/requests/cacert.pem file from pip

Virtualenv should not error on that