### PR TITLE
more robust exe discovery in pyinfo

### DIFF
--- a/src/virtualenv/interpreters/discovery/py_info.py
+++ b/src/virtualenv/interpreters/discovery/py_info.py
@@ -190,7 +190,7 @@ class PythonInfo(object):
 
     def _find_possible_exe_names(self):
         name_candidate = OrderedDict()
-        for name in [self.implementation, "python"]:
+        for name in self._possible_base():
             for at in (3, 2, 1, 0):
                 version = ".".join(str(i) for i in self.version_info[:at])
                 for arch in ["-{}".format(self.architecture), ""]:
@@ -198,6 +198,26 @@ class PythonInfo(object):
                         candidate = "{}{}{}{}".format(name, version, arch, ext)
                         name_candidate[candidate] = None
         return list(name_candidate.keys())
+
+    def _possible_base(self):
+        possible_base = OrderedDict()
+        possible_base[os.path.splitext(os.path.basename(self.executable))[0]] = None
+        possible_base[self.implementation] = None
+        # python is always the final option as in practice is used by multiple implementation as exe name
+        if "python" in possible_base:
+            del possible_base["python"]
+        possible_base["python"] = None
+        for base in possible_base:
+            lower = base.lower()
+            yield lower
+            from virtualenv.info import is_fs_case_sensitive
+
+            if is_fs_case_sensitive():
+                if base != lower:
+                    yield base
+                upper = base.upper()
+                if upper != base:
+                    yield upper
 
     _cache_from_exe = {}
 

--- a/tests/unit/interpreters/discovery/py_info/test_py_info_exe_based_of.py
+++ b/tests/unit/interpreters/discovery/py_info/test_py_info_exe_based_of.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 
+from virtualenv.info import is_fs_case_sensitive
 from virtualenv.interpreters.discovery.py_info import CURRENT, EXTENSIONS
 
 
@@ -27,8 +28,13 @@ def test_discover_ok(tmp_path, monkeypatch, suffix, impl, version, arch, into, c
     dest = folder / "{}{}".format(impl, version, arch, suffix)
     os.symlink(CURRENT.executable, str(dest))
     inside_folder = str(tmp_path)
-    assert CURRENT.find_exe_based_of(inside_folder) == str(dest)
-    assert len(caplog.messages) == 1
+    found = CURRENT.find_exe_based_of(inside_folder)
+    dest_str = str(dest)
+    if not is_fs_case_sensitive():
+        found = found.lower()
+        dest_str = dest_str.lower()
+    assert found == dest_str
+    assert len(caplog.messages) >= 1, caplog.text
     assert "get interpreter info via cmd: " in caplog.text
 
     dest.rename(dest.parent / (dest.name + "-1"))


### PR DESCRIPTION
We should assume first it's same as ``sys.executable`` base name unless it's python, then the implementation name, and finally with python. Also, generate lower/upper case variants on filesystems that are case sensitive. Resolves an issue discovered by @rlamy 👍 