### PR TITLE
Check for os.pathsep for path.  If we use a directory with os.pathsep…

### DIFF
--- a/docs/changelog/395.bugfix.rst
+++ b/docs/changelog/395.bugfix.rst
@@ -1,1 +1,1 @@
-No longer allow os.pathsep (':' on Linux, ';' on Windows) for target path.
+Raise an error if the target path contains the operating systems path separator (using this would break our activation scripts) - by @rrauenza.

--- a/docs/changelog/395.bugfix.rst
+++ b/docs/changelog/395.bugfix.rst
@@ -1,0 +1,1 @@
+No longer allow os.pathsep (':' on Linux, ';' on Windows) for target path.

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -38,6 +38,14 @@ def test_commandline_basic(tmpdir):
     _check_no_warnings("distutils")
 
 
+def test_commandline_ospathsep(tmpdir):
+    path = str(tmpdir.join("pathsepvenv" + os.pathsep + "0"))
+    assert not os.path.exists(path)
+    ret = subprocess.call([sys.executable, VIRTUALENV_SCRIPT, path])
+    assert ret != 0
+    assert not os.path.exists(path)
+
+
 def test_commandline_explicit_interp(tmpdir):
     """Specifying the Python interpreter should work"""
     subprocess.check_call([sys.executable, VIRTUALENV_SCRIPT, "-p", sys.executable, str(tmpdir.join("venv"))])

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -804,6 +804,11 @@ def main():
         logger.fatal("Please provide a different path or delete the file.")
         sys.exit(3)
 
+    if os.pathsep in home_dir:
+        logger.fatal("ERROR: path contains the operating system path seperator '{}'".format(os.pathsep))
+        logger.fatal("Please provide a different path that does not contain os.pathsep.".format(os.pathsep))
+        sys.exit(3)
+
     if os.environ.get("WORKING_ENV"):
         logger.fatal("ERROR: you cannot run virtualenv while in a working env")
         logger.fatal("Please deactivate your working env, then re-run this script")

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -805,8 +805,8 @@ def main():
         sys.exit(3)
 
     if os.pathsep in home_dir:
-        logger.fatal("ERROR: path contains the operating system path seperator '{}'".format(os.pathsep))
-        logger.fatal("Please provide a different path that does not contain os.pathsep.".format(os.pathsep))
+        logger.fatal("ERROR: target path contains the operating system path separator '{}'".format(os.pathsep))
+        logger.fatal("This is not allowed as would make the activation scripts unusable.".format(os.pathsep))
         sys.exit(3)
 
     if os.environ.get("WORKING_ENV"):


### PR DESCRIPTION
…, the virtualenv can't be added to the PATH.

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [x ] added/updated test(s)
- [ ] updated/extended the documentation

Do we want to document this limitation somewhere?  Or just let it be an error?

- [x ] added news fragment in ``docs/changelog`` folder
