### PR TITLE
avoid copying the stats with copytree

### DIFF
--- a/docs/changelog/1561.bugfix.rst
+++ b/docs/changelog/1561.bugfix.rst
@@ -1,0 +1,3 @@
+When copying (either files or trees) do not copy the permission bits, last access time, last modification time, and
+flags as access to these might be forbidden (for example in case of the macOs Framework Python) and these are not needed
+for the user to use the virtual environment - by :user:`gaborbernat`.

--- a/src/virtualenv/seed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/base.py
@@ -36,7 +36,6 @@ class PipInstall(object):
         # sync image
         for filename in self._image_dir.iterdir():
             into = self._creator.purelib / filename.name
-            logging.debug("%s %s from %s", self.__class__.__name__, into, filename)
             if into.exists():
                 if into.is_dir() and not into.is_symlink():
                     shutil.rmtree(str(into))

--- a/src/virtualenv/seed/via_app_data/pip_install/copy.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/copy.py
@@ -1,23 +1,17 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import shutil
 
 import six
 
-from virtualenv.util.path import Path
+from virtualenv.util.path import Path, copy
 
 from .base import PipInstall
 
 
 class CopyPipInstall(PipInstall):
     def _sync(self, src, dst):
-        src_str = six.ensure_text(str(src))
-        dest_str = six.ensure_text(str(dst))
-        if src.is_dir():
-            shutil.copytree(src_str, dest_str)
-        else:
-            shutil.copy(src_str, dest_str)
+        copy(src, dst)
 
     def _generate_new_files(self):
         # create the pyc files

--- a/src/virtualenv/util/path/__init__.py
+++ b/src/virtualenv/util/path/__init__.py
@@ -2,6 +2,14 @@ from __future__ import absolute_import, unicode_literals
 
 from ._pathlib import Path
 from ._permission import make_exe
-from ._sync import copy, ensure_dir, link, symlink
+from ._sync import copy, copytree, ensure_dir, link, symlink
 
-__all__ = ("ensure_dir", "link", "symlink", "copy", "Path", "make_exe")
+__all__ = (
+    "ensure_dir",
+    "link",
+    "symlink",
+    "copy",
+    "copytree",
+    "Path",
+    "make_exe",
+)

--- a/src/virtualenv/util/path/_sync.py
+++ b/src/virtualenv/util/path/_sync.py
@@ -52,7 +52,7 @@ def copy(src, dest):
 
 def copytree(src, dest):
     for root, _, files in os.walk(src):
-        dest_dir = os.path.join(dest, os.path.relpath(src, root))
+        dest_dir = os.path.join(dest, os.path.relpath(root, src))
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
         for name in files:

--- a/src/virtualenv/util/path/_sync.py
+++ b/src/virtualenv/util/path/_sync.py
@@ -45,9 +45,20 @@ def symlink(src, dest):
 def copy(src, dest):
     ensure_safe_to_do(src, dest)
     is_dir = src.is_dir()
-    method = shutil.copytree if is_dir else shutil.copy2
+    method = copytree if is_dir else shutil.copy
     logging.debug("copy %s", _Debug(src, dest))
     method(norm(src), norm(dest))
+
+
+def copytree(src, dest):
+    for root, _, files in os.walk(src):
+        dest_dir = os.path.join(dest, os.path.relpath(src, root))
+        if not os.path.exists(dest_dir):
+            os.makedirs(dest_dir)
+        for name in files:
+            src_f = os.path.join(root, name)
+            dest_f = os.path.join(dest_dir, name)
+            shutil.copy(src_f, dest_f)
 
 
 def link(src, dest):
@@ -67,4 +78,12 @@ class _Debug(object):
         )
 
 
-__all__ = ("ensure_dir", "symlink", "copy", "link", "symlink", "link")
+__all__ = (
+    "ensure_dir",
+    "symlink",
+    "copy",
+    "link",
+    "symlink",
+    "link",
+    "copytree",
+)

--- a/tests/integration/test_zipapp.py
+++ b/tests/integration/test_zipapp.py
@@ -29,7 +29,7 @@ def zipapp_build_env(tmp_path_factory):
                 try:
                     # create a virtual environment which is also guaranteed to contain a recent enough pip (bundled)
                     session = run_via_cli(
-                        ["-v", "-p", "{}3.{}".format(impl, version), "--activators", "", str(create_env_path)]
+                        ["-vvv", "-p", "{}3.{}".format(impl, version), "--activators", "", str(create_env_path)]
                     )
                     exe = str(session.creator.exe)
                     found = True


### PR DESCRIPTION
This information is not needed, so it's redundant work;
similarly, it might not be allowed (e.g. on macOS
framework python).

This should fix #1561 