### PR TITLE
Enable testing with lower-constraints

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
   - repository: tox
     type: github
     endpoint: github-gb
-    name: tox-dev/azure-pipelines-template
+    name: ssbarnea/azure-pipelines-template
     ref: master
 
 trigger:
@@ -46,6 +46,11 @@ jobs:
         image: [linux, vs2017-win2016, macOs]
       py27:
         image: [linux, windows, macOs]
+      py27_constaint:
+        image: [linux]
+        tox_env: py27
+        variables:
+          PIP_CONSTRAINT: "pip-constraint.txt"
       pypy:
         image: [linux, windows, macOs]
       pypy3:

--- a/pip-constraint.txt
+++ b/pip-constraint.txt
@@ -1,0 +1,2 @@
+# Used to test compatibility with oldest supported dependencies
+six==1.9.0  # shipped with centos-7


### PR DESCRIPTION
Assure we run with oldest dependencies that we still support by default.

Adds `pyXY-lower` environments that force use of oldest supported dependencies.