### PR TITLE
Fix python2 tests to use python3 to make zipapp

### DIFF
--- a/tests/test_zipapp.py
+++ b/tests/test_zipapp.py
@@ -22,7 +22,7 @@ def call_zipapp(tmp_path_factory):
         pytest.skip("zipapp was introduced in python3.5")
     pyz = str(tmp_path_factory.mktemp(basename="zipapp") / "virtualenv.pyz")
     subprocess.check_call(
-        (sys.executable, os.path.join(HERE, "tasks/make_zipapp.py"), "--root", virtualenv.HERE, "--dest", pyz)
+        (_python("3"), os.path.join(HERE, "tasks/make_zipapp.py"), "--root", virtualenv.HERE, "--dest", pyz)
     )
 
     def zipapp_make_env(path, python=None):


### PR DESCRIPTION
looks like this was inadvertently broken in 1d4702a9
