### PR TITLE
Stable order in pyenv.cfg, include-system-site-packages only for ref

### DIFF
--- a/docs/changelog/1535.bugfix.rst
+++ b/docs/changelog/1535.bugfix.rst
@@ -1,0 +1,2 @@
+Stable order within ``pyenv.cfg`` and add ``include-system-site-packages`` only for creators that reference a global
+Python - by ``gaborbernat``.

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -32,7 +32,6 @@ class Creator(object):
         self.interpreter = interpreter
         self._debug = None
         self.dest = Path(options.dest)
-        self.enable_system_site_package = options.system_site
         self.clear = options.clear
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
 
@@ -45,7 +44,6 @@ class Creator(object):
     def _args(self):
         return [
             ("dest", six.ensure_text(str(self.dest))),
-            ("global", self.enable_system_site_package),
             ("clear", self.clear),
         ]
 
@@ -58,15 +56,8 @@ class Creator(object):
             "--clear",
             dest="clear",
             action="store_true",
-            help="clear out the non-root install and start from scratch",
+            help="remove the destination directory if exist before starting (will overwrite files otherwise)",
             default=False,
-        )
-        parser.add_argument(
-            "--system-site-packages",
-            default=False,
-            action="store_true",
-            dest="system_site",
-            help="give the virtual environment access to the system site-packages dir",
         )
 
     @classmethod
@@ -151,13 +142,11 @@ class Creator(object):
         return True
 
     def set_pyenv_cfg(self):
-        self.pyenv_cfg.content = {
-            "home": self.interpreter.system_exec_prefix,
-            "include-system-site-packages": "true" if self.enable_system_site_package else "false",
-            "implementation": self.interpreter.implementation,
-            "version_info": ".".join(str(i) for i in self.interpreter.version_info),
-            "virtualenv": __version__,
-        }
+        self.pyenv_cfg.content = OrderedDict()
+        self.pyenv_cfg["home"] = self.interpreter.system_exec_prefix
+        self.pyenv_cfg["implementation"] = self.interpreter.implementation
+        self.pyenv_cfg["version_info"] = ".".join(str(i) for i in self.interpreter.version_info)
+        self.pyenv_cfg["virtualenv"] = __version__
 
     @property
     def debug(self):

--- a/src/virtualenv/create/via_global_ref/api.py
+++ b/src/virtualenv/create/via_global_ref/api.py
@@ -12,10 +12,18 @@ class ViaGlobalRefApi(Creator):
     def __init__(self, options, interpreter):
         super(ViaGlobalRefApi, self).__init__(options, interpreter)
         self.symlinks = getattr(options, "copies", False) is False
+        self.enable_system_site_package = options.system_site
 
     @classmethod
     def add_parser_arguments(cls, parser, interpreter, meta):
         super(ViaGlobalRefApi, cls).add_parser_arguments(parser, interpreter, meta)
+        parser.add_argument(
+            "--system-site-packages",
+            default=False,
+            action="store_true",
+            dest="system_site",
+            help="give the virtual environment access to the system site-packages dir",
+        )
         group = parser.add_mutually_exclusive_group()
         if meta.can_symlink:
             group.add_argument(
@@ -34,3 +42,10 @@ class ViaGlobalRefApi(Creator):
                 dest="copies",
                 help="try to use copies rather than symlinks, even when symlinks are the default for the platform",
             )
+
+    def _args(self):
+        return super(ViaGlobalRefApi, self)._args() + [("global", self.enable_system_site_package)]
+
+    def set_pyenv_cfg(self):
+        super(ViaGlobalRefApi, self).set_pyenv_cfg()
+        self.pyenv_cfg["include-system-site-packages"] = "true" if self.enable_system_site_package else "false"

--- a/src/virtualenv/pyenv_cfg.py
+++ b/src/virtualenv/pyenv_cfg.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import logging
+from collections import OrderedDict
 
 import six
 
@@ -16,12 +17,12 @@ class PyEnvCfg(object):
 
     @classmethod
     def from_file(cls, path):
-        content = cls._read_values(path) if path.exists() else {}
+        content = cls._read_values(path) if path.exists() else OrderedDict()
         return PyEnvCfg(content, path)
 
     @staticmethod
     def _read_values(path):
-        content = {}
+        content = OrderedDict()
         for line in path.read_text(encoding="utf-8").splitlines():
             equals_at = line.index("=")
             key = line[:equals_at].strip()


### PR DESCRIPTION
Previously the order was dictionary order depdendent, so not stable
accross Python implementations, and we also set the include system
site package for all creators, should be only for ref creators.