### PR TITLE
Remove pypy3 check for distutils import error

### DIFF
--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -37,13 +37,7 @@ def test_commandline_basic(tmpdir):
     def _check_no_warnings(module):
         subprocess.check_call((exe, "-Werror", "-c", "import {}".format(module)))
 
-    # pypy3's `distutils.sysconfig_pypy` imports `imp`
-    # https://bitbucket.org/pypy/pypy/pull-requests/634/remove-unused-and-deprecated-import-of-imp/diff
-    if virtualenv.IS_PYPY and sys.version_info > (3,):
-        with pytest.raises(subprocess.CalledProcessError):
-            _check_no_warnings("distutils")
-    else:
-        _check_no_warnings("distutils")
+    _check_no_warnings("distutils")
 
 
 def test_commandline_explicit_interp(tmpdir):


### PR DESCRIPTION
pypy3 has been modified to no longer import `imp`, which means that a pypy3 `import distutils` no longer raises an exception.

See this merged PR: https://bitbucket.org/pypy/pypy/pull-requests/634/remove-unused-and-deprecated-import-of-imp/diff

**Is a news fragment needed for this?**

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation **N/A**
- [ ] added news fragment in ``docs/changelog`` folder
