### PR TITLE
tox: call coverage as module

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,15 +31,15 @@ extras = testing
 install_command = python -m pip install {opts} {packages} --disable-pip-version-check
 commands =
     python -c 'from os.path import sep; file = open(r"{envsitepackagesdir}\{\}coverage-virtualenv.pth".format(sep), "w"); file.write("import coverage; coverage.process_startup()"); file.close()'
-    coverage erase
+    python -m coverage erase
 
-    coverage run\
+    python -m coverage run\
     -m pytest \
     --junitxml {toxworkdir}/junit.{envname}.xml \
     tests {posargs:--int}
 
-    coverage combine
-    coverage report
+    python -m coverage combine
+    python -m coverage report
 
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report;
@@ -54,10 +54,10 @@ passenv = DIFF_AGAINST
 setenv =
     COVERAGE_FILE={toxworkdir}/.coverage
 commands =
-    coverage combine
-    coverage report --show-missing
-    coverage xml -o {toxworkdir}/coverage.xml
-    coverage html -d {toxworkdir}/htmlcov
+    python -m coverage combine
+    python -m coverage report --show-missing
+    python -m coverage xml -o {toxworkdir}/coverage.xml
+    python -m coverage html -d {toxworkdir}/htmlcov
     diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
 depends =
     py38,


### PR DESCRIPTION
Avoids runtime warning and potential issues of using externally
installed coverage. Warning was observed on Azure.