### PR TITLE
Remove warning about missing license file

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1345,7 +1345,6 @@ def copy_license(prefix, dst_prefix, lib_dir, symlink):
             dest = subst_path(license_path, prefix, dst_prefix)
             copyfile(license_path, dest, symlink)
             return
-    logger.warn("No LICENSE.txt / LICENSE found in source")
 
 
 def copy_include_dir(include_src, include_dest, symlink):


### PR DESCRIPTION
Resolves #1352

Some platforms' packaging of pypy removes the license from the source directory

## Thanks for contributing a pull request, see checklist all is good!

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added news fragment in ``docs/changelog`` folder
