### PR TITLE
Make single verbosity output cleaner

### DIFF
--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -47,7 +47,7 @@ def get_interpreter(key):
         if interpreter.executable not in proposed_paths:
             logging.info("proposed %s", interpreter)
             if interpreter.satisfies(spec, impl_must_match):
-                logging.info("accepted target interpreter %s", interpreter)
+                logging.debug("accepted target interpreter %s", interpreter)
                 return interpreter
             proposed_paths.add(interpreter.executable)
 

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -114,7 +114,7 @@ class PythonSpec(object):
             type(self).__name__,
             ", ".join(
                 "{}={}".format(k, getattr(self, k))
-                for k in ("str_spec", "implementation", "major", "minor", "patch", "architecture", "path")
+                for k in ("implementation", "major", "minor", "patch", "architecture", "path")
                 if getattr(self, k) is not None
             ),
         )

--- a/src/virtualenv/seed/via_app_data/via_app_data.py
+++ b/src/virtualenv/seed/via_app_data/via_app_data.py
@@ -95,4 +95,4 @@ class FromAppData(BaseEmbed):
         return CopyPipInstall
 
     def __unicode__(self):
-        return super(FromAppData, self).__unicode__() + " app_data_dir={}".format(self.app_data_dir)
+        return super(FromAppData, self).__unicode__() + " app_data_dir={}".format(self.app_data_dir.path)


### PR DESCRIPTION
Following feedback from https://github.com/pypa/virtualenv/issues/1510, now does not contain same information multiple times:

```
find interpreter for spec PythonSpec(path=/Users/bgabor8/git/github/virtualenv/.tox/dev/bin/python)
proposed PythonInfo(spec=CPython3.8.1.final.0-64, exe=/Users/bgabor8/git/github/virtualenv/.tox/dev/bin/python, platform=darwin, version='3.8.1 (default, Jan 17 2020, 10:06:39) \n[Clang 11.0.0 (clang-1100.0.33.16)]', encoding_fs_io=utf-8-utf-8)
create virtual environment via CPython3Posix(dest=/Users/bgabor8/git/github/virtualenv/venv, global=False, clear=False)
add seed packages via FromAppData pip=latest setuptools=latest wheel=latest app_data_dir=/Users/bgabor8/Library/Application Support/virtualenv/seed-v1
add activators for Bash, CShell, Fish, PowerShell, Python, Xonsh
done in 53ms
```