### PR TITLE
pth files are not processed on Ubuntu under Python 2 #1517

### DIFF
--- a/docs/changelog/1517.bugfix.rst
+++ b/docs/changelog/1517.bugfix.rst
@@ -1,0 +1,1 @@
+pth files were not processed under Debian CPython2 interpreters - by ``gaborbernat``.


### PR DESCRIPTION
If the host platfrom and pure library paths differed from the
distutils installs ones, we patched the sys.path by appending the
missing paths, this did not trigger the pth processing though.
Changed to use the site.add_site_dir to solve the problem.

Resolves #1518. 
Resolves #1517.