### PR TITLE
LEGACY: Only get setuptools < 44 on Python 3.4

### DIFF
--- a/docs/changelog/1677.misc.rst
+++ b/docs/changelog/1677.misc.rst
@@ -1,0 +1,1 @@
+Don't attempt to use setuptools 44+ with Python 3.4 - by ``hroncok``

--- a/virtualenv.py
+++ b/virtualenv.py
@@ -998,6 +998,8 @@ def find_wheels(projects, search_dirs):
                 )
                 if project == "pip" and sys.version_info[0:2] == (3, 4):
                     wheel = next(p for v, p in versions if v <= (19, 1, 1))
+                elif project == "setuptools" and sys.version_info[0:2] == (3, 4):
+                    wheel = next(p for v, p in versions if v < (44,))
                 else:
                     wheel = versions[0][1]
                 wheels.append(wheel)
@@ -1091,9 +1093,13 @@ def _install_wheel_with_search_dir(download, project_names, py_executable, searc
         )
     ).encode("utf8")
 
-    if sys.version_info[0:2] == (3, 4) and "pip" in project_names:
-        at = project_names.index("pip")
-        project_names[at] = "pip<19.2"
+    if sys.version_info[0:2] == (3, 4):
+        if "pip" in project_names:
+            at = project_names.index("pip")
+            project_names[at] = "pip<19.2"
+        if "setuptools" in project_names:
+            at = project_names.index("setuptools")
+            project_names[at] = "setuptools<44"
 
     cmd = [py_executable, "-"] + project_names
     logger.start_progress("Installing {}...".format(", ".join(project_names)))


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
