### PR TITLE
Fix error printing in bailout for Python < 2.7

### DIFF
--- a/docs/changelog/1651.bugfix.rst
+++ b/docs/changelog/1651.bugfix.rst
@@ -1,0 +1,1 @@
+fix error printing in bailout for Python < 2.7 - by ``AdamWill`

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -50,7 +50,7 @@ __version__ = "16.7.9"
 virtualenv_version = __version__  # legacy
 DEBUG = os.environ.get("_VIRTUALENV_DEBUG", None) == "1"
 if sys.version_info < (2, 7):
-    print("ERROR: {}".format(sys.exc_info()[1]))
+    print("ERROR: {0}".format(sys.exc_info()[1]))
     print("ERROR: this script requires Python 2.7 or greater.")
     sys.exit(101)
 


### PR DESCRIPTION
Ironically, the code that tries to print an error message when
we're running on Python < 2.7 can only work on Python 2.7 or
higher! Prior to 2.7, the curly-braces style of string formatting
required all fields to be explicitly numbered; you have to use
{0}, you cannot use {}. So if you actually try to run virtualenv
on Python 2.6, you get an error when trying to print the error!
This should fix that, and print the right error...

Signed-off-by: Adam Williamson <awilliam@redhat.com>

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added news fragment in ``docs/changelog`` folder
