### PR TITLE
Default testing with lower constrainsts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,19 +38,41 @@ jobs:
     jobs:
       py38:
         image: [linux, vs2017-win2016, macOs]
+      py38-lower:
+        name: py38_lower
+        image: [linux, vs2017-win2016, macOs]
       py37:
+        image: [linux, vs2017-win2016, macOs]
+      py37-lower:
+        name: py37_lower
         image: [linux, vs2017-win2016, macOs]
       py36:
         image: [linux, vs2017-win2016, macOs]
+      py36-lower:
+        name: py36_lower
+        image: [linux, vs2017-win2016, macOs]
       py35:
+        image: [linux, vs2017-win2016, macOs]
+      py35-lower:
+        name: py35_lower
         image: [linux, vs2017-win2016, macOs]
       py27:
         image: [linux, windows, macOs]
+      py27-lower:
+        name: py27_lower
+        image: [linux, windows, macOs]
       pypy:
+        image: [linux, windows, macOs]
+      pypy-lower:
+        name: pypy_lower
         image: [linux, windows, macOs]
       pypy3:
         image: [linux, windows, macOs]
-      fix_lint:
+      pypy3-lower:
+        name: pypy3_lower
+        image: [linux, windows, macOs]
+      fix-lint:
+        name: fix_lint
         image: [linux, windows]
       docs:
         image: [linux, windows]
@@ -79,38 +101,38 @@ jobs:
     before:
       - script: '$(toxPython.pythonLocation)/python -m pip install "virtualenv < 20"'
         displayName: pypy3 tox needs fix to accomodate separate bin and Script
-        condition: and(succeeded(), eq(variables['image_name'], 'windows'), in(variables['TOXENV'], 'pypy3'))
+        condition: and(succeeded(), eq(variables['image_name'], 'windows'), in(variables['TOXENV'], 'pypy3', 'pypy3-lower'))
       - script: '$(toxPython.pythonLocation)/python -m pip install .'
         displayName: tox uses this virtualenv (eat our own dogfood)
-        condition: not(and(succeeded(), eq(variables['image_name'], 'windows'), in(variables['TOXENV'], 'pypy3')))
+        condition: not(and(succeeded(), eq(variables['image_name'], 'windows'), in(variables['TOXENV'], 'pypy3', 'pypy3-lower')))
       - script: 'sudo apt-get update -y && sudo apt-get install fish csh'
-        condition: and(succeeded(), eq(variables['image_name'], 'linux'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py27', 'pypy', 'pypy3'))
+        condition: and(succeeded(), eq(variables['image_name'], 'linux'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py27', 'pypy', 'pypy3', 'py38-lower', 'py37-lower', 'py36-lower', 'py35-lower', 'py27-lower', 'pypy-lower', 'pypy3-lower'))
         displayName: install fish and csh via apt-get
       - script: 'brew update -vvv && brew install fish tcsh'
-        condition: and(succeeded(), eq(variables['image_name'], 'macOs'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py27', 'pypy', 'pypy3'))
+        condition: and(succeeded(), eq(variables['image_name'], 'macOs'), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py27', 'pypy', 'pypy3', 'py38-lower', 'py37-lower', 'py36-lower', 'py35-lower', 'py27-lower', 'pypy-lower', 'pypy3-lower'))
         displayName: install fish and csh via brew
       - task: UsePythonVersion@0
-        condition: and(succeeded(), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35'))
+        condition: and(succeeded(), in(variables['TOXENV'], 'py38', 'py37', 'py36', 'py35', 'py38-lower', 'py37-lower', 'py36-lower', 'py35-lower'))
         displayName: provision cpython 2
         inputs:
           versionSpec: '2.7'
       - task: UsePythonVersion@0
-        condition: and(succeeded(), in(variables['TOXENV'], 'py27'))
+        condition: and(succeeded(), in(variables['TOXENV'], 'py27', 'py27-lower'))
         displayName: provision cpython 3
         inputs:
           versionSpec: '3.8'
       - task: UsePythonVersion@0
-        condition: and(succeeded(), in(variables['TOXENV'], 'pypy'))
+        condition: and(succeeded(), in(variables['TOXENV'], 'pypy', 'pypy-lower'))
         displayName: provision pypy 3
         inputs:
           versionSpec: 'pypy3'
       - task: UsePythonVersion@0
-        condition: and(succeeded(), in(variables['TOXENV'], 'pypy3'))
+        condition: and(succeeded(), in(variables['TOXENV'], 'pypy3', 'pypy3-lower'))
         displayName: provision pypy 2
         inputs:
           versionSpec: 'pypy2'
       - script: choco install vcpython27 --yes -f
-        condition: and(succeeded(), eq(variables['image_name'], 'windows'), in(variables['TOXENV'], 'py27', 'pypy'))
+        condition: and(succeeded(), eq(variables['image_name'], 'windows'), in(variables['TOXENV'], 'py27', 'py27-lower', 'pypy', 'pypy-lower'))
         displayName: Install Visual C++ for Python 2.7
     coverage:
       with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run

--- a/pip-constraint.txt
+++ b/pip-constraint.txt
@@ -1,0 +1,10 @@
+# Used to test compatibility with oldest supported dependencies
+appdirs==1.4.3
+six==1.9.0
+contextlib2==0.6.0;python_version<"3.3"
+importlib-metadata==0.12;python_version<"3.8"
+importlib-resources==1.0;python_version<"3.7"
+pathlib2==2.3.3;python_version < '3.4' and sys.platform != 'win32'
+# Not eanbled yet as they break test_zipapp tests
+# distlib==0.3.0  # ERROR: Could not satisfy constraints for 'distlib': installation from path or url cannot be constrained to a version
+# filelock==3.0.0  # ERROR: Could not satisfy constraints for 'filelock': installation from path or url cannot be constrained to a version

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,9 @@
 [tox]
 minversion = 3.14.0
 envlist =
-    fix_lint,
-    py38,
-    py37,
-    py36,
-    py35,
-    py34,
-    py27,
-    pypy,
-    pypy3,
+    fix-lint,
+    py{38,37,36,35,34,27},
+    py{38,37,36,35,34,27}-lower,
     coverage,
     readme,
     docs,
@@ -24,8 +18,10 @@ setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
     _COVERAGE_SRC = {envsitepackagesdir}/virtualenv
-    PYTHONIOENCODING=utf-8
-    PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
+    PYTHONIOENCODING = utf-8
+    PYTHONWARNINGS = ignore:DEPRECATION::pip._internal.cli.base_command
+    py{38,37,36,35,34,27}-lower: PIP_CONSTRAINT = {toxinidir}/pip-constraint.txt
+
 passenv = https_proxy http_proxy no_proxy HOME PYTEST_* PIP_* CI_RUN TERM
 extras = testing
 install_command = python -m pip install {opts} {packages} --disable-pip-version-check
@@ -99,7 +95,7 @@ passenv = UPGRADE_ADVISORY
 changedir = {toxinidir}/tasks
 commands = python upgrade_wheels.py
 
-[testenv:fix_lint]
+[testenv:fix-lint]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
 basepython = python3.8
 passenv = *


### PR DESCRIPTION
Assure we run with oldest dependencies that we still support by default.

Adds optional `pyXY-upper` environments that bypass the lower
constraints and run tests using latest releases still inside our
supported range.

## Thanks for contributing a pull request, see checklist all is good!

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added news fragment in ``docs/changelog`` folder
