### PR TITLE
Link or copy PyPy headers instead of include directory as a whole

### DIFF
--- a/docs/changelog/1302.bugfix.rst
+++ b/docs/changelog/1302.bugfix.rst
@@ -1,1 +1,1 @@
-Copy or link Python header files instead of include directory itself
+Copy or link PyPy header files instead of include directory itself

--- a/docs/changelog/1302.bugfix.rst
+++ b/docs/changelog/1302.bugfix.rst
@@ -1,0 +1,1 @@
+Copy or link Python header files instead of include directory itself

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -297,7 +297,8 @@ def test_install_python_bin():
             assert os.path.exists(os.path.join(bin_dir, pth)), "%s should exist in bin_dir" % pth
         if not virtualenv.IS_JYTHON:
             assert os.path.exists(inc_dir)
-        assert not os.path.islink(inc_dir)
+        root_inc_dir = os.path.join(home_dir, 'include')
+        assert not os.path.islink(root_inc_dir)
     finally:
         shutil.rmtree(tmp_virtualenv)
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -297,7 +297,7 @@ def test_install_python_bin():
             assert os.path.exists(os.path.join(bin_dir, pth)), "%s should exist in bin_dir" % pth
         if not virtualenv.IS_JYTHON:
             assert os.path.exists(inc_dir)
-        root_inc_dir = os.path.join(home_dir, 'include')
+        root_inc_dir = os.path.join(home_dir, "include")
         assert not os.path.islink(root_inc_dir)
     finally:
         shutil.rmtree(tmp_virtualenv)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -295,6 +295,8 @@ def test_install_python_bin():
 
         for pth in required_executables:
             assert os.path.exists(os.path.join(bin_dir, pth)), "%s should exist in bin_dir" % pth
+        assert os.path.exists(inc_dir)
+        assert not os.path.islink(inc_dir)
     finally:
         shutil.rmtree(tmp_virtualenv)
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -295,7 +295,8 @@ def test_install_python_bin():
 
         for pth in required_executables:
             assert os.path.exists(os.path.join(bin_dir, pth)), "%s should exist in bin_dir" % pth
-        assert os.path.exists(inc_dir)
+        if not virtualenv.IS_JYTHON:
+            assert os.path.exists(inc_dir)
         assert not os.path.islink(inc_dir)
     finally:
         shutil.rmtree(tmp_virtualenv)

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1268,6 +1268,14 @@ def copy_required_files(src_dir, lib_dir, symlink):
             copyfile(join(src_dir, fn), join(lib_dir, fn), symlink)
 
 
+def copy_directory_contents(src_dir, dst_dir, symlink):
+    """Copy all files from *src_dir* to *dst_dir* symlinking if required"""
+    if not os.path.isdir(src_dir):
+        return
+    for fn in os.listdir(src_dir):
+        copyfile(join(src_dir, fn), join(dst_dir, fn), symlink)
+
+
 def copy_tcltk(src, dest, symlink):
     """ copy tcl/tk libraries on Windows (issue #93) """
     for lib_version in "8.5", "8.6":
@@ -1354,7 +1362,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
     else:
         standard_lib_include_dir = join(prefix, "include", PY_VERSION + ABI_FLAGS)
     if os.path.exists(standard_lib_include_dir):
-        copyfile(standard_lib_include_dir, inc_dir, symlink)
+        copy_directory_contents(standard_lib_include_dir, inc_dir, symlink)
     else:
         logger.debug("No include dir %s", standard_lib_include_dir)
 
@@ -1370,7 +1378,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             # (traversing virtualenvs), whereas the platinc_dir is relative to
             # the inner virtualenv and ignores the prefix argument.
             # This seems more evolved than designed.
-            copyfile(platform_include_dir, platform_include_dest, symlink)
+            copy_directory_contents(platform_include_dir, platform_include_dest, symlink)
 
     # pypy never uses exec_prefix, just ignore it
     if os.path.realpath(sys.exec_prefix) != os.path.realpath(prefix) and not IS_PYPY:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1268,12 +1268,17 @@ def copy_required_files(src_dir, lib_dir, symlink):
             copyfile(join(src_dir, fn), join(lib_dir, fn), symlink)
 
 
-def copy_directory_contents(src_dir, dst_dir, symlink):
-    """Copy all files from *src_dir* to *dst_dir* symlinking if required"""
-    if not os.path.isdir(src_dir):
+def copy_include_dir(include_src, include_dest, symlink):
+    """Copy headers from *include_src* to *include_dest* symlinking if required"""
+    if not os.path.isdir(include_src):
         return
-    for fn in os.listdir(src_dir):
-        copyfile(join(src_dir, fn), join(dst_dir, fn), symlink)
+    # PyPy headers are located in ``pypy-dir/include`` and following code
+    # avoids making ``venv-dir/include`` symlink to it
+    if IS_PYPY:
+        for fn in os.listdir(include_src):
+            copyfile(join(include_src, fn), join(include_dest, fn), symlink)
+    else:
+        copyfile(include_src, include_dest, symlink)
 
 
 def copy_tcltk(src, dest, symlink):
@@ -1362,7 +1367,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
     else:
         standard_lib_include_dir = join(prefix, "include", PY_VERSION + ABI_FLAGS)
     if os.path.exists(standard_lib_include_dir):
-        copy_directory_contents(standard_lib_include_dir, inc_dir, symlink)
+        copy_include_dir(standard_lib_include_dir, inc_dir, symlink)
     else:
         logger.debug("No include dir %s", standard_lib_include_dir)
 
@@ -1378,7 +1383,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
             # (traversing virtualenvs), whereas the platinc_dir is relative to
             # the inner virtualenv and ignores the prefix argument.
             # This seems more evolved than designed.
-            copy_directory_contents(platform_include_dir, platform_include_dest, symlink)
+            copy_include_dir(platform_include_dir, platform_include_dest, symlink)
 
     # pypy never uses exec_prefix, just ignore it
     if os.path.realpath(sys.exec_prefix) != os.path.realpath(prefix) and not IS_PYPY:


### PR DESCRIPTION
This pull request changes method of virtualenv's include directory population - instead of linking Python include directory (for example ``/usr/include/python3.7m``) it links or copies distinct header files from that directory. The reason for this change is to make virtualenv'` ``include`` directory not to be symlink in case of PyPy.

Closes #1198 

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added news fragment in ``docs/changelog`` folder
