### PR TITLE
Allow missing .py files if .pyc is present

### DIFF
--- a/docs/changelog/1714.bugfix.rst
+++ b/docs/changelog/1714.bugfix.rst
@@ -1,0 +1,1 @@
+Allow missing ``.py`` files if a compiled ``.pyc`` version is available - by :user:`tucked`.

--- a/docs/changelog/1714.doc.rst
+++ b/docs/changelog/1714.doc.rst
@@ -1,0 +1,2 @@
+:ref:`supports <compatibility-requirements>` details now explicitly what Python installations we support
+- by :user:`gaborbernat`.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -122,6 +122,6 @@ Windows
 Packaging variants
 ~~~~~~~~~~~~~~~~~~
 - Normal variant (file structure as comes from `python.org <https://www.python.org/downloads/>`_).
-- We support system installations that do not contain the python files for the standard library if the respective
-  compiled files are present (e.g. only ``os.pyc``, not ``os.py``) - relevant mostly for ``Python 2.7``. This can be
-  used by custom systems may want to maximize available storage or obfuscate source code by removing ``.py`` files.
+- We support CPython 2 system installations that do not contain the python files for the standard library if the
+  respective compiled files are present (e.g. only ``os.pyc``, not ``os.py``). This can be used by custom systems may
+  want to maximize available storage or obfuscate source code by removing ``.py`` files.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -89,8 +89,39 @@ virtualenv works with the following Python interpreter implementations:
 - `PyPy <https://pypy.org/>`_ 2.7 and 3.4+.
 
 This means virtualenv works on the latest patch version of each of these minor versions. Previous patch versions are
-supported on a best effort approach. virtualenv works on the following platforms:
+supported on a best effort approach.
 
-- Unix/Linux,
-- macOS,
-- Windows.
+CPython is shipped in multiple forms, and each OS repackages it, often applying some customization along the way.
+Therefore we cannot say universally that we support all platforms, but rather specify some we test against. In case
+of ones not specified here the support is unknown, though likely will work. If you find some cases please open a feature
+request on our issue tracker.
+
+Linux
+~~~~~
+- installations from `python.org <https://www.python.org/downloads/>`_
+- Ubuntu 16.04+ (both upstream and `deasnakes <https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa>`_ builds)
+- Fedora
+- RHEL and CentOS
+- OpenSuse
+- Arch Linux
+
+macOS
+~~~~~
+In case of macOs we support:
+- installations from `python.org <https://www.python.org/downloads/>`_
+- python versions installed via `brew <https://docs.brew.sh/Homebrew-and-Python>`_ (both older python2.7 and python3)
+- Python 3 part of XCode (Python framework - ``/Library/Frameworks/Python3.framework/``)
+- Python 2 part of the OS (``/System/Library/Frameworks/Python.framework/Versions/``)
+
+Windows
+~~~~~~~
+- Installations from `python.org <https://www.python.org/downloads/>`_
+- Windows Store Python - note only `version 3.8+ <https://www.microsoft.com/en-us/p/python-38/9mssztt1n39l>`_ (``3.7``
+  was marked experimental and contains many bugs that would make it very hard for us to support it)
+
+Packaging variants
+~~~~~~~~~~~~~~~~~~
+- Normal variant (file structure as comes from `python.org <https://www.python.org/downloads/>`_).
+- We support system installations that do not contain the python files for the standard library if the respective
+  compiled files are present (e.g. only ``os.pyc``, not ``os.py``) - relevant mostly for ``Python 2.7``. This can be
+  used by custom systems may want to maximize available storage or obfuscate source code by removing ``.py`` files.

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython2.py
@@ -26,6 +26,10 @@ class CPython2(CPython, Python2):
             yield PathRefToDest(host_include_marker.parent, dest=lambda self, _: self.include)
 
     @classmethod
+    def needs_stdlib_py_module(cls):
+        return False
+
+    @classmethod
     def host_include_marker(cls, interpreter):
         return Path(interpreter.system_include) / "Python.h"
 

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
@@ -32,6 +32,10 @@ class PyPy2(PyPy, Python2):
             yield PathRefToDest(host_include_marker.parent, dest=lambda self, _: self.include)
 
     @classmethod
+    def needs_stdlib_py_module(cls):
+        return True
+
+    @classmethod
     def host_include_marker(cls, interpreter):
         return Path(interpreter.system_include) / "PyPy.h"
 

--- a/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
@@ -57,13 +57,13 @@ class Python2(ViaGlobalRefVirtualenvBuiltin, Python2Supports):
             yield src
         # install files needed to run site.py
         for req in cls.modules():
-            stdlib_path = interpreter.stdlib_path("{}.py".format(req))
-            comp = Path(stdlib_path.stem + ".pyc")
+            comp = interpreter.stdlib_path("{}.pyc".format(req))
             comp_exists = comp.exists()
-            if stdlib_path.exists() or not comp_exists:
-                yield PathRefToDest(stdlib_path, dest=cls.to_stdlib)
             if comp_exists:
                 yield PathRefToDest(comp, dest=cls.to_stdlib)
+            stdlib_path = interpreter.stdlib_path("{}.py".format(req))
+            if stdlib_path.exists() or not comp_exists:
+                yield PathRefToDest(stdlib_path, dest=cls.to_stdlib)
 
     def to_stdlib(self, src):
         return self.stdlib / src.name

