### PR TITLE
support entry point paths with space

### DIFF
--- a/docs/changelog/1660.bugfix.rst
+++ b/docs/changelog/1660.bugfix.rst
@@ -1,0 +1,1 @@
+Fix creation of entry points when path contains spaces - by :user:`nsoranzo`.

--- a/src/virtualenv/seed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/base.py
@@ -129,13 +129,13 @@ class PipInstall(object):
 
     def _create_console_entry_point(self, name, value, to_folder, version_info):
         result = []
-        from distlib.scripts import ScriptMaker
+        from distlib.scripts import _enquote_executable, ScriptMaker
 
         maker = ScriptMaker(None, str(to_folder))
         maker.clobber = True  # overwrite
         maker.variants = {""}
         maker.set_mode = True  # ensure they are executable
-        maker.executable = str(self._creator.exe)
+        maker.executable = _enquote_executable(str(self._creator.exe))
         specification = "{} = {}".format(name, value)
         with self.patch_distlib_correct_variants(version_info, maker):
             new_files = maker.make(specification)

--- a/src/virtualenv/seed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/base.py
@@ -9,6 +9,8 @@ from contextlib import contextmanager
 from tempfile import mkdtemp
 from threading import Lock
 
+# noinspection PyProtectedMember
+from distlib.scripts import ScriptMaker, _enquote_executable
 from six import PY3, add_metaclass
 
 from virtualenv.util import ConfigParser
@@ -129,12 +131,11 @@ class PipInstall(object):
 
     def _create_console_entry_point(self, name, value, to_folder, version_info):
         result = []
-        from distlib.scripts import _enquote_executable, ScriptMaker
-
         maker = ScriptMaker(None, str(to_folder))
         maker.clobber = True  # overwrite
         maker.variants = {""}
         maker.set_mode = True  # ensure they are executable
+        # calling private until https://bitbucket.org/pypa/distlib/issues/135/expose-_enquote_executable-as-public
         maker.executable = _enquote_executable(str(self._creator.exe))
         specification = "{} = {}".format(name, value)
         with self.patch_distlib_correct_variants(version_info, maker):

--- a/src/virtualenv/seed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/base.py
@@ -133,7 +133,7 @@ class PipInstall(object):
         result = []
         maker = ScriptMaker(None, str(to_folder))
         maker.clobber = True  # overwrite
-        maker.variants = {""}
+        maker.variants = {""}  # set within patch_distlib_correct_variants
         maker.set_mode = True  # ensure they are executable
         # calling private until https://bitbucket.org/pypa/distlib/issues/135/expose-_enquote_executable-as-public
         maker.executable = _enquote_executable(str(self._creator.exe))

--- a/tests/unit/seed/test_boostrap_link_via_app_data.py
+++ b/tests/unit/seed/test_boostrap_link_via_app_data.py
@@ -16,7 +16,7 @@ from virtualenv.util.subprocess import Popen
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("copies", [True, False] if fs_supports_symlink() else [True])
+@pytest.mark.parametrize("copies", [False, True] if fs_supports_symlink() else [True])
 def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastest, copies):
     current = PythonInfo.current_system()
     bundle_ver = BUNDLE_SUPPORT[current.version_release_str]
@@ -87,6 +87,9 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
     files_post_second_create = list(site_package.iterdir())
     assert files_post_first_create == files_post_second_create
 
+    # Windows does not allow removing a executable while running it, so when uninstalling pip we need to do it via
+    # python -m pip
+    remove_cmd = [str(result.creator.exe), "-m", "pip"] + remove_cmd[1:]
     process = Popen(remove_cmd + ["pip", "wheel"])
     _, __ = process.communicate()
     assert not process.returncode

--- a/tests/unit/seed/test_boostrap_link_via_app_data.py
+++ b/tests/unit/seed/test_boostrap_link_via_app_data.py
@@ -21,7 +21,7 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
     current = PythonInfo.current_system()
     bundle_ver = BUNDLE_SUPPORT[current.version_release_str]
     create_cmd = [
-        ensure_text(str(tmp_path / "env")),
+        ensure_text(str(tmp_path / "en v")),  # space in the name to ensure generated scripts work when path has space
         "--seeder",
         "app-data",
         "--extra-search-dir",
@@ -64,9 +64,7 @@ def test_base_bootstrap_link_via_app_data(tmp_path, coverage_env, current_fastes
         assert not process.returncode
 
     remove_cmd = [
-        str(result.creator.exe),
-        "-m",
-        "pip",
+        str(result.creator.script("pip")),
         "--verbose",
         "--disable-pip-version-check",
         "uninstall",

--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,7 @@ force_grid_wrap = 0
 line_length = 120
 known_standard_library = ConfigParser
 known_first_party = virtualenv
-known_third_party = _subprocess,appdirs,coverage,docutils,filelock,git,packaging,pytest,setuptools,six,sphinx,sphinx_rtd_theme,sphinxarg
+known_third_party = _subprocess,appdirs,coverage,distlib,docutils,filelock,git,packaging,pytest,setuptools,six,sphinx,sphinx_rtd_theme,sphinxarg
 
 [flake8]
 max-complexity = 22


### PR DESCRIPTION
Before this patch:

```console
$ virtualenv --version
virtualenv 20.0.6.dev5+g9201422 from /usr/users/ga002/soranzon/software/nsoranzo_virtualenv/.venv/local/lib/python2.7/site-packages/virtualenv/__init__.pyc
$ virtualenv 'foo bar'
created virtual environment CPython2.7.17.final.0-64 in 403ms
  creator CPython2Posix(dest=/usr/users/ga002/soranzon/software/nsoranzo_virtualenv/foo bar, clear=False, global=False)
  seeder FromAppData(download=False, pip=latest, setuptools=latest, wheel=latest, via=copy, app_data_dir=/usr/users/ga002/soranzon/.local/share/virtualenv/seed-v1)
  activators PythonActivator,CShellActivator,FishActivator,PowerShellActivator,BashActivator
$ head -n 3 foo\ bar/bin/pip
#!/bin/sh
'''exec' /usr/users/ga002/soranzon/software/nsoranzo_virtualenv/foo bar/bin/python "$0" "$@"
' '''
$ ./foo\ bar/bin/pip
./foo bar/bin/pip: 2: exec: /usr/users/ga002/soranzon/software/nsoranzo_virtualenv/foo: not found
```

After this patch:

```console
$ virtualenv 'foo bar'
created virtual environment CPython2.7.17.final.0-64 in 336ms
  creator CPython2Posix(dest=/usr/users/ga002/soranzon/software/nsoranzo_virtualenv/foo bar, clear=False, global=False)
  seeder FromAppData(download=False, pip=latest, setuptools=latest, wheel=latest, via=copy, app_data_dir=/usr/users/ga002/soranzon/.local/share/virtualenv/seed-v1)
  activators PythonActivator,CShellActivator,FishActivator,PowerShellActivator,BashActivator
$ head -n 3 foo\ bar/bin/pip
#!/bin/sh
'''exec' "/usr/users/ga002/soranzon/software/nsoranzo_virtualenv/foo bar/bin/python" "$0" "$@"
' '''
$ ./foo\ bar/bin/pip

Usage:
  pip <command> [options]
...
```

N.B.: virtualenv <20 was also quoting the path and therefore did not have the issue.

## Thanks for contributing a pull request, see checklist all is good!

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added news fragment in ``docs/changelog`` folder
