### PR TITLE
Remove a leftover error line with empty exception info

### DIFF
--- a/docs/changelog/1651.bugfix.rst
+++ b/docs/changelog/1651.bugfix.rst
@@ -1,1 +1,1 @@
-fix error printing in bailout for Python < 2.7 - by ``AdamWill`
+fix error printing in bailout for Python < 2.7 - by ``AdamWill` and ``hroncok``

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -50,7 +50,6 @@ __version__ = "16.7.9"
 virtualenv_version = __version__  # legacy
 DEBUG = os.environ.get("_VIRTUALENV_DEBUG", None) == "1"
 if sys.version_info < (2, 7):
-    print("ERROR: {0}".format(sys.exc_info()[1]))
     print("ERROR: this script requires Python 2.7 or greater.")
     sys.exit(101)
 


### PR DESCRIPTION
Since a6d6ed791d94c39b7348192503866aff6a0ba458 there is no exception to report about.

Related to https://github.com/pypa/virtualenv/pull/1651

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added news fragment in ``docs/changelog`` folder
