### PR TITLE
fix relative zipapp paths on UNIX - release 20.0.6

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,7 @@ Bugfixes - 20.0.6
   by :user:`gaborbernat`. (`#1640 <https://github.com/pypa/virtualenv/issues/1640>`_)
 - Fix PyPy 2 builtin modules are imported from standard library, rather than from builtin  - by :user:`gaborbernat`. (`#1652 <https://github.com/pypa/virtualenv/issues/1652>`_)
 - Fix creation of entry points when path contains spaces - by :user:`nsoranzo`. (`#1660 <https://github.com/pypa/virtualenv/issues/1660>`_)
-
+- Fix relative paths for the zipapp (for python ``3.7+``) - by :user:`gaborbernat`. (`#1666 <https://github.com/pypa/virtualenv/issues/1666>`_)
 
 v20.0.5 (2020-02-21)
 --------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,28 @@ Release History
 
 .. towncrier release notes start
 
+v20.0.6 (2020-02-26)
+--------------------
+
+Bugfixes - 20.0.6
+~~~~~~~~~~~~~~~~~
+- Fix global site package always being added with bundled macOs python framework builds - by :user:`gaborbernat`. (`#1561 <https://github.com/pypa/virtualenv/issues/1561>`_)
+- Fix generated scripts use host version info rather than target - by :user:`gaborbernat`. (`#1600 <https://github.com/pypa/virtualenv/issues/1600>`_)
+- Fix circular prefix reference with single elements (accept these as if they were system executables, print a info about
+  them referencing themselves) - by :user:`gaborbernat`. (`#1632 <https://github.com/pypa/virtualenv/issues/1632>`_)
+- Handle the case when the application data folder is read-only:
+
+  - the application data folder is now controllable via :option:`app-data`,
+  - :option:`clear-app-data` now cleans the entire application data folder, not just the ``app-data`` seeder path,
+  - check if the application data path passed in does not exist or is read-only, and fallback to a temporary directory,
+  - temporary directory application data is automatically cleaned up at the end of execution,
+  - :option:`symlink-app-data` is always ``False`` when the application data is temporary
+
+  by :user:`gaborbernat`. (`#1640 <https://github.com/pypa/virtualenv/issues/1640>`_)
+- Fix PyPy 2 builtin modules are imported from standard library, rather than from builtin  - by :user:`gaborbernat`. (`#1652 <https://github.com/pypa/virtualenv/issues/1652>`_)
+- Fix creation of entry points when path contains spaces - by :user:`nsoranzo`. (`#1660 <https://github.com/pypa/virtualenv/issues/1660>`_)
+
+
 v20.0.5 (2020-02-21)
 --------------------
 

--- a/docs/changelog/1561.bugfix.rst
+++ b/docs/changelog/1561.bugfix.rst
@@ -1,1 +1,0 @@
-Fix global site package always being added with bundled macOs python framework builds - by :user:`gaborbernat`.

--- a/docs/changelog/1600.bugfix.rst
+++ b/docs/changelog/1600.bugfix.rst
@@ -1,1 +1,0 @@
-Fix generated scripts use host version info rather than target - by :user:`gaborbernat`.

--- a/docs/changelog/1632.bugfix.rst
+++ b/docs/changelog/1632.bugfix.rst
@@ -1,2 +1,0 @@
-Fix circular prefix reference with single elements (accept these as if they were system executables, print a info about
-them referencing themselves) - by :user:`gaborbernat`.

--- a/docs/changelog/1640.bugfix.rst
+++ b/docs/changelog/1640.bugfix.rst
@@ -1,9 +1,0 @@
-Handle the case when the application data folder is read-only:
-
-- the application data folder is now controllable via :option:`app-data`,
-- :option:`clear-app-data` now cleans the entire application data folder, not just the ``app-data`` seeder path,
-- check if the application data path passed in does not exist or is read-only, and fallback to a temporary directory,
-- temporary directory application data is automatically cleaned up at the end of execution,
-- :option:`symlink-app-data` is always ``False`` when the application data is temporary
-
-by :user:`gaborbernat`.

--- a/docs/changelog/1652.bugfix.rst
+++ b/docs/changelog/1652.bugfix.rst
@@ -1,1 +1,0 @@
-Fix PyPy 2 builtin modules are imported from standard library, rather than from builtin  - by :user:`gaborbernat`.

--- a/docs/changelog/1660.bugfix.rst
+++ b/docs/changelog/1660.bugfix.rst
@@ -1,1 +1,0 @@
-Fix creation of entry points when path contains spaces - by :user:`nsoranzo`.

--- a/src/virtualenv/util/zipapp.py
+++ b/src/virtualenv/util/zipapp.py
@@ -29,7 +29,8 @@ def extract(full_path, dest):
 
 
 def _get_path_within_zip(full_path):
-    sub_file = str(full_path)[len(ROOT) + 1 :]
+    full_path = os.path.abspath(str(full_path))
+    sub_file = full_path[len(ROOT) + 1 :]
     if IS_WIN:
         # paths are always UNIX separators, even on Windows, though __file__ still follows platform default
         sub_file = sub_file.replace(os.sep, "/")


### PR DESCRIPTION
zipapp release via https://github.com/pypa/get-virtualenv/pull/11
PyPi release via https://dev.azure.com/pypa/virtualenv/_build/results?buildId=19409&view=results