### PR TITLE
Lower min version of six to 1.9

### DIFF
--- a/docs/changelog/1606.bugfix.rst
+++ b/docs/changelog/1606.bugfix.rst
@@ -1,0 +1,1 @@
+Lower minimal version of six required to 1.9 - by ``ssbarnea``

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     appdirs>=1.4.3,<2
     distlib>=0.3.0,<1
     filelock>=3.0.0,<4
-    six>=1.12.0,<2
+    six>=1.9.0,<2   # keep it >=1.9.0 as it may cause problems on LTS platforms
     contextlib2>=0.6.0,<1;python_version<"3.3"
     importlib-metadata>=0.12,<2;python_version<"3.8"
     importlib-resources>=1.0,<2;python_version<"3.7"

--- a/src/virtualenv/__main__.py
+++ b/src/virtualenv/__main__.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from datetime import datetime
 
-import six
+from virtualenv.util.six import ensure_text
 
 
 def run(args=None, options=None):
@@ -20,8 +20,8 @@ def run(args=None, options=None):
         logging.warning(
             "created virtual environment in %.0fms %s with seeder %s",
             (datetime.now() - start).total_seconds() * 1000,
-            six.ensure_text(str(session.creator)),
-            six.ensure_text(str(session.seeder)),
+            ensure_text(str(session.creator)),
+            ensure_text(str(session.seeder)),
         )
     except ProcessCallFailed as exception:
         print("subprocess call failed for {}".format(exception.cmd))

--- a/src/virtualenv/activation/activator.py
+++ b/src/virtualenv/activation/activator.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from abc import ABCMeta, abstractmethod
 
-import six
+from six import add_metaclass
 
 
-@six.add_metaclass(ABCMeta)
+@add_metaclass(ABCMeta)
 class Activator(object):
     """Generates an activate script for the virtual environment"""
 

--- a/src/virtualenv/activation/python/__init__.py
+++ b/src/virtualenv/activation/python/__init__.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import, unicode_literals
 import os
 from collections import OrderedDict
 
-import six
-
 from virtualenv.info import WIN_CPYTHON_2
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 
 from ..via_template import ViaTemplateActivator
 
@@ -20,7 +19,7 @@ class PythonActivator(ViaTemplateActivator):
         lib_folders = OrderedDict((os.path.relpath(str(i), str(dest_folder)), None) for i in creator.libs)
         replacements.update(
             {
-                "__LIB_FOLDERS__": six.ensure_text(os.pathsep.join(lib_folders.keys())),
+                "__LIB_FOLDERS__": ensure_text(os.pathsep.join(lib_folders.keys())),
                 "__DECODE_PATH__": ("yes" if WIN_CPYTHON_2 else ""),
             }
         )
@@ -30,5 +29,5 @@ class PythonActivator(ViaTemplateActivator):
     def _repr_unicode(creator, value):
         py2 = creator.interpreter.version_info.major == 2
         if py2:  # on Python 2 we need to encode this into explicit utf-8, py3 supports unicode literals
-            value = six.ensure_text(repr(value.encode("utf-8"))[1:-1])
+            value = ensure_text(repr(value.encode("utf-8"))[1:-1])
         return value

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -4,7 +4,9 @@ import os
 import sys
 from abc import ABCMeta, abstractmethod
 
-import six
+from six import add_metaclass
+
+from virtualenv.util.six import ensure_text
 
 from .activator import Activator
 
@@ -14,7 +16,7 @@ else:
     from importlib_resources import read_text
 
 
-@six.add_metaclass(ABCMeta)
+@add_metaclass(ABCMeta)
 class ViaTemplateActivator(Activator):
     @abstractmethod
     def templates(self):
@@ -30,10 +32,10 @@ class ViaTemplateActivator(Activator):
     def replacements(self, creator, dest_folder):
         return {
             "__VIRTUAL_PROMPT__": "" if self.flag_prompt is None else self.flag_prompt,
-            "__VIRTUAL_ENV__": six.ensure_text(str(creator.dest)),
+            "__VIRTUAL_ENV__": ensure_text(str(creator.dest)),
             "__VIRTUAL_NAME__": creator.env_name,
-            "__BIN_NAME__": six.ensure_text(str(creator.bin_dir.relative_to(creator.dest))),
-            "__PATH_SEP__": six.ensure_text(os.pathsep),
+            "__BIN_NAME__": ensure_text(str(creator.bin_dir.relative_to(creator.dest))),
+            "__PATH_SEP__": ensure_text(os.pathsep),
         }
 
     def _generate(self, replacements, templates, to_folder, creator):

--- a/src/virtualenv/config/env_var.py
+++ b/src/virtualenv/config/env_var.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-import six
+from virtualenv.util.six import ensure_str, ensure_text
 
 from .convert import convert
 
