### PR TITLE
virtualenv does not *always* have a runtime dependency on setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,6 @@ include_package_data = True
 zip_safe = True
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 
-# setuptools needed for the entry points below to work
-install_requires = setuptools >= 18.0.0
-
 [options.extras_require]
 testing = mock;python_version<"3.3"
           pytest >= 4.0.0, <5


### PR DESCRIPTION
![confused](https://media.tenor.co/images/a8c6d589afe31bd35928ef60aa6755df/tenor.gif)