### PR TITLE
Ensure distutils configuration values do not escape virtual environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,8 @@ if int(__version__.split(".")[0]) < 41:
 
 setup(
     use_scm_version={"write_to": "src/virtualenv/version.py", "write_to_template": '__version__ = "{version}"'},
-    setup_requires=["setuptools_scm >= 2"],
+    setup_requires=[
+        # this cannot be enabled until https://github.com/pypa/pip/issues/7778 is addressed
+        # "setuptools_scm >= 2"
+    ],
 )

--- a/src/virtualenv/create/via_global_ref/_distutils_patch_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_distutils_patch_virtualenv.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+Distutils allows user to configure some arguments via a configuration file:
+https://docs.python.org/3/install/index.html#distutils-configuration-files
+
+Some of this arguments though don't make sense in context of the virtual environment files, let's fix them up.
+"""
+import os
+import sys
+
+VIRTUALENV_PATCH_FILE = os.path.join(__file__)
+
+
+def patch(dist_of):
+    # we cannot allow the prefix override as that would get packages installed outside of the virtual environment
+    old_parse_config_files = dist_of.Distribution.parse_config_files
+
+    def parse_config_files(self, *args, **kwargs):
+        result = old_parse_config_files(self, *args, **kwargs)
+        install_dict = self.get_option_dict("install")
+
+        if "prefix" in install_dict:  # the prefix governs where to install the libraries
+            install_dict["prefix"] = VIRTUALENV_PATCH_FILE, os.path.abspath(sys.prefix)
+
+        if "install_scripts" in install_dict:  # the install_scripts governs where to generate console scripts
+            script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "__SCRIPT_DIR__"))
+            install_dict["install_scripts"] = VIRTUALENV_PATCH_FILE, script_path
+
+        return result
+
+    dist_of.Distribution.parse_config_files = parse_config_files
+
+
+def run():
+    # patch distutils
+    from distutils import dist
+
+    patch(dist)
+
+    # patch setuptools (that has it's own copy of the dist package)
+    try:
+        from setuptools import dist
+    except ImportError:
+        pass  # if setuptools is not around that's alright, just don't patch
+    else:
+        patch(dist)
+
+
+run()

--- a/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
+++ b/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
@@ -79,6 +79,7 @@ class ViaGlobalRefVirtualenvBuiltin(ViaGlobalRefApi, VirtualenvBuiltin):
         finally:
             if true_system_site != self.enable_system_site_package:
                 self.enable_system_site_package = true_system_site
+        super(ViaGlobalRefVirtualenvBuiltin, self).create()
 
     def ensure_directories(self):
         return {self.dest, self.bin_dir, self.script_dir, self.stdlib} | set(self.libs)

--- a/src/virtualenv/create/via_global_ref/venv.py
+++ b/src/virtualenv/create/via_global_ref/venv.py
@@ -38,9 +38,12 @@ class Venv(ViaGlobalRefApi):
             self.create_inline()
         else:
             self.create_via_sub_process()
-            # TODO: cleanup activation scripts
+
+        # TODO: cleanup activation scripts
+
         for lib in self.libs:
             ensure_dir(lib)
+        super(Venv, self).create()
 
     def create_inline(self):
         from venv import EnvBuilder

--- a/tests/unit/create/console_app/demo/__init__.py
+++ b/tests/unit/create/console_app/demo/__init__.py
@@ -1,0 +1,6 @@
+def run():
+    print("magic")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/unit/create/console_app/demo/__main__.py
+++ b/tests/unit/create/console_app/demo/__main__.py
@@ -1,0 +1,6 @@
+def run():
+    print("magic")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/unit/create/console_app/setup.cfg
+++ b/tests/unit/create/console_app/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = demo
+version = 1.0.0
+description = magic package
+
+[options]
+packages = find:
+install_requires =
+
+[options.entry_points]
+console_scripts =
+    magic=demo.__main__:run
+
+[bdist_wheel]
+universal = true

--- a/tests/unit/create/console_app/setup.py
+++ b/tests/unit/create/console_app/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -133,7 +133,9 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
         # pypy cleans up file descriptors periodically so our (many) subprocess calls impact file descriptor limits
         # force a cleanup of these on system where the limit is low-ish (e.g. MacOS 256)
         gc.collect()
-    patch_files = {result.creator.purelib / "{}.{}".format("_distutils_patch_virtualenv", i) for i in ("py", "pth")}
+    purelib = result.creator.purelib
+    patch_files = {purelib / "{}.{}".format("_distutils_patch_virtualenv", i) for i in ("py", "pyc", "pth")}
+    patch_files.add(purelib / "__pycache__")
     content = set(result.creator.purelib.iterdir()) - patch_files
     assert not content, "\n".join(ensure_text(str(i)) for i in content)
     assert result.creator.env_name == ensure_text(dest.name)

--- a/tests/unit/seed/test_boostrap_link_via_app_data.py
+++ b/tests/unit/seed/test_boostrap_link_via_app_data.py
@@ -93,7 +93,9 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
     assert not process.returncode
     # pip is greedy here, removing all packages removes the site-package too
     if site_package.exists():
-        patch_files = {result.creator.purelib / "{}.{}".format("_distutils_patch_virtualenv", i) for i in ("py", "pth")}
+        purelib = result.creator.purelib
+        patch_files = {purelib / "{}.{}".format("_distutils_patch_virtualenv", i) for i in ("py", "pyc", "pth")}
+        patch_files.add(purelib / "__pycache__")
         post_run = set(site_package.iterdir()) - patch_files
         assert not post_run, "\n".join(str(i) for i in post_run)
 

--- a/tests/unit/seed/test_boostrap_link_via_app_data.py
+++ b/tests/unit/seed/test_boostrap_link_via_app_data.py
@@ -93,7 +93,8 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
     assert not process.returncode
     # pip is greedy here, removing all packages removes the site-package too
     if site_package.exists():
-        post_run = list(site_package.iterdir())
+        patch_files = {result.creator.purelib / "{}.{}".format("_distutils_patch_virtualenv", i) for i in ("py", "pth")}
+        post_run = set(site_package.iterdir()) - patch_files
         assert not post_run, "\n".join(str(i) for i in post_run)
 
     if sys.version_info[0:2] == (3, 4) and os.environ.get(str("PIP_REQ_TRACKER")):


### PR DESCRIPTION
Distutils has some configuration files where the user may alter paths to
point outside of the virtual environment. Defend against this by
installing a pth file that resets this to their expected path.

Resolves #1635.