--- a/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
@@ -58,9 +58,11 @@ class Python2(ViaGlobalRefVirtualenvBuiltin, Python2Supports):
         # install files needed to run site.py
         for req in cls.modules():
             stdlib_path = interpreter.stdlib_path("{}.py".format(req))
-            yield PathRefToDest(stdlib_path, dest=cls.to_stdlib)
-            comp = stdlib_path.parent / "{}.pyc".format(req)
-            if comp.exists():
+            comp = Path(stdlib_path.stem + ".pyc")
+            comp_exists = comp.exists()
+            if stdlib_path.exists() or not comp_exists:
+                yield PathRefToDest(stdlib_path, dest=cls.to_stdlib)
+            if comp_exists:
                 yield PathRefToDest(comp, dest=cls.to_stdlib)
 
     def to_stdlib(self, src):

--- a/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/python2.py
@@ -57,13 +57,27 @@ class Python2(ViaGlobalRefVirtualenvBuiltin, Python2Supports):
             yield src
         # install files needed to run site.py
         for req in cls.modules():
-            comp = interpreter.stdlib_path("{}.pyc".format(req))
-            comp_exists = comp.exists()
-            if comp_exists:
-                yield PathRefToDest(comp, dest=cls.to_stdlib)
-            stdlib_path = interpreter.stdlib_path("{}.py".format(req))
-            if stdlib_path.exists() or not comp_exists:
-                yield PathRefToDest(stdlib_path, dest=cls.to_stdlib)
+
+            # the compiled path is optional, but refer to it if exists
+            module_compiled_path = interpreter.stdlib_path("{}.pyc".format(req))
+            has_compile = module_compiled_path.exists()
+            if has_compile:
+                yield PathRefToDest(module_compiled_path, dest=cls.to_stdlib)
+
+            # stdlib module src may be missing if the interpreter allows it by falling back to the compiled
+            module_path = interpreter.stdlib_path("{}.py".format(req))
+            add_py_module = cls.needs_stdlib_py_module()
+            if add_py_module is False:
+                if module_path.exists():  # if present add it
+                    add_py_module = True
+                else:
+                    add_py_module = not has_compile  # otherwise only add it if the pyc is not present
+            if add_py_module:
+                yield PathRefToDest(module_path, dest=cls.to_stdlib)
+
+    @classmethod
+    def needs_stdlib_py_module(cls):
+        raise NotImplementedError
 
     def to_stdlib(self, src):
         return self.stdlib / src.name

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -19,6 +19,7 @@ import pytest
 
 from virtualenv.__main__ import run, run_with_catch
 from virtualenv.create.creator import DEBUG_SCRIPT, Creator, get_env_debug_info
+from virtualenv.create.via_global_ref.builtin.cpython.cpython2 import CPython2
 from virtualenv.discovery.builtin import get_interpreter
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import IS_PYPY, IS_WIN, PY3, fs_is_case_sensitive, fs_supports_symlink
@@ -448,3 +449,31 @@ def test_python_path(monkeypatch, tmp_path, python_path_on):
         assert non_python_path == [i for i in base if i not in extra_as_python_path]
     else:
         assert base == extra_all
+
+
+@pytest.fixture
+def creator_with_pyc_only_cp2_modules(tmp_path, monkeypatch, current_creators):
+    """
+    Get a current_creator in a context where CPython2.modules only
+    references modules that have .pyc files (and no corresponding .py file).
+    """
+    monkeypatch.chdir(tmp_path)
+    creator = current_creators[2]
+    module_name = os.path.relpath("CPython2_patch_modules_module", CURRENT.system_stdlib)
+    module_path = Path(CURRENT.system_stdlib) / "{}.pyc".format(module_name)
+    with module_path.open(mode="w"):
+        pass  # just a touch
+
+    @classmethod
+    def modules(cls):
+        return [module_name]
+
+    monkeypatch.setattr(CPython2, "modules", modules)
+    yield creator
+    module_path.unlink()
+
+
+@pytest.mark.skipif(PY3, reason=".py files are only checked for in py2.")
+def test_pyc_only(creator_with_pyc_only_cp2_modules):
+    """Ensure that creation can succeed if os.pyc exists (even if os.py has been deleted)."""
+    assert creator_with_pyc_only_cp2_modules.can_create(CURRENT) is not None

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -451,7 +451,8 @@ def test_python_path(monkeypatch, tmp_path, python_path_on):
 
 
 @pytest.mark.skipif(
-    not PY2 or not ("builtin" in CURRENT.creators().key_to_class), reason="stdlib python files only needed for Python 2"
+    not (CURRENT.implementation == "CPython" and PY2),
+    reason="stdlib components without py files only possible on CPython2",
 )
 def test_pyc_only(tmp_path, mocker, session_app_data):
     """Ensure that creation can succeed if os.pyc exists (even if os.py has been deleted)"""


### PR DESCRIPTION
Python can run with just `.pyc` files; however, if only a `.pyc` file is present (e.g. `os.pyc`), `virtualenv` will throw a `RuntimeError: No virtualenv implementation for PythonInfo(...)`.

This makes it so the `.py` file is checked if it exists or if _neither_ it nor the `.pyc` file exists (so as to preserve the current behavior when both are missing).

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation
