### PR TITLE
Add support for MacOS 10.15 using Python3.framework

### DIFF
--- a/docs/changelog/1402.bugfix.rst
+++ b/docs/changelog/1402.bugfix.rst
@@ -1,0 +1,1 @@
+fix to support for Python 3 on MacOS 10.15 provided by Xcode

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1630,10 +1630,10 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
         copyfile(os.path.join(prefix, lib_name), virtual_lib, symlink)
 
         # And then change the install_name of the copied python executable
-        # noinspection PyBroadException
         search = (
             "@executable_path/../../../../Python3" if "Python3.framework" in prefix else os.path.join(prefix, lib_name)
         )
+        # noinspection PyBroadException
         try:
             mach_o_change(py_executable, search, "@executable_path/../.Python")
         except Exception:

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1498,7 +1498,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
 
     mkdir(bin_dir)
     py_executable = join(bin_dir, os.path.basename(sys.executable))
-    if "Python.framework" in prefix:
+    if "Python.framework" in prefix or "Python3.framework" in prefix:
         # OS X framework builds cause validation to break
         # https://github.com/pypa/virtualenv/issues/322
         if os.environ.get("__PYVENV_LAUNCHER__"):
@@ -1607,7 +1607,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
 
     if ".framework" in prefix:
         original_python = None
-        if "Python.framework" in prefix:
+        if "Python.framework" in prefix or "Python3.framework" in prefix:
             logger.debug("MacOSX Python framework detected")
             # Make sure we use the embedded interpreter inside
             # the framework, even if sys.executable points to
@@ -1626,25 +1626,21 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
 
         if os.path.exists(virtual_lib):
             os.unlink(virtual_lib)
-        copyfile(os.path.join(prefix, "Python"), virtual_lib, symlink)
+        lib_name = "Python3" if "Python3.framework" in prefix else "Python"
+        copyfile(os.path.join(prefix, lib_name), virtual_lib, symlink)
 
         # And then change the install_name of the copied python executable
         # noinspection PyBroadException
+        search = (
+            "@executable_path/../../../../Python3" if "Python3.framework" in prefix else os.path.join(prefix, lib_name)
+        )
         try:
-            mach_o_change(py_executable, os.path.join(prefix, "Python"), "@executable_path/../.Python")
+            mach_o_change(py_executable, search, "@executable_path/../.Python")
         except Exception:
             e = sys.exc_info()[1]
             logger.warn("Could not call mach_o_change: %s. " "Trying to call install_name_tool instead.", e)
             try:
-                call_subprocess(
-                    [
-                        "install_name_tool",
-                        "-change",
-                        os.path.join(prefix, "Python"),
-                        "@executable_path/../.Python",
-                        py_executable,
-                    ]
-                )
+                call_subprocess(["install_name_tool", "-change", search, "@executable_path/../.Python", py_executable])
             except Exception:
                 logger.fatal("Could not call install_name_tool -- you must " "have Apple's development tools installed")
                 raise
@@ -2195,99 +2191,99 @@ v0qnz27jJKUUNBDj8BBVqYncOTHRL/AepJ06wSFBX2ilPj6+Bu7gVMGwOx3tbZ2ZZGtPhGs+Ray6
 qOzp/eZmu8TbQ3a3yrbrEEP2LxFuszf2RULi4dYjJL1i0wYEFEWteNxPpQfNace8/uAZ9c9quzT8
 sehb3Hto+O9j38ZxJyo8hFb/Pqx+KriGzQB7gIHZ4pTtcMm6Q/Mm09w4VqwglDhATXIg1rTRTClN
 8MsygDJjl6sHDoqH3q58UZclbzqSQipkeYj7aCOBNTbGt6LSnS6Yo9eyQkxssymliJ2KjLxPYkKd