@@ -14,12 +14,12 @@ def get_env_var(key, as_type):
     :param as_type: the type we would like to convert it to
     :return:
     """
-    environ_key = six.ensure_str("VIRTUALENV_{}".format(key.upper()))
+    environ_key = ensure_str("VIRTUALENV_{}".format(key.upper()))
     if os.environ.get(environ_key):
         value = os.environ[environ_key]
         # noinspection PyBroadException
         try:
-            source = "env var {}".format(six.ensure_text(environ_key))
+            source = "env var {}".format(ensure_text(environ_key))
             as_type = convert(value, as_type, source)
             return as_type, source
         except Exception:  # note the converter already logs a warning when failures happen

--- a/src/virtualenv/config/ini.py
+++ b/src/virtualenv/config/ini.py
@@ -3,18 +3,17 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import os
 
-import six
-
 from virtualenv.dirs import default_config_dir
 from virtualenv.info import PY3
 from virtualenv.util import ConfigParser
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_str
 
 from .convert import convert
 
 
 class IniConfig(object):
-    VIRTUALENV_CONFIG_FILE_ENV_VAR = six.ensure_str("VIRTUALENV_CONFIG_FILE")
+    VIRTUALENV_CONFIG_FILE_ENV_VAR = ensure_str("VIRTUALENV_CONFIG_FILE")
     STATE = {None: "failed to parse", True: "active", False: "missing"}
 
     section = "virtualenv"

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -11,13 +11,13 @@ from ast import literal_eval
 from collections import OrderedDict
 from stat import S_IWUSR
 
-import six
 from six import add_metaclass
 
 from virtualenv.discovery.cached_py_info import LogCmd
 from virtualenv.info import WIN_CPYTHON_2
 from virtualenv.pyenv_cfg import PyEnvCfg
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_str, ensure_text
 from virtualenv.util.subprocess import run_cmd
 from virtualenv.util.zipapp import ensure_file_on_disk
 from virtualenv.version import __version__
@@ -43,14 +43,14 @@ class Creator(object):
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
 
     def __repr__(self):
-        return six.ensure_str(self.__unicode__())
+        return ensure_str(self.__unicode__())
 
     def __unicode__(self):
         return "{}({})".format(self.__class__.__name__, ", ".join("{}={}".format(k, v) for k, v in self._args()))
 
     def _args(self):
         return [
-            ("dest", six.ensure_text(str(self.dest))),
+            ("dest", ensure_text(str(self.dest))),
             ("clear", self.clear),
         ]
 
@@ -103,7 +103,7 @@ class Creator(object):
         encoding = sys.getfilesystemencoding()
         refused = OrderedDict()
         kwargs = {"errors": "ignore"} if encoding != "mbcs" else {}
-        for char in six.ensure_text(raw_value):
+        for char in ensure_text(raw_value):
             try:
                 trip = char.encode(encoding, **kwargs).decode(encoding)
                 if trip == char:
@@ -135,7 +135,7 @@ class Creator(object):
         value = dest
         while dest:
             if dest.exists():
-                if os.access(six.ensure_text(str(dest)), os.W_OK):
+                if os.access(ensure_text(str(dest)), os.W_OK):
                     break
                 else:
                     non_write_able(dest, value)
@@ -188,7 +188,7 @@ def get_env_debug_info(env_exe, debug_script):
     with ensure_file_on_disk(debug_script) as debug_script:
         cmd = [str(env_exe), str(debug_script)]
         if WIN_CPYTHON_2:
-            cmd = [six.ensure_text(i) for i in cmd]
+            cmd = [ensure_text(i) for i in cmd]
         logging.debug(str("debug via %r"), LogCmd(cmd))
         code, out, err = run_cmd(cmd)
 

--- a/src/virtualenv/create/describe.py
+++ b/src/virtualenv/create/describe.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 from abc import ABCMeta
 from collections import OrderedDict
 
-from six import add_metaclass, ensure_text
+from six import add_metaclass
 
 from virtualenv.info import IS_WIN
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 
 
 @add_metaclass(ABCMeta)

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython2.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import abc
 import logging
 
-import six
+from six import add_metaclass
 
 from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest
 from virtualenv.util.path import Path
@@ -12,7 +12,7 @@ from ..python2.python2 import Python2
 from .common import CPython, CPythonPosix, CPythonWindows
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class CPython2(CPython, Python2):
     """Create a CPython version 2  virtual environment"""
 

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import abc
 
-import six
+from six import add_metaclass
 
 from virtualenv.create.describe import Python3Supports
 from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest
@@ -11,7 +11,7 @@ from virtualenv.util.path import Path
 from .common import CPython, CPythonPosix, CPythonWindows
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class CPython3(CPython, Python3Supports):
     """"""
 

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import abc
 
-import six
+from six import add_metaclass
 
 from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest
 from virtualenv.util.path import Path
@@ -10,7 +10,7 @@ from virtualenv.util.path import Path
 from ..via_global_self_do import ViaGlobalRefVirtualenvBuiltin
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class PyPy(ViaGlobalRefVirtualenvBuiltin):
     @classmethod
     def can_describe(cls, interpreter):

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import abc
 import logging
 
-import six
+from six import add_metaclass
 
 from virtualenv.create.describe import PosixSupports, WindowsSupports
 from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest
@@ -13,7 +13,7 @@ from ..python2.python2 import Python2
 from .common import PyPy
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class PyPy2(PyPy, Python2):
     """"""
 

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import abc
 
-import six
+from six import add_metaclass
 
 from virtualenv.create.describe import PosixSupports, Python3Supports, WindowsSupports
 from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest
@@ -11,7 +11,7 @@ from virtualenv.util.path import Path
 from .common import PyPy
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class PyPy3(PyPy, Python3Supports):
     @classmethod
     def exe_stem(cls):

--- a/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
@@ -4,12 +4,13 @@ import abc
 import json
 import os
 
-import six
+from six import add_metaclass
 
 from virtualenv.create.describe import Python2Supports
 from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest
 from virtualenv.info import IS_ZIPAPP
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 from virtualenv.util.zipapp import read as read_from_zipapp
 
 from ..via_global_self_do import ViaGlobalRefVirtualenvBuiltin
@@ -17,7 +18,7 @@ from ..via_global_self_do import ViaGlobalRefVirtualenvBuiltin
 HERE = Path(os.path.abspath(__file__)).parent
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class Python2(ViaGlobalRefVirtualenvBuiltin, Python2Supports):
     def create(self):
         """Perform operations needed to make the created environment work on Python 2"""
@@ -30,9 +31,7 @@ class Python2(ViaGlobalRefVirtualenvBuiltin, Python2Supports):
             custom_site_text = read_from_zipapp(custom_site)
         else:
             custom_site_text = custom_site.read_text()
-        expected = json.dumps(
-            [os.path.relpath(six.ensure_text(str(i)), six.ensure_text(str(site_py))) for i in self.libs]
-        )
+        expected = json.dumps([os.path.relpath(ensure_text(str(i)), ensure_text(str(site_py))) for i in self.libs])
         site_py.write_text(custom_site_text.replace("___EXPECTED_SITE_PACKAGES___", expected))
 
     @classmethod

--- a/src/virtualenv/create/via_global_ref/builtin/ref.py
+++ b/src/virtualenv/create/via_global_ref/builtin/ref.py
@@ -5,10 +5,11 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from stat import S_IXGRP, S_IXOTH, S_IXUSR
 
-from six import add_metaclass, ensure_text
+from six import add_metaclass
 
 from virtualenv.info import PY3, fs_is_case_sensitive, fs_supports_symlink
 from virtualenv.util.path import copy, link, make_exe, symlink
+from virtualenv.util.six import ensure_text
 
 
 @add_metaclass(ABCMeta)

--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -4,9 +4,8 @@ import logging
 import os
 import sys
 
-import six
-
 from virtualenv.info import IS_WIN
+from virtualenv.util.six import ensure_str, ensure_text
 
 from .discover import Discover
 from .py_info import PythonInfo
@@ -33,7 +32,7 @@ class Builtin(Discover):
         return get_interpreter(self.python_spec)
 
     def __repr__(self):
-        return six.ensure_str(self.__unicode__())
+        return ensure_str(self.__unicode__())
 
     def __unicode__(self):
         return "{} discover of python_spec={!r}".format(self.__class__.__name__, self.python_spec)
@@ -73,7 +72,7 @@ def propose_interpreters(spec):
     # find on path, the path order matters (as the candidates are less easy to control by end user)
     tested_exes = set()
     for pos, path in enumerate(paths):
-        path = six.ensure_text(path)
+        path = ensure_text(path)
         logging.debug(LazyPathDump(pos, path))
         for candidate, match in possible_specs(spec):
             found = check_path(candidate, path)
@@ -106,7 +105,7 @@ class LazyPathDump(object):
         self.path = path
 
     def __repr__(self):
-        return six.ensure_str(self.__unicode__())
+        return ensure_str(self.__unicode__())
 
     def __unicode__(self):
         content = "discover PATH[{}]={}".format(self.pos, self.path)

--- a/src/virtualenv/discovery/cached_py_info.py
+++ b/src/virtualenv/discovery/cached_py_info.py
@@ -14,12 +14,11 @@ import sys
 from collections import OrderedDict
 from hashlib import sha256
 
-from six import ensure_text
-
 from virtualenv.dirs import default_data_dir
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import PY2, PY3
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 from virtualenv.util.subprocess import Popen, subprocess
 from virtualenv.util.zipapp import ensure_file_on_disk
 from virtualenv.version import __version__

--- a/src/virtualenv/discovery/discover.py
+++ b/src/virtualenv/discovery/discover.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from abc import ABCMeta, abstractmethod
 
-import six
+from six import add_metaclass
 
 
-@six.add_metaclass(ABCMeta)
+@add_metaclass(ABCMeta)
 class Discover(object):
     """Discover and provide the requested Python interpreter"""
 

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -6,9 +6,8 @@ import re
 import sys
 from collections import OrderedDict
 
-import six
-
 from virtualenv.info import fs_is_case_sensitive
+from virtualenv.util.six import ensure_str
 
 PATTERN = re.compile(r"^(?P<impl>[a-zA-Z]+)?(?P<version>[0-9.]+)?(?:-(?P<arch>32|64))?$")
 IS_WIN = sys.platform == "win32"
@@ -120,4 +119,4 @@ class PythonSpec(object):
         )
 
     def __repr__(self):
-        return six.ensure_str(self.__unicode__())
+        return ensure_str(self.__unicode__())

--- a/src/virtualenv/pyenv_cfg.py
+++ b/src/virtualenv/pyenv_cfg.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 from collections import OrderedDict
 
-import six
+from virtualenv.util.six import ensure_text
 
 
 class PyEnvCfg(object):
@@ -31,7 +31,7 @@ class PyEnvCfg(object):
         return content
 
     def write(self):
-        logging.debug("write %s", six.ensure_text(str(self.path)))
+        logging.debug("write %s", ensure_text(str(self.path)))
         text = ""
         for key, value in self.content.items():
             line = "{} = {}".format(key, value)

--- a/src/virtualenv/report.py
+++ b/src/virtualenv/report.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import sys
 
-import six
+from virtualenv.util.six import ensure_str
 
 LEVELS = {
     0: logging.CRITICAL,
@@ -33,7 +33,7 @@ def setup_report(verbose, quiet):
     else:
         filelock_logger.setLevel(logging.WARN)
 
-    formatter = logging.Formatter(six.ensure_str(msg_format))
+    formatter = logging.Formatter(ensure_str(msg_format))
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setLevel(level)
     LOGGER.setLevel(logging.NOTSET)

--- a/src/virtualenv/seed/embed/base_embed.py
+++ b/src/virtualenv/seed/embed/base_embed.py
@@ -2,14 +2,15 @@ from __future__ import absolute_import, unicode_literals
 
 from abc import ABCMeta
 
-import six
+from six import add_metaclass
 
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_str, ensure_text
 
 from ..seeder import Seeder
 
 
-@six.add_metaclass(ABCMeta)
+@add_metaclass(ABCMeta)
 class BaseEmbed(Seeder):
     packages = ["pip", "setuptools", "wheel"]
 
@@ -80,9 +81,7 @@ class BaseEmbed(Seeder):
     def __unicode__(self):
         result = self.__class__.__name__
         if self.extra_search_dir:
-            result += " extra search dirs = {}".format(
-                ", ".join(six.ensure_text(str(i)) for i in self.extra_search_dir)
-            )
+            result += " extra search dirs = {}".format(", ".join(ensure_text(str(i)) for i in self.extra_search_dir))
         for package in self.packages:
             result += " {}{}".format(
                 package, "={}".format(getattr(self, "{}_version".format(package), None) or "latest")
@@ -90,4 +89,4 @@ class BaseEmbed(Seeder):
         return result
 
     def __repr__(self):
-        return six.ensure_str(self.__unicode__())
+        return ensure_str(self.__unicode__())

--- a/src/virtualenv/seed/embed/wheels/acquire.py
+++ b/src/virtualenv/seed/embed/wheels/acquire.py
@@ -10,10 +10,9 @@ from copy import copy
 from shutil import copy2
 from zipfile import ZipFile
 
-import six
-
 from virtualenv.info import IS_ZIPAPP
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_str, ensure_text
 from virtualenv.util.subprocess import Popen, subprocess
 from virtualenv.util.zipapp import ensure_file_on_disk
 
@@ -85,7 +84,7 @@ def acquire_from_dir(packages, for_py_version, to_folder, extra_search_dir):
 
 def wheel_support_py(filename, py_version):
     name = "{}.dist-info/METADATA".format("-".join(filename.stem.split("-")[0:2]))
-    with ZipFile(six.ensure_text(str(filename)), "r") as zip_file:
+    with ZipFile(ensure_text(str(filename)), "r") as zip_file:
         metadata = zip_file.read(name).decode("utf-8")
     marker = "Requires-Python:"
     requires = next(i[len(marker) :] for i in metadata.splitlines() if i.startswith(marker))
@@ -158,7 +157,7 @@ def pip_wheel_env_run(version):
     env = os.environ.copy()
     env.update(
         {
-            six.ensure_str(k): str(v)  # python 2 requires these to be string only (non-unicode)
+            ensure_str(k): str(v)  # python 2 requires these to be string only (non-unicode)
             for k, v in {"PIP_USE_WHEEL": "1", "PIP_USER": "0", "PIP_NO_INPUT": "1"}.items()
         }
     )

--- a/src/virtualenv/seed/seeder.py
+++ b/src/virtualenv/seed/seeder.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from abc import ABCMeta, abstractmethod
 
-import six
+from six import add_metaclass
 
 
-@six.add_metaclass(ABCMeta)
+@add_metaclass(ABCMeta)
 class Seeder(object):
     """A seeder will install some seed packages into a virtual environment."""
 

--- a/src/virtualenv/seed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/base.py
@@ -8,14 +8,14 @@ import zipfile
 from abc import ABCMeta, abstractmethod
 from tempfile import mkdtemp
 
-import six
-from six import PY3
+from six import PY3, add_metaclass
 
 from virtualenv.util import ConfigParser
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 
 
-@six.add_metaclass(ABCMeta)
+@add_metaclass(ABCMeta)
 class PipInstall(object):
     def __init__(self, wheel, creator, image_folder):
         self._wheel = wheel
@@ -60,8 +60,7 @@ class PipInstall(object):
 
     def _records_text(self, files):
         record_data = "\n".join(
-            "{},,".format(os.path.relpath(six.ensure_text(str(rec)), six.ensure_text(str(self._image_dir))))
-            for rec in files
+            "{},,".format(os.path.relpath(ensure_text(str(rec)), ensure_text(str(self._image_dir)))) for rec in files
         )
         return record_data
 
@@ -77,12 +76,10 @@ class PipInstall(object):
         folder = mkdtemp()
         try:
             to_folder = Path(folder)
-            rel = os.path.relpath(
-                six.ensure_text(str(self._creator.script_dir)), six.ensure_text(str(self._creator.purelib))
-            )
+            rel = os.path.relpath(ensure_text(str(self._creator.script_dir)), ensure_text(str(self._creator.purelib)))
             for name, module in self._console_scripts.items():
                 new_files.update(
-                    Path(os.path.normpath(six.ensure_text(str(self._image_dir / rel / i.name))))
+                    Path(os.path.normpath(ensure_text(str(self._image_dir / rel / i.name))))
                     for i in self._create_console_entry_point(name, module, to_folder)
                 )
         finally:
@@ -142,7 +139,7 @@ class PipInstall(object):
 
     def clear(self):
         if self._image_dir.exists():
-            shutil.rmtree(six.ensure_text(str(self._image_dir)))
+            shutil.rmtree(ensure_text(str(self._image_dir)))
 
     def has_image(self):
         return self._image_dir.exists() and next(self._image_dir.iterdir()) is not None

--- a/src/virtualenv/seed/via_app_data/pip_install/copy.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/copy.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-import six
-
 from virtualenv.util.path import Path, copy
+from virtualenv.util.six import ensure_text
 
 from .base import PipInstall
 
@@ -22,7 +21,7 @@ class CopyPipInstall(PipInstall):
     def _cache_files(self):
         version = self._creator.interpreter.version_info
         py_c_ext = ".{}-{}{}.pyc".format(self._creator.interpreter.implementation.lower(), version.major, version.minor)
-        for root, dirs, files in os.walk(six.ensure_text(str(self._image_dir)), topdown=True):
+        for root, dirs, files in os.walk(ensure_text(str(self._image_dir)), topdown=True):
             root_path = Path(root)
             for name in files:
                 if name.endswith(".py"):
@@ -32,5 +31,5 @@ class CopyPipInstall(PipInstall):
 
     def _fix_records(self, new_files):
         extra_record_data_str = self._records_text(new_files)
-        with open(six.ensure_text(str(self._dist_info / "RECORD")), "ab") as file_handler:
+        with open(ensure_text(str(self._dist_info / "RECORD")), "ab") as file_handler:
             file_handler.write(extra_record_data_str.encode("utf-8"))

--- a/src/virtualenv/seed/via_app_data/pip_install/symlink.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/symlink.py
@@ -5,8 +5,7 @@ import shutil
 import subprocess
 from stat import S_IREAD, S_IRGRP, S_IROTH, S_IWUSR
 
-import six
-
+from virtualenv.util.six import ensure_text
 from virtualenv.util.subprocess import Popen
 
 from .base import PipInstall
@@ -14,14 +13,14 @@ from .base import PipInstall
 
 class SymlinkPipInstall(PipInstall):
     def _sync(self, src, dst):
-        src_str = six.ensure_text(str(src))
-        dest_str = six.ensure_text(str(dst))
+        src_str = ensure_text(str(src))
+        dest_str = ensure_text(str(dst))
         os.symlink(src_str, dest_str)
 
     def _generate_new_files(self):
         # create the pyc files, as the build image will be R/O
         process = Popen(
-            [six.ensure_text(str(self._creator.exe)), "-m", "compileall", six.ensure_text(str(self._image_dir))],
+            [ensure_text(str(self._creator.exe)), "-m", "compileall", ensure_text(str(self._image_dir))],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -32,7 +31,7 @@ class SymlinkPipInstall(PipInstall):
         if root_py_cache.exists():
             new_files.update(root_py_cache.iterdir())
             new_files.add(root_py_cache)
-            shutil.rmtree(six.ensure_text(str(root_py_cache)))
+            shutil.rmtree(ensure_text(str(root_py_cache)))
         core_new_files = super(SymlinkPipInstall, self)._generate_new_files()
         # remove files that are within the image folder deeper than one level (as these will be not linked directly)
         for file in core_new_files:
@@ -48,7 +47,7 @@ class SymlinkPipInstall(PipInstall):
     def _fix_records(self, new_files):
         new_files.update(i for i in self._image_dir.iterdir())
         extra_record_data_str = self._records_text(sorted(new_files, key=str))
-        with open(six.ensure_text(str(self._dist_info / "RECORD")), "wb") as file_handler:
+        with open(ensure_text(str(self._dist_info / "RECORD")), "wb") as file_handler:
             file_handler.write(extra_record_data_str.encode("utf-8"))
 
     def build_image(self):
@@ -63,6 +62,6 @@ class SymlinkPipInstall(PipInstall):
 
     @staticmethod
     def _set_tree(folder, stat):
-        for root, _, files in os.walk(six.ensure_text(str(folder))):
+        for root, _, files in os.walk(ensure_text(str(folder))):
             for filename in files:
                 os.chmod(os.path.join(root, filename), stat)

--- a/src/virtualenv/seed/via_app_data/via_app_data.py
+++ b/src/virtualenv/seed/via_app_data/via_app_data.py
@@ -6,12 +6,11 @@ import shutil
 from contextlib import contextmanager
 from threading import Lock, Thread
 
-import six
-
 from virtualenv.dirs import default_data_dir
 from virtualenv.info import fs_supports_symlink
 from virtualenv.seed.embed.base_embed import BaseEmbed
 from virtualenv.seed.embed.wheels.acquire import get_wheels
+from virtualenv.util.six import ensure_text
 
 from .pip_install.copy import CopyPipInstall
 from .pip_install.symlink import SymlinkPipInstall
@@ -74,7 +73,7 @@ class FromAppData(BaseEmbed):
         with base_cache.lock_for_key("wheels"):
             wheels_to = base_cache.path / "wheels"
             if self.clear and wheels_to.exists():
-                shutil.rmtree(six.ensure_text(str(wheels_to)))
+                shutil.rmtree(ensure_text(str(wheels_to)))
             wheels_to.mkdir(parents=True, exist_ok=True)
             name_to_whl, lock = {}, Lock()
 

--- a/src/virtualenv/session.py
+++ b/src/virtualenv/session.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 import logging
 
-import six
+from virtualenv.util.six import ensure_text
 
 
 class Session(object):
@@ -48,7 +48,7 @@ class Session(object):
         self.creator.pyenv_cfg.write()
 
     def _create(self):
-        logging.info("create virtual environment via %s", six.ensure_text(str(self.creator)))
+        logging.info("create virtual environment via %s", ensure_text(str(self.creator)))
         self.creator.run()
         logging.debug(_DEBUG_MARKER)
         logging.debug("%s", _Debug(self.creator))
@@ -77,7 +77,7 @@ class _Debug(object):
         self.creator = creator
 
     def __unicode__(self):
-        return six.ensure_text(repr(self))
+        return ensure_text(repr(self))
 
     def __repr__(self):
         return json.dumps(self.creator.debug, indent=2)

--- a/src/virtualenv/util/path/_pathlib/via_os_path.py
+++ b/src/virtualenv/util/path/_pathlib/via_os_path.py
@@ -4,7 +4,7 @@ import os
 import platform
 from contextlib import contextmanager
 
-import six
+from virtualenv.util.six import ensure_str, ensure_text
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 
@@ -14,25 +14,25 @@ class Path(object):
         if isinstance(path, Path):
             _path = path._path
         else:
-            _path = six.ensure_text(path)
+            _path = ensure_text(path)
             if IS_PYPY:
                 _path = _path.encode("utf-8")
         self._path = _path
 
     def __repr__(self):
-        return six.ensure_str("Path({})".format(six.ensure_text(self._path)))
+        return ensure_str("Path({})".format(ensure_text(self._path)))
 
     def __unicode__(self):
-        return six.ensure_text(self._path)
+        return ensure_text(self._path)
 
     def __str__(self):
-        return six.ensure_str(self._path)
+        return ensure_str(self._path)
 
     def __div__(self, other):
         if isinstance(other, Path):
             right = other._path
         else:
-            right = six.ensure_text(other)
+            right = ensure_text(other)
             if IS_PYPY:
                 right = right.encode("utf-8")
         return Path(os.path.join(self._path, right))

--- a/src/virtualenv/util/path/_sync.py
+++ b/src/virtualenv/util/path/_sync.py
@@ -4,9 +4,10 @@ import logging
 import os
 import shutil
 
-from six import PY2, PY3, ensure_text
+from six import PY2, PY3
 
 from virtualenv.info import IS_CPYTHON, IS_WIN
+from virtualenv.util.six import ensure_text
 
 if PY3:
     from os import link as os_link

--- a/src/virtualenv/util/six.py
+++ b/src/virtualenv/util/six.py
@@ -1,0 +1,50 @@
+"""Backward compatibility layer with older version of six.
+
+This is used to avoid virtualenv requring a version of six newer than what
+the system may have.
+"""
+from __future__ import absolute_import
+
+from six import PY2, PY3, binary_type, text_type
+
+try:
+    from six import ensure_text
+except ImportError:
+
+    def ensure_text(s, encoding="utf-8", errors="strict"):
+        """Coerce *s* to six.text_type.
+        For Python 2:
+        - `unicode` -> `unicode`
+        - `str` -> `unicode`
+        For Python 3:
+        - `str` -> `str`
+        - `bytes` -> decoded to `str`
+        """
+        if isinstance(s, binary_type):
+            return s.decode(encoding, errors)
+        elif isinstance(s, text_type):
+            return s
+        else:
+            raise TypeError("not expecting type '%s'" % type(s))
+
+
+try:
+    from six import ensure_str
+except ImportError:
+
+    def ensure_str(s, encoding="utf-8", errors="strict"):
+        """Coerce *s* to `str`.
+        For Python 2:
+        - `unicode` -> encoded to `str`
+        - `str` -> `str`
+        For Python 3:
+        - `str` -> `str`
+        - `bytes` -> decoded to `str`
+        """
+        if not isinstance(s, (text_type, binary_type)):
+            raise TypeError("not expecting type '%s'" % type(s))
+        if PY2 and isinstance(s, text_type):
+            s = s.encode(encoding, errors)
+        elif PY3 and isinstance(s, binary_type):
+            s = s.decode(encoding, errors)
+        return s

--- a/src/virtualenv/util/zipapp.py
+++ b/src/virtualenv/util/zipapp.py
@@ -5,10 +5,9 @@ import os
 import zipfile
 from contextlib import contextmanager
 
-import six
-
 from virtualenv.dirs import default_data_dir
 from virtualenv.info import IS_WIN, IS_ZIPAPP, ROOT
+from virtualenv.util.six import ensure_text
 from virtualenv.version import __version__
 
 
@@ -25,7 +24,7 @@ def extract(full_path, dest):
     with zipfile.ZipFile(ROOT, "r") as zip_file:
         info = zip_file.getinfo(sub_file)
         info.filename = dest.name
-        zip_file.extract(info, six.ensure_text(str(dest.parent)))
+        zip_file.extract(info, ensure_text(str(dest.parent)))
 
 
 def _get_path_within_zip(full_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import IS_PYPY, IS_WIN, fs_supports_symlink
 from virtualenv.report import LOGGER
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 
 _TEST_SETUP_DIR = tempfile.mkdtemp()
 dirs._DATA_DIR = dirs.ReentrantFileLock(_TEST_SETUP_DIR)
@@ -279,7 +280,7 @@ def special_name_dir(tmp_path, special_char_name):
     dest = Path(str(tmp_path)) / special_char_name
     yield dest
     if six.PY2 and sys.platform == "win32" and not IS_PYPY:  # pytest python2 windows does not support unicode delete
-        shutil.rmtree(six.ensure_text(str(dest)))
+        shutil.rmtree(ensure_text(str(dest)))
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_zipapp.py
+++ b/tests/integration/test_zipapp.py
@@ -5,11 +5,11 @@ import subprocess
 import sys
 
 import pytest
-import six
 
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.run import cli_run
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 
 HERE = Path(__file__).parent
 CURRENT = PythonInfo.current_system()
@@ -70,7 +70,7 @@ def zipapp_test_env(tmp_path_factory):
 def call_zipapp(zipapp, monkeypatch, tmp_path, zipapp_test_env):
     def _run(*args):
         monkeypatch.setenv(str("VIRTUALENV_OVERRIDE_APP_DATA"), str(tmp_path / "app_data"))
-        cmd = [str(zipapp_test_env), str(zipapp), "-vv", six.ensure_text(str(tmp_path / "env"))] + list(args)
+        cmd = [str(zipapp_test_env), str(zipapp), "-vv", ensure_text(str(tmp_path / "env"))] + list(args)
         subprocess.check_call(cmd)
 
     return _run

--- a/tests/unit/activation/conftest.py
+++ b/tests/unit/activation/conftest.py
@@ -14,6 +14,7 @@ import six
 from virtualenv.info import IS_PYPY, WIN_CPYTHON_2
 from virtualenv.run import cli_run
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_str, ensure_text
 from virtualenv.util.subprocess import Popen
 
 
@@ -58,22 +59,22 @@ class ActivationTester(object):
         )
 
     def __repr__(self):
-        return six.ensure_str(self.__unicode__())
+        return ensure_str(self.__unicode__())
 
     def __call__(self, monkeypatch, tmp_path):
         activate_script = self._creator.bin_dir / self.activate_script
         test_script = self._generate_test_script(activate_script, tmp_path)
-        monkeypatch.chdir(six.ensure_text(str(tmp_path)))
+        monkeypatch.chdir(ensure_text(str(tmp_path)))
 
         monkeypatch.delenv(str("VIRTUAL_ENV"), raising=False)
-        invoke, env = self._invoke_script + [six.ensure_text(str(test_script))], self.env(tmp_path)
+        invoke, env = self._invoke_script + [ensure_text(str(test_script))], self.env(tmp_path)
 
         try:
             process = Popen(invoke, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
             _raw, _ = process.communicate()
             raw = _raw.decode("utf-8")
         except subprocess.CalledProcessError as exception:
-            assert not exception.returncode, six.ensure_text(exception.output)
+            assert not exception.returncode, ensure_text(exception.output)
             return
 
         out = re.sub(r"pydev debugger: process \d+ is connecting\n\n", "", raw, re.M).strip().splitlines()
@@ -97,9 +98,9 @@ class ActivationTester(object):
 
     def _generate_test_script(self, activate_script, tmp_path):
         commands = self._get_test_lines(activate_script)
-        script = six.ensure_text(os.linesep).join(commands)
+        script = ensure_text(os.linesep).join(commands)
         test_script = tmp_path / "script.{}".format(self.extension)
-        with open(six.ensure_text(str(test_script)), "wb") as file_handler:
+        with open(ensure_text(str(test_script)), "wb") as file_handler:
             file_handler.write(script.encode(self.script_encoding))
         return test_script
 
@@ -156,8 +157,8 @@ class ActivationTester(object):
         )
 
     def activate_call(self, script):
-        cmd = self.quote(six.ensure_text(str(self.activate_cmd)))
-        scr = self.quote(six.ensure_text(str(script)))
+        cmd = self.quote(ensure_text(str(self.activate_cmd)))
+        scr = self.quote(ensure_text(str(script)))
         return "{} {}".format(cmd, scr).strip()
 
     @staticmethod
@@ -165,7 +166,7 @@ class ActivationTester(object):
         # python may return Windows short paths, normalize
         if not isinstance(path, Path):
             path = Path(path)
-        path = six.ensure_text(str(path.resolve()))
+        path = ensure_text(str(path.resolve()))
         if sys.platform != "win32":
             result = path
         else:
@@ -206,7 +207,7 @@ def raise_on_non_source_class():
 
 @pytest.fixture(scope="session")
 def activation_python(tmp_path_factory, special_char_name, current_fastest):
-    dest = os.path.join(six.ensure_text(str(tmp_path_factory.mktemp("activation-tester-env"))), special_char_name)
+    dest = os.path.join(ensure_text(str(tmp_path_factory.mktemp("activation-tester-env"))), special_char_name)
     session = cli_run(["--without-pip", dest, "--prompt", special_char_name, "--creator", current_fastest, "-vv"])
     pydoc_test = session.creator.purelib / "pydoc_test.py"
     pydoc_test.write_text('"""This is pydoc_test.py"""')

--- a/tests/unit/activation/test_python_activator.py
+++ b/tests/unit/activation/test_python_activator.py
@@ -5,10 +5,9 @@ import sys
 from ast import literal_eval
 from textwrap import dedent
 
-import six
-
 from virtualenv.activation import PythonActivator
 from virtualenv.info import WIN_CPYTHON_2
+from virtualenv.util.six import ensure_text
 
 
 def test_python(raise_on_non_source_class, activation_tester):
@@ -77,7 +76,7 @@ def test_python(raise_on_non_source_class, activation_tester):
             # sys path contains the site package at its start
             new_sys_path = out[5]
 
-            new_lib_paths = {six.ensure_text(j) if WIN_CPYTHON_2 else j for j in {str(i) for i in self._creator.libs}}
+            new_lib_paths = {ensure_text(j) if WIN_CPYTHON_2 else j for j in {str(i) for i in self._creator.libs}}
             assert prev_sys_path == new_sys_path[len(new_lib_paths) :]
             assert new_lib_paths == set(new_sys_path[: len(new_lib_paths)])
 
@@ -89,7 +88,7 @@ def test_python(raise_on_non_source_class, activation_tester):
         def non_source_activate(self, activate_script):
             act = str(activate_script)
             if WIN_CPYTHON_2:
-                act = six.ensure_text(act)
+                act = ensure_text(act)
             cmd = self._invoke_script + [
                 "-c",
                 "exec(open({}).read())".format(repr(act)),

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -11,7 +11,6 @@ from itertools import product
 from threading import Thread
 
 import pytest
-import six
 
 from virtualenv.__main__ import run, run_with_catch
 from virtualenv.create.creator import DEBUG_SCRIPT, Creator, get_env_debug_info
@@ -21,6 +20,7 @@ from virtualenv.info import IS_PYPY, fs_supports_symlink
 from virtualenv.pyenv_cfg import PyEnvCfg
 from virtualenv.run import cli_run, session_via_cli
 from virtualenv.util.path import Path
+from virtualenv.util.six import ensure_text
 
 CURRENT = PythonInfo.current_system()
 
@@ -115,8 +115,8 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
         "-v",
         "-v",
         "-p",
-        six.ensure_text(python),
-        six.ensure_text(str(dest)),
+        ensure_text(python),
+        ensure_text(str(dest)),
         "--without-pip",
         "--activators",
         "",
@@ -133,22 +133,20 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
         # force a cleanup of these on system where the limit is low-ish (e.g. MacOS 256)
         gc.collect()
     content = list(result.creator.purelib.iterdir())
-    assert not content, "\n".join(six.ensure_text(str(i)) for i in content)
-    assert result.creator.env_name == six.ensure_text(dest.name)
+    assert not content, "\n".join(ensure_text(str(i)) for i in content)
+    assert result.creator.env_name == ensure_text(dest.name)
     debug = result.creator.debug
     sys_path = cleanup_sys_path(debug["sys"]["path"])
     system_sys_path = cleanup_sys_path(system["sys"]["path"])
     our_paths = set(sys_path) - set(system_sys_path)
-    our_paths_repr = "\n".join(six.ensure_text(repr(i)) for i in our_paths)
+    our_paths_repr = "\n".join(ensure_text(repr(i)) for i in our_paths)
 
     # ensure we have at least one extra path added
     assert len(our_paths) >= 1, our_paths_repr
     # ensure all additional paths are related to the virtual environment
     for path in our_paths:
         msg = "\n{}\ndoes not start with {}\nhas:\n{}".format(
-            six.ensure_text(str(path)),
-            six.ensure_text(str(dest)),
-            "\n".join(six.ensure_text(str(p)) for p in system_sys_path),
+            ensure_text(str(path)), ensure_text(str(dest)), "\n".join(ensure_text(str(p)) for p in system_sys_path),
         )
         assert str(path).startswith(str(dest)), msg
     # ensure there's at least a site-packages folder as part of the virtual environment added
@@ -158,7 +156,7 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
     last_from_system_path = next(j for j in reversed(system_sys_path) if str(j).startswith(system["sys"]["prefix"]))
     if isolated == "isolated":
         assert last_from_system_path not in sys_path, "last from system sys path {} is in venv sys path:\n{}".format(
-            six.ensure_text(str(last_from_system_path)), "\n".join(six.ensure_text(str(j)) for j in sys_path)
+            ensure_text(str(last_from_system_path)), "\n".join(ensure_text(str(j)) for j in sys_path)
         )
     else:
         common = []
@@ -169,7 +167,7 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
                 break
 
         def list_to_str(iterable):
-            return [six.ensure_text(str(i)) for i in iterable]
+            return [ensure_text(str(i)) for i in iterable]
 
         assert common, "\n".join(difflib.unified_diff(list_to_str(sys_path), list_to_str(system_sys_path)))
 
@@ -184,7 +182,7 @@ def test_venv_fails_not_inline(tmp_path, capsys, mocker):
     mocker.patch("virtualenv.run.session_via_cli", side_effect=_session_via_cli)
     before = tmp_path.stat().st_mode
     cfg_path = tmp_path / "pyvenv.cfg"
-    cfg_path.write_text(six.ensure_text(""))
+    cfg_path.write_text(ensure_text(""))
     cfg = str(cfg_path)
     try:
         os.chmod(cfg, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
@@ -268,8 +266,8 @@ def test_cross_major(cross_python, coverage_env, tmp_path, current_fastest):
         "-v",
         "-v",
         "-p",
-        six.ensure_text(cross_python.executable),
-        six.ensure_text(str(tmp_path)),
+        ensure_text(cross_python.executable),
+        ensure_text(str(tmp_path)),
         "--no-seed",
         "--activators",
         "",

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -6,11 +6,11 @@ import sys
 from uuid import uuid4
 
 import pytest
-import six
 
 from virtualenv.discovery.builtin import get_interpreter
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import fs_supports_symlink
+from virtualenv.util.six import ensure_text
 
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink not supported")
@@ -27,7 +27,7 @@ def test_discovery_via_path(monkeypatch, case, special_name_dir, caplog):
     exe_name = "{}{}{}".format(name, current.version_info.major, ".exe" if sys.platform == "win32" else "")
     special_name_dir.mkdir()
     executable = special_name_dir / exe_name
-    os.symlink(sys.executable, six.ensure_text(str(executable)))
+    os.symlink(sys.executable, ensure_text(str(executable)))
     new_path = os.pathsep.join([str(special_name_dir)] + os.environ.get(str("PATH"), str("")).split(os.pathsep))
     monkeypatch.setenv(str("PATH"), new_path)
     interpreter = get_interpreter(core)

--- a/tests/unit/seed/test_boostrap_link_via_app_data.py
+++ b/tests/unit/seed/test_boostrap_link_via_app_data.py
@@ -4,13 +4,13 @@ import os
 import sys
 
 import pytest
-import six
 
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import fs_supports_symlink
 from virtualenv.run import cli_run
 from virtualenv.seed.embed.wheels import BUNDLE_SUPPORT
 from virtualenv.seed.embed.wheels.acquire import BUNDLE_FOLDER
+from virtualenv.util.six import ensure_text
 from virtualenv.util.subprocess import Popen
 
 
@@ -20,11 +20,11 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
     current = PythonInfo.current_system()
     bundle_ver = BUNDLE_SUPPORT[current.version_release_str]
     create_cmd = [
-        six.ensure_text(str(tmp_path / "env")),
+        ensure_text(str(tmp_path / "env")),
         "--seeder",
         "app-data",
         "--extra-search-dir",
-        six.ensure_text(str(BUNDLE_FOLDER)),
+        ensure_text(str(BUNDLE_FOLDER)),
         "--download",
         "--pip",
         bundle_ver["pip"].split("-")[1],
@@ -58,7 +58,7 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
         )
     ]:
         assert pip_exe.exists()
-        process = Popen([six.ensure_text(str(pip_exe)), "--version", "--disable-pip-version-check"])
+        process = Popen([ensure_text(str(pip_exe)), "--version", "--disable-pip-version-check"])
         _, __ = process.communicate()
         assert not process.returncode
 


### PR DESCRIPTION
This change should allow installation of virtualenv on systems with older six where their LTS support may prevent them from upgrading it.

Fixes: #1605