### PR TITLE
Add tests to confirm activate.sh prompt modification behaviors

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,60 +1,78 @@
 """test that prompt behavior is correct in supported shells"""
 from __future__ import absolute_import, unicode_literals
 
+import os
 import subprocess
 
 import pytest
 
 import virtualenv
 
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
 
-CUSTOM_PROMPT = "!!!ENV!!!"
 ENV_DEFAULT = "env"
 ENV_CUSTOM = "env_custom"
 
+PREFIX_DEFAULT = "({}) ".format(ENV_DEFAULT)
+PREFIX_CUSTOM = "!!!ENV!!!"
+
+OUTPUT_FILE = "outfile"
+
+VIRTUAL_ENV_DISABLE_PROMPT = "VIRTUAL_ENV_DISABLE_PROMPT"
+VIRTUAL_ENV = "VIRTUAL_ENV"
+
 
 @pytest.fixture(scope="module")
-def env_root(tmp_path_factory):
+def tmp_root(tmp_path_factory):
     """Provide Path to root with default and custom venvs created."""
     root = tmp_path_factory.mktemp("env_root")
+    virtualenv.create_environment(str(root / ENV_DEFAULT), no_setuptools=True, no_pip=True, no_wheel=True)
     virtualenv.create_environment(
-        str(root / ENV_DEFAULT),
-        no_setuptools=True,
-        no_pip=True,
-        no_wheel=True,
-    )
-    virtualenv.create_environment(
-        str(root / ENV_CUSTOM),
-        prompt=CUSTOM_PROMPT,
-        no_setuptools=True,
-        no_pip=True,
-        no_wheel=True,
+        str(root / ENV_CUSTOM), prompt=PREFIX_CUSTOM, no_setuptools=True, no_pip=True, no_wheel=True
     )
     return root
 
 
-def test_functional_env_root(env_root):
-    assert subprocess.call(
-        'ls',
-        cwd=str(env_root),
-        shell=True,
-    ) == 0
+@pytest.fixture(scope="function")
+def clean_env():
+    """Provide a fresh copy of the shell environment."""
+    return os.environ.copy()
 
 
-def test_nonzero_exit(env_root):
-    assert subprocess.call(
-        'exit 1',
-        cwd=str(env_root),
-        shell=True,
-    ) == 1
+def fix_PS1_return(result, trim_newline=True):
+    """Replace select byte values with escape sequences."""
+    result = result.replace(b"\x1b", b"\\e")
+    result = result.replace(b"\x07", b"\\a")
+
+    # For some reason, indexing a single value into a bytes string
+    # gives the underlying integer value. b'\n' --> 10
+    if trim_newline and result[-1] == 10:
+        return result[:-1]
+    else:
+        return result
+
+
+def test_functional_env_root(tmp_root):
+    assert subprocess.call("ls", cwd=str(tmp_root), shell=True) == 0
+
+
+def test_nonzero_exit(tmp_root):
+    assert subprocess.call("exit 1", cwd=str(tmp_root), shell=True) == 1
 
 
 class TestBashPrompts:
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def PS1():
+        return os.environ.get("PS1")
 
     @staticmethod
-    def test_dummy(env_root):
-        assert 1 == 1
+    def test_suppressed_prompt_default_env(tmp_root, PS1, clean_env):
+        clean_env.update({VIRTUAL_ENV_DISABLE_PROMPT: "1"})
+        command = '. {0}/bin/activate && echo "$PS1"'.format(ENV_DEFAULT)
+        result = subprocess.check_output(command, cwd=str(tmp_root), shell=True, env=clean_env)
+        result = fix_PS1_return(result)
+
+        # This assert MUST be made by encoding PS1, **NOT** by decoding
+        # result. Python's decoding machinery mangles the content of the
+        # returned $PS1 ~irretrievably.
+        assert result == PS1.encode()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -43,21 +44,18 @@ def fix_PS1_return(result, trim_newline=True):
     result = result.replace(b"\x1b", b"\\e")
     result = result.replace(b"\x07", b"\\a")
 
-    if trim_newline and result[-1:] == b'\n':
+    if trim_newline and result[-1:] == b"\n":
         return result[:-1]
     else:
         return result
 
 
-def test_functional_env_root(tmp_root):
-    assert subprocess.call("ls", cwd=str(tmp_root), shell=True) == 0
+@pytest.mark.parametrize(["command", "code"], [("dir", 0), ("exit 1", 1)])
+def test_exit_code(command, code, tmp_root):
+    assert subprocess.call(command, cwd=str(tmp_root), shell=True) == code
 
 
-def test_nonzero_exit(tmp_root):
-    assert subprocess.call("exit 1", cwd=str(tmp_root), shell=True) == 1
-
-
-@pytest.mark.skipif(os.name.startswith("win"), reason="Invalid on Windows")
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Invalid on Windows")
 class TestBashPrompts:
     @staticmethod
     @pytest.fixture(scope="class")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -9,7 +9,6 @@ import pytest
 
 import virtualenv
 
-
 ENV_DEFAULT = "env"
 ENV_CUSTOM = "env_custom"
 
@@ -39,7 +38,7 @@ def clean_env():
     return os.environ.copy()
 
 
-@pytest.mark.parametrize(["command", "code"], [("dir", 0), ("exit 1", 1)])
+@pytest.mark.parametrize(["command", "code"], [("echo test", 0), ("exit 1", 1)])
 def test_exit_code(command, code, tmp_root):
     """Confirm subprocess.call exit codes work as expected at the unit test level."""
     assert subprocess.call(command, cwd=str(tmp_root), shell=True) == code

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -39,50 +39,19 @@ def clean_env():
     return os.environ.copy()
 
 
