### PR TITLE
get python versions from 32&64-bit registry views

### DIFF
--- a/docs/changelog/1340.feature.rst
+++ b/docs/changelog/1340.feature.rst
@@ -1,0 +1,1 @@
+``-p`` option accepts Python version in following formats now: ``X``, ``X-ZZ``, ``X.Y`` and ``X.Y-ZZ``, where ``ZZ`` is ``32`` or ``64``. (Windows only)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -54,14 +54,29 @@ class TestGetInstalledPythons:
             raise WindowsError
 
         mock_winreg = NonCallableMock(
-            spec_set=["HKEY_LOCAL_MACHINE", "HKEY_CURRENT_USER", "KEY_READ", "KEY_WOW64_32KEY", "KEY_WOW64_64KEY", "OpenKey", "EnumKey", "QueryValue", "CloseKey"]
+            spec_set=[
+                "HKEY_LOCAL_MACHINE",
+                "HKEY_CURRENT_USER",
+                "KEY_READ",
+                "KEY_WOW64_32KEY",
+                "KEY_WOW64_64KEY",
+                "OpenKey",
+                "EnumKey",
+                "QueryValue",
+                "CloseKey",
+            ]
         )
         mock_winreg.HKEY_LOCAL_MACHINE = "HKEY_LOCAL_MACHINE"
         mock_winreg.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
         mock_winreg.KEY_READ = 0x10
         mock_winreg.KEY_WOW64_32KEY = 0x1
         mock_winreg.KEY_WOW64_64KEY = 0x2
-        mock_winreg.OpenKey.side_effect = [cls.key_local_machine, cls.key_current_user, cls.key_local_machine_64, cls.key_current_user_64]
+        mock_winreg.OpenKey.side_effect = [
+            cls.key_local_machine,
+            cls.key_current_user,
+            cls.key_local_machine_64,
+            cls.key_current_user_64,
+        ]
         mock_winreg.EnumKey.side_effect = enum_key
         mock_winreg.QueryValue.side_effect = query_value
         mock_winreg.CloseKey.return_value = None
@@ -95,7 +110,7 @@ class TestGetInstalledPythons:
                     "3.7",
                     "3.8",  # 64-bit with a 32-bit user install
                 ),
-                self.key_current_user_64: ("3.7", ),
+                self.key_current_user_64: ("3.7",),
             },
         )
         monkeypatch.setattr(virtualenv, "join", "{}\\{}".format)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -33,6 +33,8 @@ def test_version():
 class TestGetInstalledPythons:
     key_local_machine = "key-local-machine"
     key_current_user = "key-current-user"
+    key_local_machine_64 = "key-local-machine-64"
+    key_current_user_64 = "key-current-user-64"
 
     @classmethod
     def mock_virtualenv_winreg(cls, monkeypatch, data):
@@ -52,11 +54,14 @@ class TestGetInstalledPythons:
             raise WindowsError
 
         mock_winreg = NonCallableMock(
-            spec_set=["HKEY_LOCAL_MACHINE", "HKEY_CURRENT_USER", "CreateKey", "EnumKey", "QueryValue", "CloseKey"]
+            spec_set=["HKEY_LOCAL_MACHINE", "HKEY_CURRENT_USER", "KEY_READ", "KEY_WOW64_32KEY", "KEY_WOW64_64KEY", "OpenKey", "EnumKey", "QueryValue", "CloseKey"]
         )
         mock_winreg.HKEY_LOCAL_MACHINE = "HKEY_LOCAL_MACHINE"
         mock_winreg.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
-        mock_winreg.CreateKey.side_effect = [cls.key_local_machine, cls.key_current_user]
+        mock_winreg.KEY_READ = 0x10
+        mock_winreg.KEY_WOW64_32KEY = 0x1
+        mock_winreg.KEY_WOW64_64KEY = 0x2
+        mock_winreg.OpenKey.side_effect = [cls.key_local_machine, cls.key_current_user, cls.key_local_machine_64, cls.key_current_user_64]
         mock_winreg.EnumKey.side_effect = enum_key
         mock_winreg.QueryValue.side_effect = query_value
         mock_winreg.CloseKey.return_value = None
@@ -80,13 +85,17 @@ class TestGetInstalledPythons:
                     "2.7",
                     "3.2",
                     "3.4",
-                    "3.5",  # 64-bit only
                     "3.6-32",  # 32-bit only
-                    "3.7",
                     "3.7-32",  # both 32 & 64-bit with a 64-bit user install
