### PR TITLE
bugfix: allow create env with no-pip

### DIFF
--- a/docs/changelog/1430.bugfix.rst
+++ b/docs/changelog/1430.bugfix.rst
@@ -1,0 +1,1 @@
+* fix virtualenv creation when `--no-pip` argument used.

--- a/docs/changelog/1430.bugfix.rst
+++ b/docs/changelog/1430.bugfix.rst
@@ -1,1 +1,1 @@
-* fix virtualenv creation when `--no-pip` argument used.
+* fix virtualenv creation when ``--no-pip`` argument used.

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -628,6 +628,23 @@ def test_create_environment_from_venv(tmpdir):
     assert out.strip() == getattr(sys, "real_prefix", sys.prefix)
 
 
+@pytest.mark.skipif(std_venv is None, reason="needs standard venv module")
+def test_create_environment_from_venv_no_pip(tmpdir):
+    std_venv_dir = str(tmpdir / "stdvenv")
+    ve_venv_dir = str(tmpdir / "vevenv")
+    home_dir, lib_dir, inc_dir, bin_dir = virtualenv.path_locations(ve_venv_dir)
+    builder = std_venv.EnvBuilder()
+    ctx = builder.ensure_directories(std_venv_dir)
+    builder.create_configuration(ctx)
+    builder.setup_python(ctx)
+    builder.setup_scripts(ctx)
+    subprocess.check_call([ctx.env_exe, virtualenv.__file__, "--no-pip", ve_venv_dir])
+    ve_exe = os.path.join(bin_dir, "python")
+    out = subprocess.check_output([ve_exe, "-c", "import sys; print(sys.real_prefix)"], universal_newlines=True)
+    # Test against real_prefix if present - we might be running the test from a virtualenv (e.g. tox).
+    assert out.strip() == getattr(sys, "real_prefix", sys.prefix)
+
+
 def test_create_environment_with_old_pip(tmpdir):
     old = Path(__file__).parent / "old-wheels"
     old_pip = old / "pip-9.0.1-py2.py3-none-any.whl"

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -1086,7 +1086,7 @@ def _install_wheel_with_search_dir(download, project_names, py_executable, searc
         )
     ).encode("utf8")
 
-    if sys.version_info[0:2] == (3, 4):
+    if sys.version_info[0:2] == (3, 4) and "pip" in project_names:
         at = project_names.index("pip")
         project_names[at] = "pip<19.2"
 


### PR DESCRIPTION
This PR fixes a bug introduced since version 16.7.0 where creating a python virtualenv with only the `--no-pip` flag leads to the following error,

```python
Traceback (most recent call last):
  File "./virtualenv.py", line 2630, in <module>
    main()
  File "./virtualenv.py", line 870, in main
    symlink=options.symlink,
  File "./virtualenv.py", line 1175, in create_environment
    install_wheel(to_install, py_executable, search_dirs, download=download)
  File "./virtualenv.py", line 1019, in install_wheel
    _install_wheel_with_search_dir(download, project_names, py_executable, search_dirs)
  File "./virtualenv.py", line 1090, in _install_wheel_with_search_dir
    at = project_names.index("pip")
ValueError: 'pip' is not in list
``` 

# Details

Recent introduction of pinning the pip version to "<19.2" in order to support deprecated python 3.4 introduces this bug.

If the `--no-pip` argument is passed,  "pip" will no longer be in the project_names,
  
```python
 if sys.version_info[0:2] == (3, 4):
        at = project_names.index("pip")
        project_names[at] = "pip<19.2"
```
accessing `project_names.index("pip")`  raises a ValueError.

## Tests
The tests did not pick this up since all to_install projects where excluded  with the arguments
"--no-setuptools", "--no-pip", "--no-wheel"

which does not follow the following codepath 
```python
if to_install:
    install_wheel(to_install, py_executable, search_dirs, download=download)
```
