### PR TITLE
Improve executable discovery of a PythonInfo inside a given folder

### DIFF
--- a/tests/unit/interpreters/create/conftest.py
+++ b/tests/unit/interpreters/create/conftest.py
@@ -28,7 +28,9 @@ def get_venv(tmp_path_factory):
         root_python = get_root(tmp_path_factory)
         dest = tmp_path_factory.mktemp("venv")
         subprocess.check_call([str(root_python), "-m", "venv", "--without-pip", str(dest)])
-        return CURRENT.find_exe(str(dest))
+        # sadly creating a virtual environment does not tell us where the executable lives in general case
+        # so discover using some heuristic
+        return CURRENT.find_exe_based_of(inside_folder=str(dest))
 
 
 def get_virtualenv(tmp_path_factory):
@@ -41,14 +43,14 @@ def get_virtualenv(tmp_path_factory):
         virtualenv_at = str(tmp_path_factory.mktemp("venv-for-virtualenv"))
         builder = EnvBuilder(symlinks=not IS_WIN)
         builder.create(virtualenv_at)
-        venv_for_virtualenv = CURRENT.find_exe(virtualenv_at)
+        venv_for_virtualenv = CURRENT.find_exe_based_of(inside_folder=virtualenv_at)
         cmd = venv_for_virtualenv, "-m", "pip", "install", "virtualenv==16.6.1"
         subprocess.check_call(cmd)
 
         virtualenv_python = tmp_path_factory.mktemp("virtualenv")
         cmd = venv_for_virtualenv, "-m", "virtualenv", virtualenv_python
         subprocess.check_call(cmd)
-        return CURRENT.find_exe(virtualenv_python)
+        return CURRENT.find_exe_based_of(inside_folder=virtualenv_python)
 
 
 PYTHON = {"root": get_root, "venv": get_venv, "virtualenv": get_virtualenv}

--- a/tests/unit/interpreters/discovery/py_info/test_py_info_exe_based_of.py
+++ b/tests/unit/interpreters/discovery/py_info/test_py_info_exe_based_of.py
@@ -1,0 +1,33 @@
+import logging
+import os
+import sys
+
+import pytest
+
+from virtualenv.interpreters.discovery.py_info import CURRENT, EXTENSIONS
+
+
+def test_discover_empty_folder(tmp_path, monkeypatch):
+    with pytest.raises(RuntimeError):
+        CURRENT.find_exe_based_of(inside_folder=str(tmp_path))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink is not guaranteed to work on windows")
+@pytest.mark.parametrize("suffix", EXTENSIONS)
+@pytest.mark.parametrize("arch", [CURRENT.architecture, ""])
+@pytest.mark.parametrize("version", [".".join(str(i) for i in CURRENT.version_info[0:i]) for i in range(3, 0, -1)])
+@pytest.mark.parametrize("impl", [CURRENT.implementation, "python"])
+@pytest.mark.parametrize("into", [CURRENT.prefix[len(CURRENT.executable) :], ""])
+def test_discover_ok(tmp_path, monkeypatch, suffix, impl, version, arch, into, caplog):
+    caplog.set_level(logging.DEBUG)
+    folder = tmp_path / into
+    folder.mkdir(parents=True, exist_ok=True)
+    dest = folder / "{}{}".format(impl, version, arch, suffix)
+    os.symlink(CURRENT.executable, str(dest))
+    inside_folder = str(tmp_path)
+    assert CURRENT.find_exe_based_of(inside_folder) == str(dest)
+    assert not caplog.text
+
+    dest.rename(dest.parent / (dest.name + "-1"))
+    with pytest.raises(RuntimeError):
+        CURRENT.find_exe_based_of(inside_folder)


### PR DESCRIPTION
- Use architecture, version, implementation and platform extensions for candidates
- Cache PythonInfo.from_exe by path (resolving symlinks)
- Ensure what we discover has the same version, implementation and architecture.
- Improve our test suite for this functionality.