-                    "3.8",
-                ),  # 64-bit with a 32-bit user install
-                self.key_current_user: ("2.5", "2.7", "3.7", "3.8-32"),
+                ),
+                self.key_current_user: ("2.5", "2.7", "3.8-32"),
+                self.key_local_machine_64: (
+                    "2.6",
+                    "3.5",  # 64-bit only
+                    "3.7",
+                    "3.8",  # 64-bit with a 32-bit user install
+                ),
+                self.key_current_user_64: ("3.7", ),
             },
         )
         monkeypatch.setattr(virtualenv, "join", "{}\\{}".format)
@@ -95,25 +104,36 @@ class TestGetInstalledPythons:
 
         assert installed_pythons == {
             "2": self.key_current_user + "-2.7-path\\python.exe",
+            "2-32": self.key_current_user + "-2.7-path\\python.exe",
+            "2-64": self.key_local_machine_64 + "-2.6-path\\python.exe",
             "2.4": self.key_local_machine + "-2.4-path\\python.exe",
+            "2.4-32": self.key_local_machine + "-2.4-path\\python.exe",
             "2.5": self.key_current_user + "-2.5-path\\python.exe",
+            "2.5-32": self.key_current_user + "-2.5-path\\python.exe",
+            "2.6": self.key_local_machine_64 + "-2.6-path\\python.exe",
+            "2.6-64": self.key_local_machine_64 + "-2.6-path\\python.exe",
             "2.7": self.key_current_user + "-2.7-path\\python.exe",
-            "3": self.key_local_machine + "-3.8-path\\python.exe",
+            "2.7-32": self.key_current_user + "-2.7-path\\python.exe",
+            "3": self.key_local_machine_64 + "-3.8-path\\python.exe",
+            "3-32": self.key_current_user + "-3.8-32-path\\python.exe",
+            "3-64": self.key_local_machine_64 + "-3.8-path\\python.exe",
             "3.2": self.key_local_machine + "-3.2-path\\python.exe",
+            "3.2-32": self.key_local_machine + "-3.2-path\\python.exe",
             "3.4": self.key_local_machine + "-3.4-path\\python.exe",
-            "3.5": self.key_local_machine + "-3.5-path\\python.exe",
-            "3.5-64": self.key_local_machine + "-3.5-path\\python.exe",
+            "3.4-32": self.key_local_machine + "-3.4-path\\python.exe",
+            "3.5": self.key_local_machine_64 + "-3.5-path\\python.exe",
+            "3.5-64": self.key_local_machine_64 + "-3.5-path\\python.exe",
             "3.6": self.key_local_machine + "-3.6-32-path\\python.exe",
             "3.6-32": self.key_local_machine + "-3.6-32-path\\python.exe",
-            "3.7": self.key_current_user + "-3.7-path\\python.exe",
+            "3.7": self.key_current_user_64 + "-3.7-path\\python.exe",
             "3.7-32": self.key_local_machine + "-3.7-32-path\\python.exe",
-            "3.7-64": self.key_current_user + "-3.7-path\\python.exe",
-            "3.8": self.key_local_machine + "-3.8-path\\python.exe",
+            "3.7-64": self.key_current_user_64 + "-3.7-path\\python.exe",
+            "3.8": self.key_local_machine_64 + "-3.8-path\\python.exe",
             "3.8-32": self.key_current_user + "-3.8-32-path\\python.exe",
-            "3.8-64": self.key_local_machine + "-3.8-path\\python.exe",
+            "3.8-64": self.key_local_machine_64 + "-3.8-path\\python.exe",
         }
         assert mock_winreg.mock_calls == [
-            call.CreateKey(mock_winreg.HKEY_LOCAL_MACHINE, "Software\\Python\\PythonCore"),
+            call.OpenKey(mock_winreg.HKEY_LOCAL_MACHINE, "Software\\Python\\PythonCore", 0, 0x11),
             call.EnumKey(self.key_local_machine, 0),
             call.QueryValue(self.key_local_machine, "2.4\\InstallPath"),
             call.EnumKey(self.key_local_machine, 1),
@@ -123,28 +143,36 @@ class TestGetInstalledPythons:
             call.EnumKey(self.key_local_machine, 3),
             call.QueryValue(self.key_local_machine, "3.4\\InstallPath"),
             call.EnumKey(self.key_local_machine, 4),
-            call.QueryValue(self.key_local_machine, "3.5\\InstallPath"),
-            call.EnumKey(self.key_local_machine, 5),
             call.QueryValue(self.key_local_machine, "3.6-32\\InstallPath"),
-            call.EnumKey(self.key_local_machine, 6),
-            call.QueryValue(self.key_local_machine, "3.7\\InstallPath"),
-            call.EnumKey(self.key_local_machine, 7),
+            call.EnumKey(self.key_local_machine, 5),
             call.QueryValue(self.key_local_machine, "3.7-32\\InstallPath"),
-            call.EnumKey(self.key_local_machine, 8),
-            call.QueryValue(self.key_local_machine, "3.8\\InstallPath"),
-            call.EnumKey(self.key_local_machine, 9),
+            call.EnumKey(self.key_local_machine, 6),
             call.CloseKey(self.key_local_machine),
-            call.CreateKey(mock_winreg.HKEY_CURRENT_USER, "Software\\Python\\PythonCore"),
+            call.OpenKey(mock_winreg.HKEY_CURRENT_USER, "Software\\Python\\PythonCore", 0, 0x11),
             call.EnumKey(self.key_current_user, 0),
             call.QueryValue(self.key_current_user, "2.5\\InstallPath"),
             call.EnumKey(self.key_current_user, 1),
             call.QueryValue(self.key_current_user, "2.7\\InstallPath"),
             call.EnumKey(self.key_current_user, 2),
-            call.QueryValue(self.key_current_user, "3.7\\InstallPath"),
-            call.EnumKey(self.key_current_user, 3),
             call.QueryValue(self.key_current_user, "3.8-32\\InstallPath"),
-            call.EnumKey(self.key_current_user, 4),
+            call.EnumKey(self.key_current_user, 3),
             call.CloseKey(self.key_current_user),
+            call.OpenKey(mock_winreg.HKEY_LOCAL_MACHINE, "Software\\Python\\PythonCore", 0, 0x12),
+            call.EnumKey(self.key_local_machine_64, 0),
+            call.QueryValue(self.key_local_machine_64, "2.6\\InstallPath"),
+            call.EnumKey(self.key_local_machine_64, 1),
+            call.QueryValue(self.key_local_machine_64, "3.5\\InstallPath"),
+            call.EnumKey(self.key_local_machine_64, 2),
+            call.QueryValue(self.key_local_machine_64, "3.7\\InstallPath"),
+            call.EnumKey(self.key_local_machine_64, 3),
+            call.QueryValue(self.key_local_machine_64, "3.8\\InstallPath"),
+            call.EnumKey(self.key_local_machine_64, 4),
+            call.CloseKey(self.key_local_machine_64),
+            call.OpenKey(mock_winreg.HKEY_CURRENT_USER, "Software\\Python\\PythonCore", 0, 0x12),
+            call.EnumKey(self.key_current_user_64, 0),
+            call.QueryValue(self.key_current_user_64, "3.7\\InstallPath"),
+            call.EnumKey(self.key_current_user_64, 1),
+            call.CloseKey(self.key_current_user_64),
         ]
 
     @pytest.mark.skipif(sys.platform != "win32", reason="windows specific test")
