### PR TITLE
Minor fix to installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ inconsistent state.
 
 .. code-block:: console
 
-    python -m pip --user install virtualenv
+    python -m pip install --user virtualenv
     python -m virtualenv --help
 
 via zipapp


### PR DESCRIPTION
Fixed the position of the --user flag for the suggested pip install command.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation
