### PR TITLE
fish prompt: preserve pipestatus

### DIFF
--- a/src/virtualenv/activation/fish/activate.fish
+++ b/src/virtualenv/activation/fish/activate.fish
@@ -82,8 +82,8 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
     functions -c fish_prompt _old_fish_prompt
 
     function fish_prompt
-        # Save the current $status, for fish_prompts that display it.
-        set -l old_status $status
+        # Run the user's prompt first; it might depend on (pipe)status.
+        set -l prompt (_old_fish_prompt)
 
         # Prompt override provided?
         # If not, just prepend the environment name.
@@ -93,9 +93,7 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
             printf '%s(%s) ' (set_color normal) (basename '$VIRTUAL_ENV')
         end
 
-        # Restore the original $status
-        echo "exit $old_status" | source
-        _old_fish_prompt
+        string join -- \n $prompt # handle multi-line prompts
     end
 
     set -gx _OLD_FISH_PROMPT_OVERRIDE "$VIRTUAL_ENV"


### PR DESCRIPTION
The upcoming release fish 3.1.0 provides a variable $pipestatus, that
exposes the exit code of each process in a pipeline. This $pipestatus
is also used by the new default prompt.

Presently, $status is restored but not $pipestatus, so a prompt displaying
the pipestatus is wrong:

expected:

	(env) $ false | true | false
	(env) [1|0|1] $

actual:

	(env) $ false | true | false
	(env) [0|1] $

The wrong $pipestatus is because `echo 'exit 1' | source` is used
to restore the $status.
This commit solves this problem more elegantly by running the user's
prompt immediately, and printing it later.
Uses the fish builtin "string" command which exists since fish 2.3b1
(released April 19, 2016) so that's unlikely to cause problems.

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added news fragment in ``docs/changelog`` folder