@@ -156,12 +184,18 @@ class TestGetInstalledPythons:
 
         assert installed_pythons == {}
         assert mock_winreg.mock_calls == [
-            call.CreateKey(mock_winreg.HKEY_LOCAL_MACHINE, "Software\\Python\\PythonCore"),
+            call.OpenKey(mock_winreg.HKEY_LOCAL_MACHINE, "Software\\Python\\PythonCore", 0, 0x11),
             call.EnumKey(self.key_local_machine, 0),
             call.CloseKey(self.key_local_machine),
-            call.CreateKey(mock_winreg.HKEY_CURRENT_USER, "Software\\Python\\PythonCore"),
+            call.OpenKey(mock_winreg.HKEY_CURRENT_USER, "Software\\Python\\PythonCore", 0, 0x11),
             call.EnumKey(self.key_current_user, 0),
             call.CloseKey(self.key_current_user),
+            call.OpenKey(mock_winreg.HKEY_LOCAL_MACHINE, "Software\\Python\\PythonCore", 0, 0x12),
+            call.EnumKey(self.key_local_machine_64, 0),
+            call.CloseKey(self.key_local_machine_64),
+            call.OpenKey(mock_winreg.HKEY_CURRENT_USER, "Software\\Python\\PythonCore", 0, 0x12),
+            call.EnumKey(self.key_current_user_64, 0),
+            call.CloseKey(self.key_current_user_64),
         ]
 
 

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -145,7 +145,7 @@ else:
                         continue
                     # Remove bitness from version
                     if version.endswith(bitness):
-                        version = version[:-len(bitness)]
+                        version = version[: -len(bitness)]
                     exes[(version, bitness)] = join(at_path, "python.exe")
                 except WindowsError:
                     break

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -104,9 +104,11 @@ else:
 
         # Grab exes from 32-bit registry view
         exes = _get_installed_pythons_for_view("-32", winreg.KEY_WOW64_32KEY)
