### PR TITLE
[PROOF OF CONCEPT] Use venv module to create the base Python where it's present

### DIFF
--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -21,7 +21,7 @@ VIRTUALENV_SCRIPT = get_src(virtualenv.__file__)
 
 def test_commandline_basic(tmpdir):
     """Simple command line usage should work and files should be generated"""
-    home_dir, lib_dir, inc_dir, bin_dir = virtualenv.path_locations(str(tmpdir.join("venv")))
+    home_dir, lib_dir, inc_dir, bin_dir = virtualenv.path_locations(str(tmpdir.join("ve")))
     subprocess.check_call([sys.executable, VIRTUALENV_SCRIPT, home_dir])
 
     assert os.path.exists(home_dir)
@@ -42,7 +42,7 @@ def test_commandline_basic(tmpdir):
 
 def test_commandline_explicit_interp(tmpdir):
     """Specifying the Python interpreter should work"""
-    subprocess.check_call([sys.executable, VIRTUALENV_SCRIPT, "-p", sys.executable, str(tmpdir.join("venv"))])
+    subprocess.check_call([sys.executable, VIRTUALENV_SCRIPT, "-p", sys.executable, str(tmpdir.join("ve"))])
 
 
 # The registry lookups to support the abbreviated "-p 3.5" form of specifying
@@ -54,4 +54,4 @@ def test_commandline_explicit_interp(tmpdir):
 def test_commandline_abbrev_interp(tmpdir):
     """Specifying abbreviated forms of the Python interpreter should work"""
     abbrev = "{}{}.{}".format("" if sys.platform == "win32" else "python", *sys.version_info[0:2])
-    subprocess.check_call([sys.executable, VIRTUALENV_SCRIPT, "-p", abbrev, str(tmpdir.join("venv"))])
+    subprocess.check_call([sys.executable, VIRTUALENV_SCRIPT, "-p", abbrev, str(tmpdir.join("ve"))])

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -356,7 +356,7 @@ def test_install_python_bin():
 def test_always_copy_option():
     """Should be no symlinks in directory tree"""
     tmp_virtualenv = tempfile.mkdtemp()
-    ve_path = os.path.join(tmp_virtualenv, "venv")
+    ve_path = os.path.join(tmp_virtualenv, "ve")
     try:
         virtualenv.create_environment(ve_path, symlink=False)
 

--- a/tests/test_zipapp.py
+++ b/tests/test_zipapp.py
@@ -59,7 +59,7 @@ def test_wheel_basic_invocation(call_wheel, tmp_path):
 
 
 def _test_basic_invocation(make_env, tmp_path):
-    venv = tmp_path / "venv"
+    venv = tmp_path / "ve"
     make_env(str(venv))
     assert_venv_looks_good(
         venv, list(sys.version_info), "{}{}".format(virtualenv.EXPECTED_EXE, ".exe" if virtualenv.IS_WIN else "")
@@ -83,7 +83,7 @@ def assert_venv_looks_good(venv, version_info, exe_name):
 
 
 def _test_invocation_dash_p(make_env, tmp_path):
-    venv = tmp_path / "venv"
+    venv = tmp_path / "ve"
     python = {2: _python("3"), 3: _python("2.7")}[sys.version_info[0]]
     make_env(str(venv), python)
     expected = {3: 2, 2: 3}[sys.version_info[0]]

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1331,6 +1331,22 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         print("Please use the *system* python to run this script")
         return
 
+    try:
+        import venv
+    except ImportError:
+        venv = None
+
+    if venv:
+        assert sys.version_info[0] == 3
+        builder = venv.EnvBuilder(system_site_packages=site_packages, clear=clear, symlinks=False, with_pip=False)
+        env_dir = os.path.abspath(home_dir)
+        context = builder.ensure_directories(env_dir)
+        builder.create_configuration(context)
+        # TODO: For Python 3.7.2, the work of setup>python is done in setup_scripts :-()
+        builder.setup_python(context)
+        # TODO: Look at whether we need to skip setting up our site.py and distutils hacks
+        return context.env_exe
+
     if clear:
         rm_tree(lib_dir)
         # FIXME: why not delete it?


### PR DESCRIPTION
This is not ready for merge - at this point it is simply a proof of concept.

Looking at the stdlib venv module and the virtualenv codebase, it seems that the process of creating the base virtual environment (before we add in all of the scripts and install pip, etc) could be handled using the programming API for venv. There are some differences in API that need to be ironed out, but if it works, this would make virtualenv compatible with venv (in the sense of using the virtual environment support built into core Python).

This isn't any sort of attempt to make the two tools compatible at the UI level, it's purely about using the core mechanism when it's available.

At the moment, all I'm doing here is using the virtualenv CI infrastructure to ensure the change works. It needs a lot more manual testing and work before it's going to be ready to propose for actual merging.