### PR TITLE
Fix ResourceWarning: unclosed file

### DIFF
--- a/docs/changelog/1277.bugfix.rst
+++ b/docs/changelog/1277.bugfix.rst
@@ -1,0 +1,1 @@
+fixed a ``ResourceWarning: unclosed file`` in ``call_subprocess()`` - by :user:`BoboTiG`

--- a/docs/changelog/1277.bugfix.rst
+++ b/docs/changelog/1277.bugfix.rst
@@ -1,1 +1,1 @@
-fixed a ``ResourceWarning: unclosed file`` in ``call_subprocess()`` - by :user:`BoboTiG`
+fixed a ``ResourceWarning: unclosed file`` in ``call_subprocess()`` - by Mickaël Schoentgen


### PR DESCRIPTION
## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added news fragment in ``docs/changelog`` folder

## Description

Such warning is fired when enabling `PYTHONWARNINGS`:
```python
virtualenv.py:983 unclosed file <_io.BufferedReader name=26>'
``` 