### PR TITLE
raise build error if we have setuptools less than 42

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.tox
+virtualenv.pyz
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ venv*
 .python-version
 
 *wheel-store*
+Dockerfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 41.0.0",
+    "setuptools >= 42.0.0",
     "wheel >= 0.30.0",
     "setuptools_scm >= 2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import __version__, setup
 
-if int(__version__.split(".")[0]) < 41:
-    raise RuntimeError("setuptools >= 41 required to build")
+if int(__version__.split(".")[0]) < 42:
+    raise RuntimeError("setuptools >= 42 required to build")
 
 setup(
     use_scm_version={"write_to": "src/virtualenv/version.py", "write_to_template": '__version__ = "{version}"'},


### PR DESCRIPTION
Resolves https://github.com/pypa/virtualenv/issues/1630

The zipp package fails to install otherwise, ending up in runtime error.