### PR TITLE
Reverse vendored wheel lookup order

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,8 @@ jobs:
       cross_python2: null
       cross_python3: null
       docs: null
+      py38:
+        image: [linux, windows, macOs]
       py37:
         image: [linux, windows, macOs]
       py36:
@@ -48,10 +50,10 @@ jobs:
       package_readme: null
     before:
       - script: 'sudo apt-get update -y && sudo apt-get install fish csh'
-        condition: and(succeeded(), eq(variables['image_name'], 'linux'), in(variables['TOXENV'], 'py37', 'py36', 'py35', 'py34', 'py27'))
+        condition: and(succeeded(), eq(variables['image_name'], 'linux'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py34', 'py27'))
         displayName: install fish and csh via apt-get
       - script: 'brew update -vvv && brew install fish tcsh'
-        condition: and(succeeded(), eq(variables['image_name'], 'macOs'), in(variables['TOXENV'], 'py37', 'py36', 'py35', 'py34', 'py27'))
+        condition: and(succeeded(), eq(variables['image_name'], 'macOs'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py34', 'py27'))
         displayName: install fish and csh via brew
     coverage:
       with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -990,8 +990,12 @@ def find_wheels(projects, search_dirs):
             # The pattern could be tightened to require -py2.py3-none-any.whl.
             files = glob.glob(os.path.join(dirname, "{}-*.whl".format(project)))
             if files:
-                versions = sorted(
-                    [(tuple(int(i) for i in os.path.basename(f).split("-")[1].split(".")), f) for f in files]
+                versions = list(
+                    reversed(
+                        sorted(
+                            [(tuple(int(i) for i in os.path.basename(f).split("-")[1].split(".")), f) for f in files]
+                        )
+                    )
                 )
                 if project == "pip" and sys.version_info[0:2] == (3, 4):
                     wheel = next(p for v, p in versions if v <= (19, 1, 1))


### PR DESCRIPTION
On cursory testing, appears to fix #1449 (pip execution error on virtualenv creation in python 3.9.0a1).

Rationale described [here](https://github.com/pypa/virtualenv/issues/1449#issuecomment-556819840).

@gaborbernat, if you think this is sufficiently durable an approach, I can flesh out the PR. Not sure how to get it under CI, though, save with a full Python 3.9 build... looks like deadsnakes doesn't have 3.9 yet.

## Thanks for contributing a pull request, see checklist all is good!

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added news fragment in ``docs/changelog`` folder
 