### PR TITLE
Documentation theme updates

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,8 +1,3 @@
-.wy-nav-content {
-    max-width: 51.5em;
-    padding: 1em;
-}
-
 #virtualenv img {
     margin-bottom: 6px;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -57,6 +57,8 @@ div[class*="highlight-"] {
     margin-top: 24px;
 }
 
+/* Reduce whitespace on the inline-code snippets and add softer corners */
 .rst-content code {
-    padding: 2px;
+    padding: 2px 3px;
+    border-radius: 3px;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,7 @@
+.wy-nav-content {
+    padding: 1em;
+}
+
 #virtualenv img {
     margin-bottom: 6px;
 }
@@ -9,13 +13,9 @@
     padding: 8px 6px !important;
 }
 
-/* Override table width restrictions */
-.wy-table-responsive {
-    overflow: visible !important;
-}
 .wy-table-responsive table {
-    margin-left: -1em !important;
     width: calc(100% + 3em);
+    margin-left: 20px !important;
 }
 
 .rst-content table.docutils td ol {
@@ -36,12 +36,12 @@ div[class*="highlight-"] {
 
 /* Tweak whitespace on the release history page */
 #release-history p {
-    margin-bottom: 2px;
-    margin-top: 2px;
+    margin-bottom: 0;
+    margin-top: 0;
 }
 
 #release-history h3 {
-    margin-bottom: 12px;
+    margin-bottom: 6px;
 }
 
 #release-history ul {
@@ -54,7 +54,6 @@ div[class*="highlight-"] {
 
 #release-history h2 {
     margin-bottom: 12px;
-    margin-top: 24px;
 }
 
 /* Reduce whitespace on the inline-code snippets and add softer corners */

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -2,16 +2,20 @@
     margin-bottom: 6px;
 }
 
-/* override table width restrictions */
+/* Allow table content to wrap around */
 .wy-table-responsive table th, .wy-table-responsive table td {
-    /* !important prevents the common CSS stylesheets from
-       overriding this as on RTD they are loaded after this stylesheet */
+    /* !important because RTD has conflicting stylesheets */
     white-space: normal !important;
-    padding: 6px !important;
+    padding: 8px 6px !important;
 }
 
+/* Override table width restrictions */
 .wy-table-responsive {
     overflow: visible !important;
+}
+.wy-table-responsive table {
+    margin-left: -1em !important;
+    width: calc(100% + 3em);
 }
 
 .rst-content table.docutils td ol {
@@ -28,10 +32,6 @@
 
 div[class*="highlight-"] {
     margin-bottom: 12px;
-}
-
-table {
-    margin-left: 20px !important;
 }
 
 #release-history p {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -34,13 +34,14 @@ div[class*="highlight-"] {
     margin-bottom: 12px;
 }
 
+/* Tweak whitespace on the release history page */
 #release-history p {
-    margin-bottom: 0;
-    margin-top: 0;
+    margin-bottom: 2px;
+    margin-top: 2px;
 }
 
 #release-history h3 {
-    margin-bottom: 6px;
+    margin-bottom: 12px;
 }
 
 #release-history ul {
@@ -53,6 +54,7 @@ div[class*="highlight-"] {
 
 #release-history h2 {
     margin-bottom: 12px;
+    margin-top: 24px;
 }
 
 .rst-content code {

--- a/docs/changelog/1548.doc.rst
+++ b/docs/changelog/1548.doc.rst
@@ -1,2 +1,2 @@
-Add link to the `legacy branch documentation <https://virtualenv.pypa.io/en/legacy>`_ for the changelog -
-by :user:`jezdez `.
+Fine tune the documentation layout: default width of theme, allow tables to wrap around, soft corners for code snippets
+- by :user:`pradyunsg`.

--- a/docs/changelog/1548.doc.rst
+++ b/docs/changelog/1548.doc.rst
@@ -1,0 +1,2 @@
+Add link to the `legacy branch documentation <https://virtualenv.pypa.io/en/legacy>`_ for the changelog -
+by :user:`jezdez `.


### PR DESCRIPTION
- Change the content to the default width and padding
- Allow tables to be wider than the content
- Tweak whitespace on Release History page
  - Slightly space out the content, for ease of reading + structure to page
- Tweak the inline `monospace-code` to have rounded corners, to look softer