### PR TITLE
Correct python option render

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -40,7 +40,7 @@ Options
 .. option:: -p PYTHON_EXE, --python=PYTHON_EXE
 
    The Python interpreter to use, e.g.,
-   --python=python2.5 will use the python2.5 interpreter
+   ``--python=python2.5`` will use the python2.5 interpreter
    to create the new environment.  The default is the
    interpreter that virtualenv was installed with
    (like ``/usr/bin/python``)


### PR DESCRIPTION
Old content will render to `-python=2.5`
This patch correct it to `--python=2.5`

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [x] added/updated test(s): just docs changes and don't need test
- [x] updated/extended the documentation
- [x] added news fragment in ``docs/changelog`` folder: minor change and not nedd
