### PR TITLE
support long path names for the app-data seeder generates console entry points

### DIFF
--- a/docs/changelog/997.bugfix.rst
+++ b/docs/changelog/997.bugfix.rst
@@ -1,0 +1,2 @@
+Support long path names for generated virtual environment console entry points (such as ``pip``) when using the
+``app-data`` :option:`seeder` - by :user:`gaborbernat`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,10 +41,10 @@ project_urls =
 packages = find:
 install_requires =
     appdirs>=1.4.3,<2
+    distlib>=0.3.0,<1
     filelock>=3.0.0,<4
     six>=1.12.0,<2
     contextlib2>=0.6.0,<1;python_version<"3.3"
-    distlib>=0.3.0,<1;sys.platform == 'win32'
     importlib-metadata>=0.12,<2;python_version<"3.8"
     importlib-resources>=1.0,<2;python_version<"3.7"
     pathlib2>=2.3.3,<3;python_version < '3.4' and sys.platform != 'win32'

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -297,3 +297,18 @@ def test_creator_input_passed_is_abs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = Creator.validate_dest("venv")
     assert str(result) == str(tmp_path / "venv")
+
+
+def test_create_long_path(current_fastest, tmp_path):
+    if sys.platform == "darwin":
+        max_shebang_length = 512
+    else:
+        max_shebang_length = 127
+    # filenames can be at most 255 long on macOS, so split to to levels
+    count = max_shebang_length - len(str(tmp_path))
+    folder = tmp_path / ("a" * (count // 2)) / ("b" * (count // 2)) / "c"
+    folder.mkdir(parents=True)
+
+    cmd = [str(folder)]
+    result = run_via_cli(cmd)
+    subprocess.check_call([str(result.creator.exe.parent / "pip"), "--version"])


### PR DESCRIPTION
Resolves #997.