-9LUzCRsvvZ/tlrlJDsnsNimhL6i/QfjTm5/Pt7AFpkyh08N1+taG+PEWGOGyR49zxiX+PZ7n1nH9
-N2ZH1aRANfbd+XUynyZ67ifFPRkQbwuPtykpLp0u5fRmLGnvFdkF+zpp4Bf4GlGxW7J+BY2K51QG
-BFOZpjWShz1MrN+a19mUtgcqCW6ILrbE4gvaUeWE1zyNF2JAnWeYa9FcQemY27jUXlZR5ljeJ+pk
-drRIZkL+VscpBrNyPgdccPNGv4p4eEq5iJe8KcxlX0pO6zKpNkCDWOV674v2j52Gkw1PdOAhybsc
-TEHcUT4RVzhtfM+EmxlymZDYT/LjJIFBqIOz2xvRc3if5WMcdYzkBd4jpIbtfAg/Dtoj5HoXAeav
-R2i/kfTK3WCjNXeJitrKI6UbX+fkoiCUwRDje/5NP31OdJlrC5aL7VgudmO5aGO56MVy4WO52I2l
-KxO4sE2uxohCX76mncjvrVhwUy08znk8XXI7LJ/DMjmAKAoTKhqh4ipSL6HD+1sEhPSns+NKD5sK
-hITr8sqcs74aJLI/7tvosNTU/zqdqZ5Bd+apGC9vWxWG3/coiqjaZkLdWeBmcRVHnmAs0nwCcmvR
-HTUARqJdkME5wux2POF8ZttkvP3f9z+9eY3NEZTd4KduuIio4XEqg4O4XKiuODVBUgH8SC39wgjq
-pgHu9WaU9jmjtD8S+5xR2tfD7PGflznWYSHniDXt0eeiAFtMhTG2mVs+sr/feq7rTPRzZnPeXwH3
-Iqsc12ILlc7evn159v4spEqT8F+hKzKGuL58uPiYFrZB15Nym1uSY5/Gmjb2z52TR2yHJXSvT5//
-HfPr4/cfnSMQE5CIdLryy6b4O5Mj1gh0ipjc+J6dBvvOkQDHVXAEsC/p3R7A32VDl3sMc9GuzMDM
-q4nZWrrXWrkdxHGA/lHxUceTsnj0+FIOcWyz7Z5UN9GvZPX8/MeL15cXz9+evf/J8aXQJ3pzdXQs
-zn/+IKjOAA0BOxcx7qpXWNICCto9cyFmOfxXY2JhVlecNoReLy8vdaJ/hVX3WIaJujuC51wPY6Fx
-jobzkvahLmRBjFLt8TvHG6jsg44/YACw4tJ6letSTTo1MUGvr9axhD62Yo630JZoBKIAjV1SMAiu
-VYJXVFBbmTCn5B0kfeSjBylt62xNQUo5qM5Gs7N9YlL1XtqOOsOTprPWlx9DF9fwOlJFmoAGfRZa
-adDdsLSi4Rv90O6NMl596sjpDiPrhjzrrVhg2cmzkOem+w8bRvutBgwbBnsJ884kFRZQLShWSYl9
-bLTPBQTyDr7apddroGDBcJ+owkU0TJfA7GOIFsUyAU8ceHIJRgwdboDQWgk/hXzi2CSZ475++GI1
-O/xLqAnit/71157mVZke/k0UEE4IrkIJe4jpNn4JEUQkI3H+5tUwZOSmaQxO419qrFQGw075NUfY
-qfSF917HAyXTua5M8NUBvtDmll4Hrf6lLErdv9/JDFEEPn0ekPX99NkQsMmWmAFGOJ9hGz6WYlv8
-8EiTu41tPnviainTVNffXry8PAdPDKvDUY54K+ccxuQ0AG7E6lIuPnLVAoXbtPC6RGYu0SGkXfpZ
-5DXrzYyi4FFvb2PfrhZlH7u9OqnGMk6Ui/YAp60JY+qbI+RoWBKzuiH+1lJq2yCd3TZEdxQd5ozx
-25IKIn3WAJampzGHGBB7YPG5yfPyXmSSVaYALk2moE5B84JeHYGsIHXxhBUxYJ5xpjUvlTmYAQ+L
-TZkslhUm2qFzREXh2Pznsw+XF6+pTvr4aePE9vDoiBzrEVchnGKtGaYP4ItbOYZ8NR67rNt6hTBQ
-CcH/2q+4vOGUB+j044SZl+nXr/hkzKkTWfEMQE/VRVtI0J12uvVJTyMMjKuNK/HjFpE1mPlgKMeG
-hfi6XsCdX5cVbcuWRSE/xLz8gm2CeWFrmnRnp6ap/dFTnBe4uTIb9DeCt32yZT4T6HrTebOtesr9
-dKQQz+gBRt3W/himvKjTVE/H4bVtzEJBora0v7qhgtNumqEkAw0Hbuehy2P9mlg3Zwb0qnI7wMT3
-Gl0jiP36HFDUfoaHiSV2J3QwHbGoUDxSAy7BkPosQg2e1CNF+iMUj8Rg4AjuaCgOxLE3S8ce3D9L
-rbzARv4EmlCXc1IZfV4CK8KX39iB5FeEGCrSE9EEiTi9LLeVRvhZL9G7fOLPslcIKCuIclfG2UIO
-GNbIwPzKJ/eWpCapW4/YH5PrPtMiLsBJvdvC413J6N8RMKi1WKHT7kZu2vrIJw826D1csJNgPvgy
-XoPyL+pqwCu5Zbuz93TPdqj3Q8T6NWiqd4IHIXrQv/WVyviAe6mhYaGn91vPNgh+eG2sR2stZOvk
-yL59oV3ZaQkhWqX2EUnnvJRxSq0f0Jjc08boh/ZpyEeR7G/r63erdxqQPLQPkJ/xHsLbDR9YS6hq
-ujmCQW9m8lamYBfAWpkyeRyHCuR7sxi7xvVI2iDhPw7DX7XLH2c3FNa9+OvFSLx4/Q7+PpdvwEbh
-MaeR+BugJV7kJcRvfFCPTlBjxX3FgVleKzwLRdAop86HzdEfMiUvPDvM3+ujAP4ZAKuBBAbu6ATj
-DQeAYoMz04COsTam2JS3w29zGqfl8BlnrI86oX7pjBKaYwqqe06hUPMj3ePI6fIxvLx4cf766jyq
-7pBxzM/w2mnjBqD+ZpMktYuPStzFGQn7ZFrjEw3F8VF/kmnR46LqMM8cecAwT+xDDFDY0I7P08fW
-kY9LjNVFsZnl0whbigEfYxTVGnzWoRPR3WtUPYuGsAZDvQHUOM74GOgjQnhOTfQUqCGNH0/weA8/
-jsItRm4kKAkL/zu4Wc/cHK4+p0ETCtqoNdMc+P0bNbNkymqIlocItVNLeHugLU1itZpM3WNdbzKh
-b0AADUJJeTmP67QSMoOQhSJpOooOatQ9icViwivNtoKOJ1EuJF3HG+UUksRKhDgqbapK3D2gxBoE
-uj/HN6xs8YiYqPnoI0AnRCk6yZ2uqp4uWYw54NAarrNdvU6yp8dhh8g8KAegU9VQGyaKbhmjtJCV
-JgA/GAw/Pmk2yCkRO/WqDKeFLiaEbwcHB6H47/s9CsYgSvP8BlwdgNjrCVzS6y3WUM/JLlJPOZ95
-FQErTpfyIzy4pjyxfV5nlPbb0ZUWQtr/Gxi8Jg0bmg4tY8cpsZL3Q7kFb6toO/JLltAFJ5i4kahq
-9T0xmNQxkkS8CEpgP1bTJNnn8B/WYZPXeHQKk3iaUeQd8HqCYEb4FvdxOIJdot9GBYuWbSw6MBcC
-HHJlEA9H5zHpwBAgOn670XiOL7Kkair9H7ubfPrQb2UvLtEMJeI1yoSZSIsazjk8j0mb1YTfu5jT
-iwXy6ccnrSo1Z578+j7kgalByPL53KAKD80yTXNZTo05xTVLpknlgDHtEA53pgtbKL8dBT0ohaDM
-yQbMrDDbt3+yK+Ni+oY2PA/NSLrepLKX4HDaJc5a9WFR1IxPCR5LSMu55gsdC3hNeWPtCniDiT9p
-rsdib++wvnvmrM70IXyuNGhO5gMcuvjFKkfLkZ6icG4bsvCZb7ecnMcPRb+M3G1SVnWcjvVZ7zG6
-cGO7BawRtWeVdp7Ds17KCK1gsjjUldboOgybQ3lYS2lq5yH+1+F/5J7/8Y/KFDk6gMfsI4EngaSZ
-jc0ZVpOf+WgZ1p4H5GK20GELBPWVOWHS6/L2FMWJH8Tg6QgC09bpuGKDd67AAI9mGMr21IE5UbLB
-q318XfxwKgZPRuKbHdCjLQOcHLsjtMO7FoStQJ5eO3zBZzs6pyLcRePtBSIbno64v6kpURtplIbX
-bWp3qfI9EeXPLaLwUStdFfrky8YOVyC080TODh8pJITGpdGL21mLhsXjxrqKjYwVn7QV+1zxts+H
-dCcQCawbJeSoI+Oh2lHMEV6tOvh8I8o52y17RNsUVbQqzOy1Tlh9pvFrEQsAjPs2jPgWlxDfa1q4
-ftHWfURdWm3B9sTH+igcbws1DQNfBHY5YA/lQNznup/5cMvQVC36AvIFnP7wbWuHsf94ZuK67W0b
-gB2sv6TE3vMNeivpe9Z7dzW7J6m2hL3hBvPpz0p5fNTX9XfJkwOlkSxwJc3VceQEnmBNKm4K0xUd
-ujZ1hZez0fYsGqtUui4Nh7Z8Cw/6GBTNU2USLA14OfUcd1Nv6a65M0UVVG/P34qvj5+MzMFKBqQn
-8DR6+pW+ko26mcPjvgc80iEVvNT9jqP/coAlld/bvupEGzSt09bVLP5gnDkaRmNLh8b83F9r36xZ
-LPAOs4aY7Pja2xRegR8yAQ/EXEaYgy8FcWLUh66rUBrh3qb5fqd8+0oTMdglOdsU5S4l+cV8rXv1
-WwsM05GNlzG/QY+rLk5sLsvYD9zEG7h1fsQgN72neNh2oGWtbsJd0+f+u+auWwR25mZ7vjN3//Sd
-SwPdd7vF7KMBpxA0IR5Uxd6oc2s4vHl5NHI1/kiXiHQLot1WOM8tFqPTz5ScYKKauFEja5hzFU/d
-71iTdMiXm/aUCjmH41yGaE23o/jbnP4Qb4DLOPC5PWVNtTkzzXk6HqFrq8ZcNjmWi4Uax3hn2pjC
-WKpM6kQnJi56RTdeyVhtTDSD97gACMNGuhjTLbgGjgCNx3e3cmWPc0eHoKGpjtQpTFXJjBW7Dp0A
-XMQZSOpvcuBcWRqmElPJqi6LEuLNUN/wySUnfdWuDVCTHVvF6sagbnqM9IWPpB6pzsmcr+S8Z6te
-BYjAprij4Mdj+w645nFz4jwZWW6QWb2SZVw1N634u9oJBEjNCHQYF1fXSX014thiExexxDKHgxRm
-oez3ryBw86PWHUfMh1bPPZyfqIdOqX7J6XXHpgydoB+L6e4J+v3K4y8M+j34XxL0cwl/meJVBile
-j+UgpzM8Jg2F0TmdCPDvM4T/umUjQJjJRtNwgWU3lNmJ9Zo67Zd5fjMes0G/mBsvicfR+k2XVpt7
-okfUCPtx9kbpnOH7eIL7bcz6SugJIYa4C4e8aFAR/zrSGx5jEFUqEocO5ivfz4hQyADr0XOQsTKZ
-zfBKMFYhXp4Fd5S9NdDIs1WiDQKYPVdtX70/e/f+l7fOQN7Wg8FybOgw6Kb+QQLvkqrR2N2Lg7id
-AdH7rlnztu/WyzSNQDTj7ol3MIKpCPJv7sZjJMgnQy7JXMUbc+mWzPJ6seRaAJiLA81fNGOwsRXe
-lzsHI1iZcqKMJseVBJaQjCPPeTyjLKhRcuYxaTp4Rdfihb7f4nXVt3ri1i6NiZ4O7jDSroLbsk0i
-foM7XUqOoed4koBpC/Gv+L8LoPvYED7cXTyxBRC4OyfCAbGdCywI/MLFVEgrJwOsF/zNVa+XfpaZ
-N7wjyefiyH9a4Xl/ugFVcVTFd4WrSvA11qK9I77HJyy45rVEFy7LRUQ78uWUWWQA40RIYvNASxqF
-wLqyrAGHV3G/uRIfwBbolRmaDpjUpxuvzQFBvM4049GnVJ2/biO3jtkF4CtLNRR9r6kfbrDy7OEa
-zLSPp3wO0SiWMZjvBZi9ITqTj9v0vcASIqt41nizeR7PUMUZnQsYtVRV1IKBVcyLGk9J0o115iJ4
-DFVv82TG5dMooWYYvIETFEgLDO2wubckUgnh2sgZ6WNEEC9ri2cbawPkrAWoWpYk3W1thwp7hMU/
-bSLoMoBJvVDuNnSiVC2/+e7rb/ZWavHkz999+/Rbr6OZzpYb4ZyDLeG/MD8UtujYqkXr3XLz5ccs
-KYmQ/tG7B9crTV3WwQ8q/HWJrocG2D6wtRU3Dz8PxA4EHSQHr6DV67x6hU4i4TsSb2VJ1z7lGT3Y
-Uvay1zqHxf/KAOpKCgLI2vFvRAtdiG1gdAFC79LDkv/5SW/HLhXZHEbGcg48cjihRo/ngbVGbYML
-rpG3IWBNM1tOW29DmRx3wcCOU5WL8eJOeHPc1imYow36Dkq8f7KUh/YfwNBXSltw1Bn8qUUZr5RW
-ahyx8uEE/0JYdMTI0a6LyOYOGHIT2eEFhYjivjJXXkYu9m0/o2enGA8+W82ot9gBCUMTRmbcup3K
-BWn7+jD/mRT6OrkvBmm72ut/QRHoZdHRUu/5uns2vExOoGdnqJcP2PN0r/8NmF0hThhjs40ibvOv
-yjWjuGfbilwld6G9+54DUOdwE57Y6t53SV1/ZmZwEhbeTaP09MfLN8/PLokO47dnL/7n7EcqvUaJ
-bYXzD97ky/JDpvShd1rL3fDT9bJ9gzfI9lxMzSd/NYTO+06hYQ+E/lPefYvTjvTc19s6dA7LdjsB
-4run3YK6LabthdxJWembvtwa2dahrEA/5RM05pdTfWgemUohd6yeS0KeOidTuvEky0VTRWSAN/Uf
-OmDt7I1vW3VnuG5srfOA+uLpLRv3Q3sci5YPozxkTlv1YY6o2soCzv+0/20i8r7wgL+5qg3kciqd
-u4Pp2mAGVfn/CFIJkT/6U/qfGxrZf1CA2nGFi7L/UgaWqk11kNM5Yd+dn1uxOpPpFiqAumRVaa7D
-ZVSM6tT1YLaC8pESHw/pVo1DVEDX9heumk4f/jXBOsnK3iqpuIiZTRk0ntepW/to+3Q6UFaNKmry
-uXMEFbTgEVC6kW4F0oEJKbZxk43Yf6T2dc4Lj9AQJfWVsA7y6KQ42BtqPRaH2+56cO86EOLJ9oaz
-1nUKuscx91D39FC1OVDvWDo8yrHtEgfxA0HmoixBl0l6CT+sAdS7I/D19uOTE1sdgRyPrx09RBXn
-oTU6p+Kj4yfvvLvY6Y5fP/2p/DyyGyiY3B+2R7kOW2e+tueQO2dYt+SZTXkmQwq99/37i6aH9++G
-hEEbV8uBJzQzMfj0eWhn55zf1VOwT4bdaTdabBsoPpHsgqIjzF1QHb0oHpW4H9V+7hws2fDhsMFj
-e6yMboV3i2ZCR07IGfN5hHuYZH4z03Z3us/jQd0ZRdOfG7R5Ui8/iDs7I9zK36/ebibaU294YotP
-wVej9Pd/8oD+3cMPtvvxrqSPbfW090g/+7t4YgaLm9tcap5HYHlAlQ5IgT8SAyv7eElaQ0iXoZrJ
-IWNQ+EMONwZIp5gxI994rJ0KayiC/wegEfUH
+9LUzCRsvHfNU+v3T3gb9fLnMTfZIZrdJCcBBPw7Cn978fL6FbzCnCp0ervS3NsSPxwEIl11+JAry
+wO9xTbeO678xW64mR6qx786vkxo14XU/Ke5JkXh7fLyPSYHrdCmnN2NJm7PIT9jXyRO/wNeIit2z
+9UtsVDynOiGYyjStkTzsgmKB17zOprR/UEnwU3Q1JlZn0JYrZ8TmabwQA+o8w2SM5grK19zGpXbD
+ijLH+j9RJ7OjRTIT8rc6TjHalfM54IK7O/pVxMNTTka85F1jrgtTclqXSbUBGsQq15tjtMHsNJxs
+eKIDD0neBmEK4pbzibjCaeN7JtzMkMvEzP4uAE4SGIQ6ONvBET2H91k+xlHHSF7gPUJq2E6Y8OOg
+PUKutxlg/nqE9htJr9wdOFpzl6iozjxSugF4Tj4MQhkMMQHAv+mnz4kuc23BcrEdy8VuLBdtLBe9
+WC58LBe7sXRlAhe2SeYYUehL6LQz/b0lDW4uhsc5j6dLbof1dVhHBxBFYWJJI1RcZuplfHgDjICQ
+/nS2ZOlhU6KQcOFemXNaWINE9seNHR23mgJhpzMVPOjOPBXjBm4r0/D7HkURleNMqDsL3Cyu4sgT
+jEWaT0BuLbqjBsBItCs2OImY3Y4nnPBsm4y3//v+pzevsTmCshUA1A0XETU8TmVwEJcL1RWnJooq
+gB+ppV85Qd00wL3elNM+p5z2R2KfU077epg9/vMyx0It5Byxpk38XBRgrKlyxjZz60v291vPdSGK
+fs5szhsw4H9kleN7bKHS2du3L8/en4VUihL+K3RFxhDXlw8XH9PCNui6Wm5zS3Ls01jTxv65c/KI
+7bCE7vXp879jfn38/qNzBGICEpHOZ37ZFH9n9sQagU6Vk5sAYKfBvnMkwHEVHAHsy4q3B/C34dAn
+H8NctCszMPNqgrqW7rVWbgdxHKB/VADV8aQsHj2+lEMc22y7J9XdCVCyen7+48Xry4vnb8/e/+T4
+UugTvbk6OhbnP38QVIiAhoCdixi33SuseQEF7R7KELMc/qsx8zCrK84rQq+Xl5d6J2CFZflYp4m6
+O4LnXDBjoXEShxOX9qGudEGMUh0SOOcfqC6EzkdghLDi2nuV61pOOlYxQa+v1sGGPtdizr/QnmkE
+ogCNXVIwCC5mgldUcVuZOKjkLSZ9JqQHKW3rbNFBSkmqzk60s79icvleXo86w5Oms9aXH0MX1/A6
+UkWagAZ9Flpp0N2w9qLhG/3Qbp4yXn3qyOkOI+uGPOutWGBdyrOQ56b7DxtG+60GDBsGewnzziRV
+HlCxKJZRiX1stM8VBvIOvtql12ugYMFwI6nCRTRMl8DsYwgnxTIBTxx4cglGDB1ugNBaCT/HfOLY
+JJnjxn/4YjU7/EuoCeK3/vXXnuZVmR7+TRQQTgguUwl7iOk2fgkRRCQjcf7m1TBk5KZpDE7jX2os
+ZQbDTgk4R9ipNoY3Z8cDJdO5Ll3w1QG+0OaWXget/qUsSt2/38kMUQQ+fR6Q9f302RCwSaeYAUY4
+n2EbPtZqW/zwzJO7z20+e+JqKdNUF+hevLw8B08My8dRjniv5xzG5DwB7tTqWi8+k9UChfu48LpE
+Zi7RIaRt/FnkNetNnaLgUW9v59+uFqUnu706ucgyTpSL9gCnrQljCqAj5GhYErO6If7WUmrbIJ3d
+NkR3FB3mjPHbkiomfdYAlqanMYcYEHtgdbpJBPNmZZJVpkIuTaagTkHzgl4dgawgdfEIFjFgnnEq
+Ni+VObkBD4tNmSyWFWbioXNEVePY/OezD5cXr6mQ+vhp48T28OiIHOsRlymcYjEapg/gi1tahnw1
+Hrus23qFMFAJwf/ar7j+4ZQH6PTjjJq3FaBf8dGZUyey4hmAnqqLtpCgO+1065OeRhgYVxtX4set
+Mmsw88FQEg4r9XVBgTu/Livali2LQn6IefkF+wjzwhY96c5O0VP7o6c4L3D3ZTbobwRv+2TLfCbQ
+9abzZlt5lfvpSCEe4gOMuq39MUz9Uaepno7Da9uYhYJEbWl/dUMFp900Q0kGGg7czkOXx/o1sW7O
+DOiV7XaAie81ukYQ+/U5oKj9DA8TS+xO6GA6YtWheKQGXKMh9WGFGjypR4r0RygeicHAEdzRUByI
+Y2+Wjj24f5ZaeYGN/Ak0oa73pDr7vARWhC+/sQPJrwgxVKQnogkScXpZbkuR8LNeonf5xJ9lrxBQ
+VhDlroyzhRwwrJGB+ZVP7i1JTVK3HrE/Jtd9pkVcgJN6t4XHu5LRv2VgUGuxQqfdjdy09ZFPHmzQ
+e/pgJ8F88GW8BuVf1NWAV3LLfmjv8Z/tUO+HiAVu0FRvFQ9C9KB/66ul8QH3UkPDQk/vt559Evzw
+2liP1lrI1tGSfftCu7LTEkK0Su0jks6BKuOUWj+gMbmnjdEP7dOQzyrZ39bX75b3NCB5aB8gP+M9
+hLcbPtGWUFl1c0aD3szkrUzBLoC1MnX0OA5V0PdmMXaN65G0QcJ/HIa/apc/zm4orHvx14uRePH6
+Hfx9Lt+AjcJzUCPxN0BLvMhLiN/4JB8dscaS/IoDs7xWeFiKoFFOnU+joz9kamJ4dpi/12cF/EMC
+VgMJDNzRCcYrEADFBmemAZ1zbUyxqX+H3+a4TsvhM85YH3VC/dIZJTTnGFT3IEOh5ke6x5HT5WN4
+efHi/PXVeVTdIeOYn+G108YNQP3NJklqFx+VuIszEvbJtMYnGorjo/4k06LHRdVhnjkTgWGe2IcY
+oLChHR+4j60jH5cYq4tiM8unEbYUAz7nKKo1+KxDJ6K716h6Fg1hDYZ6A6hxnPEx0EeE8Jya6ClQ
+Qxo/nuD5H34chVuM3EhQEhb+d3Cznrk5XH2QgyYUtFFrpjnw+zdqZsmU1RAtDxFqp5bw9sRbmsRq
+NZm6577eZEJfkQAahJLych7XaSVkBiELRdJ0Vh3UqHtUi8WEV5ptBZ1folxIuo43yqk0iZUIcVTa
+VJW4e0CJNQh0f45vWNniGTJR89lIgE6IUnSSO11VPV2yGHPAoTVcZz97nWRPj8MOkXlQDkCnqqE2
+TBTdMkZpIStNAH4wGH580uygUyJ26pUhTgtdbQjfDg4OQvHf93sUjEGU5vkNuDoAsdcTuKTXW6yh
+npNdpJ56P/MqAlacLuVHeHBNeWL7vM4o7bejKy2EtP83MHhNGjY0HVrGjlNiJe+HcgveVtF25Jcs
+oRtQMHEjUdXqi2QwqWMkiXgRlMB+rKZJss/hP6zDJq/xbBUm8TSjyDvg9QTBjPAt7uNwBLtEv40q
+Gi3bWHRgLgQ45NIhHo4ObNKJIkB0/Haj8RxfZEnVHAV47G7y6VPBlb3ZRDOUiNcoE2YiLWo4B/U8
+Jm1WE37vYk4vFsinH5+0yticefLr+5AHpgYhy+dzgyo8NMs0zWU5NeYU1yyZJpUDxrRDONyZbnSh
+/HYU9KAUgjInGzCzwmzf/smujIvpG9rwPDQj6YKUyt6Sw2mXOGsVkEVRMz4leCwhLeeaL3Ru4DXl
+jbUr4A0m/qS5HqvBvdP87qG0OtOn9LnSoDm6D3DoZhirHC1HeorCuY7Iwme+3XK0Hj8U/TJyt0lZ
+1XE61ofBx+jCje0WsEbUHmbaeVDPeikjtILJ4lCXYqPrMGxO7WGxpSmuh/hfh/+Re0DIP0tT5OgA
+HrOPBJ4EkmY2NodcTX7mo2VYe2CQq91Chy0Q1FfmCEqvy9tTNSd+EIOnIwhMW8fnig1eygIDPJph
+KNtTKOZEyQav9vl28cOpGDwZiW92QI+2DHBy7I7QDu9aELYCeXrt8AUf/ugcm3AXjbcXiGx4fOL+
+pqaGbaRRGl63qd2lyvdElD+3iMJnsXTZ6JMvGztcgdDOEzk7fKSQEBqXRi9uZy0aFs8j6zI3MlZ8
+FFfsc0ncPp/inUAksG6UkKOOjIdqRzFnfLXq4AOQKOdst+wZblNU0aows/c+YfWZxq9FLAAw7tsw
+4mteQnyvaeH6RVv3EXXttQXbEx/rs3K8LdQ0DHwR2OWAPZQDcZ/rfubDLUNT1ugLyBdw+sO3rR3G
+/uOZiQu7t20AdrD+khp8zzfoLbXvWe/d5e6epNoa94YbzKc/K+XxUV/X3yVPDpRGssCVNHfLkRN4
+gkWruClMd3jo4tUV3t5G27NorFLpujQc2vI1PehjUDRPlUmwNODl1HPcTb2ly+jOFFVQvT1/K74+
+fjIyJy8ZkJ7A0+jpV/rONupmTpf7HvBIh1TwUvc7jv7LAZZUfm/7qhNt0LROW3e3+INx5mgYjS0d
+GvNzfzF+s2axwEvOGmKy42uvW3gFfsgEPBBzW2EOvhTEiVEfuq5CaYR7m+b7nfLtK03EYJfkbFOU
+u5TkF/O17tVvLTBMRzZexvwGPa66OLG5LGM/cBNv4Nb5EYPc9B7zYduBlrW6CXdNn/vvmrtuEdiZ
+m+35ztz943kuDXTf7RazjwacQtCEeFCZe6POreHw5uXRyNX4I10i0i2IdlvhPLdYjE4/U3KCiWri
+Ro2sYc5VPHW/Y03SId9+2lMq5JyecxmiNd2O4m9z+kO8AS7jwOf2GDbV5sw05+l4hO61GnPZ5Fgu
+Fmoc46VqYwpjqTKpE52YuOgVXYklY7Ux0Qxe9AIgDBvpYky34Bo4AjQeX+7KlT3OJR6ChqY6Uqcw
+VSUzVuw6dAJwEWcgqb/JgXNlaZhKTCWruixKiDdDfQUol5z0Vbs2QE12bBWrG4O66THSN0KSeqQ6
+J3MAk/OerXoVIAKb4o6CH4/tO+Cax82R9GRkuUFm9UqWcdVcxeLvaicQIDUj0GldXF0n9dWIY4tN
+XMQSyxwOUpiFst+/gsDNj1p3nEEfWj33cH6iHjql+iXH2x2bMnSCfiymuyfo9yuPvzDo9+B/SdDP
+JfxlincdpHh/loOczvCYNBRG53QiwL/wEP7rlo0AYSYbTcMFlt1QZifWa+q0X+b5zXjMBv1ibrwk
+HkfrN11abS6SHlEj7MfZG6Vzhu/jCe63MesroSeEGOIuHPKiQUX860hveIxBVKlIHDqYr3yBI0Ih
+A6xHz0HGymQ2wzvDWIV4eRbcUfbWQCPPVok2CGD2XLV99f7s3ftf3joDeVsPBsuxocOgm/oHCbxL
+qkZjd28W4nYGRO+7Zs3bvlsv0zQC0Yy7J97BCKYiyL/aG4+RIJ8MuSRzFW/MrVwyy+vFkmsBYC4O
+NH/RjMHGVnih7hyMYGXKiTKaHFcSWEIyjjzn8YyyoEbJmcek6eAV3ZsX+n6L11Vf+4lbuzQmejq4
+w0i7Cm7LNon4De50KTmGnuNJAqYtxL/i/y6A7mND+HB38cQWQODunAgHxHYusCDwCxdTIa2cDLBe
+8DdXvV76WWbe8I4kH5wj/2mFFwLQFamKoyq+TFxVgu+5Fu0d8T0+YcE1ryW6cFkuItqRL6fMIgMY
+J0ISmwda0igE1pVlDTi8q/vNlfgAtkCvzNB0wKQ+XYltThDifacZjz6l6vx1G7l1zC4A32mqoeiL
+T/1wg5VnD9dgpn085YOKRrGMwXwvwOwN0Zl83KbvBZYQWcWzxqvP83iGKs7oXMCopaqiFgysYl7U
+eIySrrQzN8VjqHqbJzMun0YJNcPgFZ2gQFpgaIfNvUaRSgjXRs5IHyOCeJtbPNtYGyBnLUDVsiTp
+bms7VNgjLP5pE0GXAUzqhXK3oROlavnNd19/s7dSiyd//u7bp996Hc10tlwZ5xxsCf+F+aGwRcdW
+LVrvlpsvP2ZJSYT0j949uF5p6rIOflDhr0t0PTTA9oGtrbh5+HkgdiDoIDl4Ba1e59UrdBIJ35F4
+K0u6FyrP6MGWspe91jks/mcIUFdSEEDWjn8jWuhCbAOjCxB6lx6W/M9Pejt2qcjmMDKWc+CRwwk1
+ejwPrDVqG1xwjbwNAWua2XLaehvK5LgLBnacqlyMF3fCm+O2TsEcbdCXVOIFlaU8tP9Chr5z2oKj
+zuBPLcp4pbRS44iVDyf4N8aiI0aOdl1ENnfAkJvIDm8wRBT3lbkTM3Kxb/sZPTvFeDLaaka9xQ5I
+GJowMuPW9VUuSNvXh/nPpND3zX0xSNvV3g8MikAvi46Wes/X3bPhZXICPTtDvXzAnqd7P3DA7Apx
+whibbRRxm3+XrhnFPdtW5Cq5C+3l+ByAOoeb8MRW90JM6vozM4OTsPCuIqWnP16+eX52SXQYvz17
+8T9nP1LpNUpsK5x/8CZflh8ypQ+901ruhp+ul+0bvEG25+ZqPvmrIXTedwoNeyD0n/LuW5x2pOe+
+3tahc1i22wkQ3z3tFtRtMW0v5E7KSl8F5tbItg5lBfopn6Axv5zqQ/PIVAq5Y/XcIvLUOZnSjSdZ
+LpoqIgO8qf/QAWtnb3zbqjvDdWNrnQfUN1Nv2bgf2uNYtHwY5SFz2qoPc0TVVhZw/qf9jxeR94UH
+/M1dbiCXU+lcLkz3CjOoyv9XkkqI/NGf0v8e0cj+iwPUjitclP2nNLBUbaqDnM4J++783IrVmUy3
+UAHUJatKc18uo2JUp64HsxWUj5T4eEjXbhyiArq2v3DVdPrwrwnWSVb22knFRcxsyqDxvE7d2kfb
+p9OBsmpUUZPPnSOooAWPgNKNdCuQDkxIsY2bbMT+I7Wvc154hIYoqe+MdZBHJ8XB3lDrsTjcdteD
+e9eBEE+2N5y1rlPQPY65h7qnh6rNgXrH0uFRjm2XOIgfCDIXZQm6bdJL+GENoN4dga+3H5+c2OoI
+5Hh87eghqjgPrdE5FR8dP3nn5cZOd/z66U/l55HdQMHk/rA9ynXYOvO1PYfcOcO6Jc9syjMZUui9
+799fND28f1gkDNq4Wg48oZmJwafPQzs75/yunoJ9MuxOu9Fi20DxiWQXFB1h7oLq6EXxqMT9qPZz
+52DJhg+HDR7bY2V0bbxbNBM6ckLOmM8j3MMk85uZtrvTfR4P6s4omv7coM2TevlB3NkZ4Vb+fvV2
+M9GeesMTW3wKvhqlv/+TB/TvHn6w3Y93JX1sq6e9R/rZ38UTM1jc3OZS8zwCywOqdEAK/JEYWNnH
+W9QaQroM1UwOGYPCH3K4MUA6xYwZ+cZj7VRYQxH8Pz99ANE=
 """
 )
 

--- a/virtualenv_embedded/site.py
+++ b/virtualenv_embedded/site.py
@@ -268,7 +268,7 @@ def addsitepackages(known_paths, sys_prefix=sys.prefix, exec_prefix=sys.exec_pre
                 # for framework builds *only* we add the standard Apple
                 # locations. Currently only per-user, but /Library and
                 # /Network/Library could be added too
-                if "Python.framework" in prefix:
+                if "Python.framework" in prefix or "Python3.framework" in prefix:
                     home = os.environ.get("HOME")
                     if home:
                         sitedirs.append(


### PR DESCRIPTION
Add support for MacOS 10.15 using Python3.framework for its default python. Fixes #1402

With MacOS 10.15, instead of putting Python 3.7 inside Python.framework/Versions/3.7 (similar to 2.7), they used a different prefix that needs to be handled.
Additionally, the dynamic library now uses a relative path (`@executable_path/../../../../Python3`) instead of the absolute path.

I'm able to run virtualenv locally with this fix, but some of the tests are failing locally, but there's even more test failures without this fix. I'm also not sure if there's any specific documentation that needs to be included for this fix.

## Thanks for contributing a pull request, see checklist all is good!

- [X] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [X] added news fragment in ``docs/changelog`` folder
