### PR TITLE
Also search the LICENSE file in lib64/pythonX.Y

### DIFF
--- a/docs/changelog/1382.bugfix.rst
+++ b/docs/changelog/1382.bugfix.rst
@@ -1,0 +1,3 @@
+Extend the LICESNE search paths list by ``lib64/pythonX.Y`` to support Linux
+vendors who install their Python to ``/usr/lib64/pythonX.Y`` (Gentoo, Fedora,
+openSUSE, RHEL and others) - by ``hroncok``

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1333,9 +1333,12 @@ def copy_required_files(src_dir, lib_dir, symlink):
 
 def copy_license(prefix, dst_prefix, lib_dir, symlink):
     """Copy the license file so `license()` builtin works"""
+    lib64_dir = lib_dir.replace("lib", "lib64")
     for license_path in (
         # posix cpython
         os.path.join(prefix, os.path.relpath(lib_dir, dst_prefix), "LICENSE.txt"),
+        # posix cpython installed in /usr/lib64
+        os.path.join(prefix, os.path.relpath(lib64_dir, dst_prefix), "LICENSE.txt"),
         # windows cpython
         os.path.join(prefix, "LICENSE.txt"),
         # pypy


### PR DESCRIPTION
Several Linux distributions including Gentoo, Fedora, openSUSE
put things in lib64/pythonX.Y instead of lib/pythonX.Y on 64bit
architectures (x86_64, aarch64, etc.).

This was already respected via the fix_lib64() function, however
when virtualenv was searching for Python LICENSE, it was not.

Now is the lib64/pythonX.Y patch searched as well and unlike fix_lib64()
no checks need to be made, as the patch are tested in sequence.

See https://github.com/pypa/virtualenv/issues/1352#issuecomment-510500384

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [x] added/updated test(s) - covered by `test_license_builtin` - not sure how would I mock lib64 Python on non-lib64 Python to test this on *other* platforms
- [x] updated/extended the documentation (this functionality is not mentioned but in changelog)
- [x] added news fragment in ``docs/changelog`` folder