-        # For 64-bit OS grab exes from 64-bit registry view
-        if sys.maxsize > 2**32 or "PROGRAMFILES(X86)" in os.environ:
-            exes.update(_get_installed_pythons_for_view("-64", winreg.KEY_WOW64_64KEY))
+        # Grab exes from 64-bit registry view
+        exes_64 = _get_installed_pythons_for_view("-64", winreg.KEY_WOW64_64KEY)
+        # Check if exes are unique
+        if set(exes.values()) != set(exes_64.values()):
+            exes.update(exes_64)
 
         # Create dict with all versions found
         for version, bitness in sorted(exes):

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -100,12 +100,35 @@ else:
         import _winreg as winreg
 
     def get_installed_pythons():
+        final_exes = dict()
+
+        # Grab exes from 32-bit registry view
+        exes = _get_installed_pythons_for_view("-32", winreg.KEY_WOW64_32KEY)
+        # For 64-bit OS grab exes from 64-bit registry view
+        if sys.maxsize > 2**32 or "PROGRAMFILES(X86)" in os.environ:
+            exes.update(_get_installed_pythons_for_view("-64", winreg.KEY_WOW64_64KEY))
+
+        # Create dict with all versions found
+        for version, bitness in sorted(exes):
+            exe = exes[(version, bitness)]
+            # Add minor version (X.Y-32 or X.Y-64)
+            final_exes[version + bitness] = exe
+            # Add minor extensionless version (X.Y); 3.2-64 wins over 3.2-32
+            final_exes[version] = exe
+            # Add major version (X-32 or X-64)
+            final_exes[version[0] + bitness] = exe
+            # Add major extensionless version (X); 3.3-32 wins over 3.2-64
+            final_exes[version[0]] = exe
+
+        return final_exes
+
+    def _get_installed_pythons_for_view(bitness, view):
         exes = dict()
         # If both system and current user installations are found for a
         # particular Python version, the current user one is used
         for key in (winreg.HKEY_LOCAL_MACHINE, winreg.HKEY_CURRENT_USER):
             try:
-                python_core = winreg.CreateKey(key, "Software\\Python\\PythonCore")
+                python_core = winreg.OpenKey(key, "Software\\Python\\PythonCore", 0, view | winreg.KEY_READ)
             except WindowsError:
                 # No registered Python installations
                 continue
@@ -118,33 +141,13 @@ else:
                         at_path = winreg.QueryValue(python_core, "{}\\InstallPath".format(version))
                     except WindowsError:
                         continue
-                    exes[version] = join(at_path, "python.exe")
+                    # Remove bitness from version
+                    if version.endswith(bitness):
+                        version = version[:-len(bitness)]
+                    exes[(version, bitness)] = join(at_path, "python.exe")
                 except WindowsError:
                     break
             winreg.CloseKey(python_core)
-
-        # For versions that track separate 32-bit (`X.Y-32`) & 64-bit (`X-Y`)
-        # installation registrations, add a `X.Y-64` version tag and make the
-        # extensionless `X.Y` version tag represent the 64-bit installation if
-        # available or 32-bit if it is not
-        updated = {}
-        for ver in exes:
-            if ver < "3.5":
-                continue
-            if ver.endswith("-32"):
-                base_ver = ver[:-3]
-                if base_ver not in exes:
-                    updated[base_ver] = exes[ver]
-            else:
-                updated[ver + "-64"] = exes[ver]
-        exes.update(updated)
-
-        # Add the major versions
-        # Sort the keys, then repeatedly update the major version entry
-        # Last executable (i.e., highest version) wins with this approach,
-        # 64-bit over 32-bit if both are found
-        for ver in sorted(exes):
-            exes[ver[0]] = exes[ver]
 
         return exes
 


### PR DESCRIPTION
On Windows, get Python paths from both 32-bit and 64-bit registry views.

Additionally you get both major and minor versions, both with and without bitness information.

For example if you have versions 3.5 (32 bit), 3.5 (64 bit) and 3.6 (32 bit) you can choose from: `3.5-32`, `3.5-64`, `3.6-32`, `3.5`, `3.6`, `3-32`, `3-64`  and `3`, where:
* `3` == `3.6-32` (because it has the highest version)
* `3-32` == `3.6-32`
* `3-64` == `3.5-64`
* `3.5` == `3.5-64` (because 64-bit wins over 32-bit)
* `3.6` == `3.6-32`