### PR TITLE
Fix creation of 32-bit environment with dual-architecture python on macOS

### DIFF
--- a/docs/changelog/1438.bugfix.rst
+++ b/docs/changelog/1438.bugfix.rst
@@ -1,0 +1,1 @@
+Fix creation of 32-bit environment with dual-architecture python on macOS


### PR DESCRIPTION
Fixes #1437

When using official `python.org` `macOS 64-bit/32-bit installer`, creating a virtual environment from a 32-bit interpreter (`pythonX.Y-32 -m virtualenv .venv`) results in a 64-bit virtual environment when host supports 64-bit. This PR aims to check wether we're running 32/64 bit interpreter and pull the right interpreter if running 32-bit by thinning the original interpreter for `i386`.

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] added news fragment in ``docs/changelog`` folder

I think there's no need for a documentation update for this bug fix. News fragment should be enough.
