### PR TITLE
Support relative paths for the python specification string.

### DIFF
--- a/docs/changelog/1514.bugfix.rst
+++ b/docs/changelog/1514.bugfix.rst
@@ -1,0 +1,1 @@
+Support relative paths for ``-p`` - by ``gaborbernat``.

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -65,7 +65,7 @@ class PythonSpec(object):
                     arch = _int_or_none(groups["arch"])
 
             if not ok:
-                path = string_spec
+                path = os.path.abspath(string_spec)
 
         return cls(string_spec, impl, major, minor, patch, arch, path)
 

--- a/tests/unit/discovery/test_py_spec.py
+++ b/tests/unit/discovery/test_py_spec.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import itertools
+import os
 import sys
 from copy import copy
 
@@ -104,3 +105,10 @@ def test_version_satisfies_nok(req, spec):
     req_spec = PythonSpec.from_string_spec("python{}".format(req))
     sat_spec = PythonSpec.from_string_spec("python{}".format(spec))
     assert sat_spec.satisfies(req_spec) is False
+
+
+def test_relative_spec(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    a_relative_path = str((tmp_path / "a" / "b").relative_to(tmp_path))
+    spec = PythonSpec.from_string_spec(a_relative_path)
+    assert spec.path == os.path.abspath(str(tmp_path / a_relative_path))


### PR DESCRIPTION
The python info discovery mechanism does not work with relative paths,
normalize python specification strings to always be absolute paths.

Resolves https://github.com/pypa/virtualenv/issues/1514.