### PR TITLE
Revert "also disallow altsep beside pathsep inside paths"

### DIFF
--- a/docs/changelog/1582.bugfix.rst
+++ b/docs/changelog/1582.bugfix.rst
@@ -1,0 +1,1 @@
+Allow the use of ``/`` as pathname component separator on Windows - by ``vphilippon``

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -117,12 +117,11 @@ class Creator(object):
                     encoding, "".join(refused.keys()), raw_value
                 )
             )
-        for char in (i for i in (os.pathsep, os.altsep) if i is not None):
-            if char in raw_value:
-                raise ArgumentTypeError(
-                    "destination {!r} must not contain the path separator ({}) as this would break "
-                    "the activation scripts".format(raw_value, char)
-                )
+        if os.pathsep in raw_value:
+            raise ArgumentTypeError(
+                "destination {!r} must not contain the path separator ({}) as this would break "
+                "the activation scripts".format(raw_value, os.pathsep)
+            )
 
         value = Path(raw_value)
         if value.exists() and value.is_file():

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -25,13 +25,12 @@ from virtualenv.util.path import Path
 CURRENT = PythonInfo.current_system()
 
 
-@pytest.mark.parametrize("sep", [i for i in (os.pathsep, os.altsep) if i is not None])
-def test_os_path_sep_not_allowed(tmp_path, capsys, sep):
-    target = "{}{}".format(str(tmp_path / "a"), "{}b".format(sep))
+def test_os_path_sep_not_allowed(tmp_path, capsys):
+    target = str(tmp_path / "a{}b".format(os.pathsep))
     err = _non_success_exit_code(capsys, target)
     msg = (
         "destination {!r} must not contain the path separator ({}) as this"
-        " would break the activation scripts".format(target, sep)
+        " would break the activation scripts".format(target, os.pathsep)
     )
     assert msg in err, err
 

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -300,6 +300,13 @@ def test_creator_input_passed_is_abs(tmp_path, monkeypatch):
     assert str(result) == str(tmp_path / "venv")
 
 
+@pytest.mark.skipif(os.altsep is None, reason="OS does not have an altsep")
+def test_creator_replaces_altsep_in_dest(tmp_path):
+    dest = str(tmp_path / "venv{}foobar")
+    result = Creator.validate_dest(dest.format(os.altsep))
+    assert str(result) == dest.format(os.sep)
+
+
 def test_create_long_path(current_fastest, tmp_path):
     if sys.platform == "darwin":
         max_shebang_length = 512


### PR DESCRIPTION
This reverts commit 524d95e782d810243cf9cd344a88711591c94efc.

Fixes #1582
This essentially allows back the usage of `/` in pathname on Windows for virtualenvs for nested dirs.
Ex: `python -m virtualenv foo/bar`.

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added news fragment in ``docs/changelog`` folder
