### PR TITLE
app-data copies by default

### DIFF
--- a/docs/changelog/1557.feature.rst
+++ b/docs/changelog/1557.feature.rst
@@ -1,2 +1,2 @@
 Print out a one line message about the created virtual environment when no :option:`verbose` is set, this can now be
-sileneced to get back the original behaviour via the :option:`quiet` flag - by :user:`pradyunsg`.
+silenced to get back the original behaviour via the :option:`quiet` flag - by :user:`pradyunsg`.

--- a/docs/changelog/1575.bugfix.rst
+++ b/docs/changelog/1575.bugfix.rst
@@ -1,1 +1,3 @@
-Respect the :option:`copies` flag inside the ``app-data`` :option:`seeder` by :user:`gaborbernat`.
+The ``app-data`` :option:`seeder` no longer symlinks the packages on UNIX and copies on Windows. Instead by default
+always copies, however now has the :option:`symlink-app-data` flag allowing users to request this less robust but faster
+method - by :user:`gaborbernat`.

--- a/tests/unit/seed/test_boostrap_link_via_app_data.py
+++ b/tests/unit/seed/test_boostrap_link_via_app_data.py
@@ -7,6 +7,7 @@ import pytest
 import six
 
 from virtualenv.discovery.py_info import PythonInfo
+from virtualenv.info import fs_supports_symlink
 from virtualenv.run import run_via_cli
 from virtualenv.seed.embed.wheels import BUNDLE_SUPPORT
 from virtualenv.seed.embed.wheels.acquire import BUNDLE_FOLDER
@@ -14,7 +15,8 @@ from virtualenv.util.subprocess import Popen
 
 
 @pytest.mark.slow
-def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastest):
+@pytest.mark.parametrize("copies", [True, False] if fs_supports_symlink() else [True])
+def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastest, copies):
     current = PythonInfo.current_system()
     bundle_ver = BUNDLE_SUPPORT[current.version_release_str]
     create_cmd = [
@@ -33,6 +35,8 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
         current_fastest,
         "-vv",
     ]
+    if not copies:
+        create_cmd.append("--symlink-app-data")
     result = run_via_cli(create_cmd)
     coverage_env()
     assert result


### PR DESCRIPTION
Allow opt-in to symlink method via ``--symlink-app-data``.

Resolves #1563.