### PR TITLE
Remove macOS python 3.4 CI tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
       py35:
         image: [linux, windows, macOs]
       py34:
-        image: [linux, windows, macOs]
+        image: [linux, windows]
       py27:
         image: [linux, windows, macOs]
       dev: null


### PR DESCRIPTION
python 3.4 removed from macOS Azure Pipelines
c.f. https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md
