### PR TITLE
Better error message when build dependencies not satisfied

### DIFF
--- a/docs/changelog/1621.feature.rst
+++ b/docs/changelog/1621.feature.rst
@@ -1,0 +1,2 @@
+Fail with better error message if trying to install source with unsupported ``setuptools``, allow ``setuptools-scm >= 2``
+and move to legacy ``setuptools-scm`` format to support better older platforms (``CentOS 7`` and such) - by :user:`gaborbernat`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,9 @@
 requires = [
     "setuptools >= 41.0.0",
     "wheel >= 0.30.0",
-    "setuptools_scm[toml]>=3.4",
+    "setuptools_scm >= 2",
 ]
 build-backend = 'setuptools.build_meta'
-
-[tool.setuptools_scm]
-write_to = "src/virtualenv/version.py"
-write_to_template = """
-\"\"\" Version information \"\"\"
-__version__ = "{version}"
-"""
 
 [tool.black]
 line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = virtualenv
-version = attr: virtualenv.__version__
 description = Virtual Python Environment builder
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
-from setuptools import setup
+from setuptools import __version__, setup
 
-setup()
+if int(__version__.split(".")[0]) < 41:
+    raise RuntimeError("setuptools >= 41 required to build")
+
+setup(
+    use_scm_version={"write_to": "src/virtualenv/version.py", "write_to_template": '__version__ = "{version}"'},
+    setup_requires=["setuptools_scm >= 2"],
+)


### PR DESCRIPTION
This only manifests on old platforms, but as we still support them
makes sense to provide better error messages, and relax a bit our
build requirements.

To validate using the docker build:
```
FROM pycontribs/centos:7
COPY . /w
RUN pip install 'setuptools==41.0.0' 'setuptools_scm==2'
RUN pip install /w -vvv --no-deps --disable-pip-version-check
RUN pip freeze 
```

Resolves https://github.com/pypa/virtualenv/issues/1621