### PR TITLE
Cross version compatibility

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,11 +58,21 @@ jobs:
       dev: null
     before:
       - script: 'sudo apt-get update -y && sudo apt-get install fish csh'
-        condition: and(succeeded(), eq(variables['image_name'], 'linux'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py34', 'py27'))
+        condition: and(succeeded(), eq(variables['image_name'], 'linux'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py27'))
         displayName: install fish and csh via apt-get
       - script: 'brew update -vvv && brew install fish tcsh'
-        condition: and(succeeded(), eq(variables['image_name'], 'macOs'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py34', 'py27'))
+        condition: and(succeeded(), eq(variables['image_name'], 'macOs'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py27'))
         displayName: install fish and csh via brew
+      - task: UsePythonVersion@0
+        condition: and(succeeded(), in(variables['TOXENV'], 'py27'))
+        displayName: provision python 3
+        inputs:
+          versionSpec: '3.8'
+      - task: UsePythonVersion@0
+        condition: and(succeeded(), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35'))
+        displayName: provision python 2
+        inputs:
+          versionSpec: '2.7'
     coverage:
       with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run
       for_envs: [py38, py37, py36, py35, py27]

--- a/src/virtualenv/interpreters/discovery/py_spec.py
+++ b/src/virtualenv/interpreters/discovery/py_spec.py
@@ -6,7 +6,7 @@ import re
 import sys
 from collections import OrderedDict
 
-PATTERN = re.compile(r"^(?P<impl>[a-zA-Z]+)(?P<version>[0-9.]+)?(?:-(?P<arch>32|64))?$")
+PATTERN = re.compile(r"^(?P<impl>[a-zA-Z]+)?(?P<version>[0-9.]+)?(?:-(?P<arch>32|64))?$")
 IS_WIN = sys.platform == "win32"
 
 

--- a/src/virtualenv/interpreters/discovery/windows/__init__.py
+++ b/src/virtualenv/interpreters/discovery/windows/__init__.py
@@ -5,13 +5,17 @@ from ..py_spec import PythonSpec
 from .pep514 import discover_pythons
 
 
+class Pep514PythonInfo(PythonInfo):
+    """"""
+
+
 def propose_interpreters(spec):
     # see if PEP-514 entries are good
     for name, major, minor, arch, exe, _ in discover_pythons():
         # pre-filter
         registry_spec = PythonSpec(None, name, major, minor, None, arch, exe)
         if registry_spec.satisfies(spec):
-            interpreter = PythonInfo.from_exe(exe, raise_on_error=False)
+            interpreter = Pep514PythonInfo.from_exe(exe, raise_on_error=False)
             if interpreter is not None:
                 if interpreter.satisfies(spec, impl_must_match=True):
                     yield interpreter

--- a/src/virtualenv/run.py
+++ b/src/virtualenv/run.py
@@ -26,6 +26,7 @@ def session_via_cli(args):
     options, verbosity = _do_report_setup(parser, args)
     discover = _get_discover(parser, args, options)
     interpreter = discover.interpreter
+    logging.debug("target interpreter %r", interpreter)
     if interpreter is None:
         raise RuntimeError("failed to find interpreter for {}".format(discover))
     elements = [
@@ -83,8 +84,9 @@ def _get_creator(interpreter, parser, options):
     creator_parser = parser.add_argument_group("creator options")
     creator_parser.add_argument(
         "--creator",
-        choices=list(creators.keys()),
-        default=next((c for c in creators if c != "venv"), None),
+        choices=list(creators),
+        # prefer the built-in venv if present, otherwise fallback to first defined type
+        default="venv" if "venv" in creators else next(iter(creators), None),
         required=False,
         help="create environment via",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ import coverage
 import pytest
 from pathlib2 import Path
 
+from virtualenv.interpreters.discovery.py_info import PythonInfo
+
 
 @pytest.fixture(scope="session")
 def has_symlink_support(tmp_path_factory):
@@ -77,6 +79,12 @@ def check_cwd_not_changed_by_test():
     new = os.getcwd()
     if old != new:
         pytest.fail("tests changed cwd: {!r} => {!r}".format(old, new))
+
+
+@pytest.fixture(autouse=True)
+def ensure_py_info_cache_empty():
+    yield
+    PythonInfo._cache_from_exe.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -207,3 +215,8 @@ class EnableCoverage(object):
                 clean()
         assert not self.cov_pth.exists()
         assert self._COV_FILE.exists()
+
+
+@pytest.fixture(scope="session")
+def is_inside_ci():
+    yield "CI_RUN" in os.environ

--- a/tests/unit/activation/conftest.py
+++ b/tests/unit/activation/conftest.py
@@ -172,16 +172,13 @@ def activation_python(tmp_path_factory):
     return session
 
 
-IS_INSIDE_CI = "CI_RUN" in os.environ
-
-
 @pytest.fixture()
-def activation_tester(activation_python, monkeypatch, tmp_path):
+def activation_tester(activation_python, monkeypatch, tmp_path, is_inside_ci):
     def _tester(tester_class):
         tester = tester_class(activation_python)
         if not tester.of_class.supports(activation_python.creator.interpreter):
             pytest.skip("{} not supported on current environment".format(tester.of_class.__name__))
-        version = tester.get_version(raise_on_fail=IS_INSIDE_CI)
+        version = tester.get_version(raise_on_fail=is_inside_ci)
         if not isinstance(version, six.string_types):
             pytest.skip(msg=six.text_type(version))
         return tester(monkeypatch, tmp_path)

--- a/tests/unit/interpreters/create/test_creator.py
+++ b/tests/unit/interpreters/create/test_creator.py
@@ -11,7 +11,8 @@ from pathlib2 import Path
 
 from virtualenv.__main__ import run
 from virtualenv.interpreters.create.creator import DEBUG_SCRIPT, get_env_debug_info
-from virtualenv.interpreters.discovery.py_info import CURRENT
+from virtualenv.interpreters.discovery.builtin import get_interpreter
+from virtualenv.interpreters.discovery.py_info import CURRENT, PythonInfo
 from virtualenv.pyenv_cfg import PyEnvCfg
 from virtualenv.run import run_via_cli, session_via_cli
 
@@ -169,7 +170,7 @@ def test_debug_bad_virtualenv(tmp_path):
 @pytest.mark.parametrize("clear", [True, False], ids=["clear", "no_clear"])
 def test_create_clear_resets(tmp_path, use_venv, clear):
     marker = tmp_path / "magic"
-    cmd = [str(tmp_path), "--without-pip"]
+    cmd = [str(tmp_path), "--seeder", "none"]
     if use_venv:
         cmd.extend(["--creator", "venv"])
     run_via_cli(cmd)
@@ -181,16 +182,15 @@ def test_create_clear_resets(tmp_path, use_venv, clear):
     assert marker.exists() is not clear
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize(
     "use_venv", [False, True] if six.PY3 else [False], ids=["no_venv", "venv"] if six.PY3 else ["no_venv"]
 )
 @pytest.mark.parametrize("prompt", [None, "magic"])
 def test_prompt_set(tmp_path, use_venv, prompt):
-    cmd = [str(tmp_path), "--without-pip"]
+    cmd = [str(tmp_path), "--seeder", "none"]
     if prompt is not None:
         cmd.extend(["--prompt", "magic"])
-    if not use_venv:
+    if not use_venv and six.PY3:
         cmd.extend(["--creator", "venv"])
 
     result = run_via_cli(cmd)
@@ -202,3 +202,23 @@ def test_prompt_set(tmp_path, use_venv, prompt):
         if use_venv is False:
             assert "prompt" in cfg, list(cfg.content.keys())
             assert cfg["prompt"] == actual_prompt
+
+
+@pytest.fixture(scope="session")
+def cross_python(is_inside_ci):
+    spec = "{}{}".format(CURRENT.implementation, 2 if CURRENT.version_info.major == 3 else 3)
+    interpreter = get_interpreter(spec)
+    if interpreter is None:
+        msg = "could not find {}".format(spec)
+        if is_inside_ci:
+            raise RuntimeError(msg)
+        pytest.skip(msg=msg)
+    yield interpreter
+
+
+def test_cross_major(cross_python, coverage_env, tmp_path):
+    cmd = ["-v", "-v", "-p", str(cross_python.executable), str(tmp_path), "--seeder", "none", "--activators", ""]
+    result = run_via_cli(cmd)
+    coverage_env()
+    env = PythonInfo.from_exe(str(result.creator.exe))
+    assert env.version_info.major != CURRENT.version_info.major

--- a/tests/unit/interpreters/discovery/test_discovery.py
+++ b/tests/unit/interpreters/discovery/test_discovery.py
@@ -11,13 +11,13 @@ from virtualenv.interpreters.discovery.py_info import CURRENT
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="symlink is not guaranteed to work on windows")
-@pytest.mark.parametrize("lower", [None, True, False])
-def test_discovery_via_path(tmp_path, monkeypatch, lower):
+@pytest.mark.parametrize("case", ["mixed", "lower", "upper"])
+def test_discovery_via_path(tmp_path, monkeypatch, case):
     core = "somethingVeryCryptic{}".format(".".join(str(i) for i in CURRENT.version_info[0:3]))
     name = "somethingVeryCryptic"
-    if lower is True:
+    if case == "lower":
         name = name.lower()
-    elif lower is False:
+    elif case == "upper":
         name = name.upper()
     exe_name = "{}{}{}".format(name, CURRENT.version_info.major, ".exe" if sys.platform == "win32" else "")
     executable = tmp_path / exe_name

--- a/tests/unit/interpreters/discovery/test_py_spec.py
+++ b/tests/unit/interpreters/discovery/test_py_spec.py
@@ -22,7 +22,7 @@ def test_bad_py_spec():
 
 
 def test_py_spec_first_digit_only_major():
-    spec = PythonSpec.from_string_spec("python278")
+    spec = PythonSpec.from_string_spec("278")
     assert spec.major == 2
     assert spec.minor == 78
 


### PR DESCRIPTION
To get this working needed:

- allow version only specifier
- use original executable instead of the executable for source python (python 2 requires to copy the executable itself, not a shell script)
- when selecting an interpreter first check each candidate per path rather than for each candidate all path
- add a test