### PR TITLE
python 3.4 no longer supported on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,6 @@ jobs:
         image: [linux, windows, macOs]
       py35:
         image: [linux, windows, macOs]
-      py34:
-        image: [linux, windows]
       py27:
         image: [linux, windows, macOs]
       dev: null
@@ -64,7 +62,7 @@ jobs:
         displayName: install fish and csh via brew
     coverage:
       with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run
-      for_envs: [py37, py36, py35, py34, py27]
+      for_envs: [py38, py37, py36, py35, py27]
 
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
   - template: publish-pypi.yml@tox


### PR DESCRIPTION
Did not remove from tox, as we still support it, but we'll need to amend the CI to support it probably via some backport 🤔. Not sure what's the best path ahead here.