### PR TITLE
Fix py info might be misslead by distutils config

### DIFF
--- a/docs/changelog/1663.bugfix.rst
+++ b/docs/changelog/1663.bugfix.rst
@@ -1,0 +1,2 @@
+Fix acquiring python information might be altered by distutils configuration files generating incorrect layout virtual
+environments - by :user:`gaborbernat`.

--- a/docs/changelog/1702.bugfix.rst
+++ b/docs/changelog/1702.bugfix.rst
@@ -1,1 +1,1 @@
-Upgrade embedded setuptools to ``46.0.0`` from ``45.3.0`` on Python ``3.5+``.
+Upgrade embedded setuptools to ``46.0.0`` from ``45.3.0`` on Python ``3.5+`` - by :user:`gaborbernat`.

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -23,11 +23,10 @@ def patch_dist(dist):
 
         if "prefix" in install:  # the prefix governs where to install the libraries
             install["prefix"] = VIRTUALENV_PATCH_FILE, os.path.abspath(sys.prefix)
-
-        if "install_scripts" in install:  # the install_scripts governs where to generate console scripts
-            script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "__SCRIPT_DIR__"))
-            install["install_scripts"] = VIRTUALENV_PATCH_FILE, script_path
-
+        for base in ("purelib", "platlib", "headers", "scripts", "data"):
+            key = "install_{}".format(base)
+            if key in install:  # do not allow global configs to hijack venv paths
+                install.pop(key, None)
         return result
 
     dist.Distribution.parse_config_files = parse_config_files

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -111,10 +111,9 @@ class PythonInfo(object):
     @staticmethod
     def _distutils_install():
         # follow https://github.com/pypa/pip/blob/master/src/pip/_internal/locations.py#L95
-        d = Distribution({"script_args": "--no-user-cfg"})
-        d.parse_config_files()
+        d = Distribution({"script_args": "--no-user-cfg"})  # configuration files not parsed so they do not hijack paths
         i = d.get_command_obj("install", create=True)
-        i.prefix = "a"
+        i.prefix = os.sep  # paths generated are relative to prefix that contains the path sep, this makes it relative
         i.finalize_options()
         result = {key: (getattr(i, "install_{}".format(key))[1:]).lstrip(os.sep) for key in SCHEME_KEYS}
         return result

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -369,11 +369,17 @@ def test_create_distutils_cfg(creator, tmp_path, monkeypatch):
     setup_cfg = dest / "setup.cfg"
     conf = dedent(
         """
-    [install]
-    prefix={}/a
-    install_scripts={}/b
-    """
-    ).format(tmp_path, tmp_path)
+            [install]
+            prefix={0}{1}prefix
+            install_purelib={0}{1}purelib
+            install_platlib={0}{1}platlib
+            install_headers={0}{1}headers
+            install_scripts={0}{1}scripts
+            install_data={0}{1}data
+            """.format(
+            tmp_path, os.sep
+        )
+    )
     setup_cfg.write_text(setup_cfg.read_text() + conf)
 
     monkeypatch.chdir(dest)  # distutils will read the setup.cfg from the cwd, so change to that


### PR DESCRIPTION
Ignore configuration file parsing when getting distutils data.

Resolves #1663.