-def fix_PS1_return(result, trim_newline=True):
-    """Replace select byte values with escape sequences."""
-    result = result.replace(b"\x1b", b"\\e")
-    result = result.replace(b"\x07", b"\\a")
-
-    if trim_newline and result[-1:] == b"\n":
-        return result[:-1]
-    else:
-        return result
-
-
 @pytest.mark.parametrize(["command", "code"], [("dir", 0), ("exit 1", 1)])
 def test_exit_code(command, code, tmp_root):
+    """Confirm subprocess.call exit codes work as expected at the unit test level."""
     assert subprocess.call(command, cwd=str(tmp_root), shell=True) == code
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Invalid on Windows")
 class TestBashPrompts:
-    @staticmethod
-    @pytest.fixture(scope="class")
-    def PS1():
-        return os.environ.get("PS1")
+    """Container for tests of bash prompt modifications."""
 
     @staticmethod
-    def test_suppressed_prompt_default_env_output(tmp_root, PS1, clean_env):
-        """Check correct form of PS1 via subprocess.check_output().
-
-        Duplicates test_suppressed_prompt_default_env_file, but demonstrates
-        how to go about handling a test like this without using a temporary
-        file, in case that's useful later.
-
-        """
-        clean_env.update({VIRTUAL_ENV_DISABLE_PROMPT: "1"})
-        command = '. {0}/bin/activate && echo "$PS1"'.format(ENV_DEFAULT)
-        result = subprocess.check_output(command, cwd=str(tmp_root), shell=True, env=clean_env)
-        result = fix_PS1_return(result)
-
-        # This assert MUST be made by encoding PS1, **NOT** by decoding
-        # result. Python's decoding machinery mangles the content of the
-        # returned $PS1 ~irretrievably.
-        assert result == PS1.encode()
-
-    @staticmethod
-    def test_suppressed_prompt_default_env_file(tmp_root, clean_env):
+    def test_suppressed_prompt_default_env(tmp_root, clean_env):
+        """Confirm VIRTUAL_ENV_DISABLE_PROMPT suppresses prompt changes on activate."""
         clean_env.update({VIRTUAL_ENV_DISABLE_PROMPT: "1"})
         command = 'echo "$PS1" > {1} && . {0}/bin/activate && echo "$PS1" >> {1}'.format(ENV_DEFAULT, OUTPUT_FILE)
 
@@ -94,6 +63,7 @@ class TestBashPrompts:
     @staticmethod
     @pytest.mark.parametrize(["env", "prefix"], [(ENV_DEFAULT, PREFIX_DEFAULT), (ENV_CUSTOM, PREFIX_CUSTOM)])
     def test_activated_prompt(env, prefix, tmp_root):
+        """Confirm prompt modification behavior with and without --prompt specified."""
         command = (
             'echo "$PS1" > {1} && . {0}/bin/activate && echo "$PS1" >> {1} ' '&& deactivate && echo "$PS1" >> {1}'
         ).format(env, OUTPUT_FILE)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -43,9 +43,7 @@ def fix_PS1_return(result, trim_newline=True):
     result = result.replace(b"\x1b", b"\\e")
     result = result.replace(b"\x07", b"\\a")
 
-    # For some reason, indexing a single value into a bytes string
-    # gives the underlying integer value. b'\n' --> 10
-    if trim_newline and result[-1] == 10:
+    if trim_newline and result[-1:] == b'\n':
         return result[:-1]
     else:
         return result
@@ -59,6 +57,7 @@ def test_nonzero_exit(tmp_root):
     assert subprocess.call("exit 1", cwd=str(tmp_root), shell=True) == 1
 
 
+@pytest.mark.skipif(os.name.startswith("win"), reason="Invalid on Windows")
 class TestBashPrompts:
     @staticmethod
     @pytest.fixture(scope="class")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,60 @@
+"""test that prompt behavior is correct in supported shells"""
+from __future__ import absolute_import, unicode_literals
+
+import subprocess
+
+import pytest
+
+import virtualenv
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+CUSTOM_PROMPT = "!!!ENV!!!"
+ENV_DEFAULT = "env"
+ENV_CUSTOM = "env_custom"
+
+
+@pytest.fixture(scope="module")
+def env_root(tmp_path_factory):
+    """Provide Path to root with default and custom venvs created."""
+    root = tmp_path_factory.mktemp("env_root")
+    virtualenv.create_environment(
+        str(root / ENV_DEFAULT),
+        no_setuptools=True,
+        no_pip=True,
+        no_wheel=True,
+    )
+    virtualenv.create_environment(
+        str(root / ENV_CUSTOM),
+        prompt=CUSTOM_PROMPT,
+        no_setuptools=True,
+        no_pip=True,
+        no_wheel=True,
+    )
+    return root
+
+
+def test_functional_env_root(env_root):
+    assert subprocess.call(
+        'ls',
+        cwd=str(env_root),
+        shell=True,
+    ) == 0
+
+
+def test_nonzero_exit(env_root):
+    assert subprocess.call(
+        'exit 1',
+        cwd=str(env_root),
+        shell=True,
+    ) == 1
+
+
+class TestBashPrompts:
+
+    @staticmethod
+    def test_dummy(env_root):
+        assert 1 == 1


### PR DESCRIPTION
**THIS PR WAS OBSOLETED BY #1330.**

-----

Adds the tests called for in #1294. No changes to API/features. Ping @gaborbernat for review.

No changes yet to documentation; no news item added yet -- I would think neither is necessary for this, though?

Let me know if I should squash-rebase.

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation (???)
- [ ] added news fragment in ``docs/changelog`` folder (???)
