### PR TITLE
Add an option not to resolve source when symlinking.

### DIFF
--- a/docs/changelog/1308.feature.rst
+++ b/docs/changelog/1308.feature.rst
@@ -1,0 +1,1 @@
+Add an option to virtualenv to prevent source symbolic link resolution when creating symbolic links. This allows to use per major-minor links targeting python builds in virtualenvs and not to be forced to rebuild virtualenvs to upgrade.


### PR DESCRIPTION
When the links are willingly made, the option allow forcing copyfile to create a symlink to the source without resolving its path.

In our setup we have a link for each major-minor python version which points to a specific build.
With current copyfile, this results in links to the sepcific build in created virtualenvs so we cannot remove any build unless when ensure all virtualenvs are no longer using it.
This MR adds a way to create symlinks to those symlinks, while keeping the default of resolving the symlinks (which was done to address issues with certain setups).

For now, my goal is mainly to get feedback on the proposed change, so I did not attempt to add documentation or edit changelog.