### PR TITLE
Remove special-casing for PyPy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,52 +25,52 @@ trigger:
 
 jobs:
 - template: azure-run-tox-env.yml
-  parameters: {tox: fix_lint, python: 3.7}
+  parameters: {tox: fix_lint, python: '3.7'}
 - template: azure-run-tox-env.yml
-  parameters: {tox: embed, python: 3.7}
+  parameters: {tox: embed, python: '3.7'}
 - template: azure-run-tox-env.yml
-  parameters: {tox: docs, python: 3.7}
+  parameters: {tox: docs, python: '3.7'}
 - template: azure-run-tox-env.yml
-  parameters: {tox: package_readme, python: 3.7}
+  parameters: {tox: package_readme, python: '3.7'}
 
 - template: azure-run-tox-env.yml
-  parameters: {tox: jython, python: 3.7, os: linux}
+  parameters: {tox: jython, python: '3.7', os: linux}
 - template: azure-run-tox-env.yml
   parameters: {tox: pypy, python: pypy, os: linux}
 - template: azure-run-tox-env.yml
   parameters: {tox: pypy3, python: pypy3, os: linux}
 
 - template: azure-run-tox-env.yml
-  parameters: {tox: py37, python: 3.7, os: windows}
+  parameters: {tox: py37, python: '3.7', os: windows}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py36, python: 3.6, os: windows}
+  parameters: {tox: py36, python: '3.6', os: windows}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py35, python: 3.5, os: windows}
+  parameters: {tox: py35, python: '3.5', os: windows}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py34, python: 3.4, os: windows}
+  parameters: {tox: py34, python: '3.4', os: windows}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py27, python: 2.7, os: windows}
+  parameters: {tox: py27, python: '2.7', os: windows}
 
 - template: azure-run-tox-env.yml
-  parameters: {tox: py37, python: 3.7, os: linux}
+  parameters: {tox: py37, python: '3.7', os: linux}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py36, python: 3.6, os: linux}
+  parameters: {tox: py36, python: '3.6', os: linux}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py35, python: 3.5, os: linux}
+  parameters: {tox: py35, python: '3.5', os: linux}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py34, python: 3.4, os: linux}
+  parameters: {tox: py34, python: '3.4', os: linux}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py27, python: 2.7, os: linux}
+  parameters: {tox: py27, python: '2.7', os: linux}
 
 - template: azure-run-tox-env.yml
-  parameters: {tox: py36, python: 3.6, os: macOs}
+  parameters: {tox: py36, python: '3.6', os: macOs}
 - template: azure-run-tox-env.yml
-  parameters: {tox: py27, python: 2.7, os: macOs}
+  parameters: {tox: py27, python: '2.7', os: macOs}
 
 - template: azure-run-tox-env.yml
-  parameters: {tox: cross_python2, python: 3.7, os: linux}
+  parameters: {tox: cross_python2, python: '3.7', os: linux}
 - template: azure-run-tox-env.yml
-  parameters: {tox: cross_python3, python: 3.7, os: linux}
+  parameters: {tox: cross_python3, python: '3.7', os: linux}
 
 - job: report_coverage
   pool: {vmImage: "Ubuntu-16.04"}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
 - template: azure-run-tox-env.yml
   parameters: {tox: jython, python: '3.7', os: linux}
 - template: azure-run-tox-env.yml
-  parameters: {tox: pypy, python: pypy, os: linux}
+  parameters: {tox: pypy, python: pypy2, os: linux}
 - template: azure-run-tox-env.yml
   parameters: {tox: pypy3, python: pypy3, os: linux}
 

--- a/azure-run-tox-env.yml
+++ b/azure-run-tox-env.yml
@@ -13,17 +13,13 @@ jobs:
     ${{ if eq(parameters.os, 'linux') }}:
       vmImage: "Ubuntu-16.04"
 
-  variables:
-    ${{ if in(parameters.tox, 'pypy', 'py27', 'py34') }}:
+  ${{ if in(parameters.tox, 'pypy', 'py27', 'py34') }}:
+    variables:
       PYTHONWARNINGS: 'ignore:::pip._internal.cli.base_command'
-    ${{ if in(parameters.python, 'pypy', 'pypy3') }}:
-      python: ${{ parameters.python }}
-    ${{ if notIn(parameters.python, 'pypy', 'pypy3') }}:
-      python: "python"
 
   steps:
   # ensure the required Python versions are available
-  - ${{ if notIn(parameters.python, 'pypy', 'pypy3', 'jython') }}:
+  - ${{ if notIn(parameters.python, 'jython') }}:
     - task: UsePythonVersion@0
       displayName: setup python
       inputs:
@@ -43,7 +39,7 @@ jobs:
     - script: echo $(PATH)
       displayName: show PATH
 
-  - script: "$(python) -c \"import sys; print(sys.version); print(sys.executable)\""
+  - script: "python -c \"import sys; print(sys.version); print(sys.executable)\""
     displayName: show python information
 
   - script: "python -m pip install -U pip setuptools --user"


### PR DESCRIPTION
Hello, Azure Pipelines PM here. We recently added `pypy2` and `pypy3` as valid versions for `UsePythonVersion`, so you no longer have to special-case your PyPy legs.
