### PR TITLE
fix Virtualenv name not correctly shown on Fish (#1587)

### DIFF
--- a/src/virtualenv/activation/fish/activate.fish
+++ b/src/virtualenv/activation/fish/activate.fish
@@ -90,7 +90,7 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
         if test -n '__VIRTUAL_PROMPT__'
             printf '%s%s' '__VIRTUAL_PROMPT__' (set_color normal)
         else
-            printf '%s(%s) ' (set_color normal) (basename '$VIRTUAL_ENV')
+            printf '%s(%s) ' (set_color normal) (basename "$VIRTUAL_ENV")
         end
 
         string join -- \n $prompt # handle multi-line prompts


### PR DESCRIPTION
use double quotes (") instead of single quotes (') arround the $VIRTUAL_ENV