### PR TITLE
added sys._enablelegacywindowsfsencoding()

### DIFF
--- a/virtualenv.py
+++ b/virtualenv.py
@@ -884,6 +884,9 @@ def call_subprocess(
     remove_from_env=None,
     stdin=None,
 ):
+    
+    sys._enablelegacywindowsfsencoding()
+    
     cmd_parts = []
     for part in cmd:
         if len(part) > 45:


### PR DESCRIPTION
Without this fix UnicodeDecodeError triggers oin line 944 on Windows (Python 3.8.1) while trying to decode Windows-1251 encoded error message.

See PEP 529 for more details

## Thanks for contributing a pull request, see checklist all is good!

- [+ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added news fragment in ``docs/changelog`` folder
