### PR TITLE
Add packaging environment

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,6 +45,15 @@ supporting Python 2.7 use
 
 .. _compatibility-requirements:
 
+from source
+-----------
+
+If you want to test unreleased version you can run `tox -e packaging` which will produce source and wheel inside
+`dist/` folder.
+
+If you have `pip>=20` you can just do a `pip install git+https://github.com/pypa/virtualenv.git`, older versions will
+fail with confusing errors.
+
 Python and OS Compatibility
 ---------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -161,3 +161,23 @@ deps =
     packaging >= 20.0.0
 commands =
     python tasks/make_zipapp.py
+
+[testenv:packaging]
+description =
+    Do packagin/distribution, leaving artifacts indist dist/ folder.
+usedevelop = false
+skip_install = true
+deps =
+    pep517 >= 0.8.1
+    twine >= 3.1.1
+setenv =
+commands =
+    rm -rfv {toxinidir}/dist/
+    python -m pep517.build \
+      --source \
+      --binary \
+      --out-dir {toxinidir}/dist/ \
+      {toxinidir}
+    python -m twine check .tox/dist/*
+whitelist_externals =
+    rm


### PR DESCRIPTION
Adds a packaging environment and documents its use. This should clarify how
to build and install and unreleased version.

Related: #1609