### PR TITLE
Allow testing via the system Python

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 .tox
+pip-wheel-metadata
+venv*
+*.pyz

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ venv*
 
 *wheel-store*
 
-Dockerfile
+Dockerfile*
 .dockerignore

--- a/docs/changelog/1721.bugfix.rst
+++ b/docs/changelog/1721.bugfix.rst
@@ -1,0 +1,2 @@
+Allow the test suite to pass even when called with the system Python - to help repackaging of the tool for Linux
+distributions -  by :user:`gaborbernat`.

--- a/tests/unit/create/test_interpreters.py
+++ b/tests/unit/create/test_interpreters.py
@@ -18,7 +18,12 @@ def test_failed_to_find_bad_spec():
     assert repr(context.value) == msg
 
 
-@pytest.mark.parametrize("of_id", [sys.executable, PythonInfo.current_system().implementation])
+SYSTEM = PythonInfo.current_system()
+
+
+@pytest.mark.parametrize(
+    "of_id", ({sys.executable} if sys.executable != SYSTEM.executable else set()) | {SYSTEM.implementation}
+)
 def test_failed_to_find_implementation(of_id, mocker):
     mocker.patch("virtualenv.run.plugin.creators.CreatorSelector._OPTIONS", return_value={})
     with pytest.raises(RuntimeError) as context:

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -133,11 +133,13 @@ def test_py_info_cached_symlink_error(mocker, tmp_path, session_app_data):
 
 def test_py_info_cache_clear(mocker, tmp_path, session_app_data):
     spy = mocker.spy(cached_py_info, "_run_subprocess")
-    assert PythonInfo.from_exe(sys.executable, session_app_data) is not None
-    assert spy.call_count >= 2  # at least two, one for the venv, one more for the host
+    result = PythonInfo.from_exe(sys.executable, session_app_data)
+    assert result is not None
+    count = 1 if result.executable == sys.executable else 2  # at least two, one for the venv, one more for the host
+    assert spy.call_count >= count
     PythonInfo.clear_cache(session_app_data)
     assert PythonInfo.from_exe(sys.executable, session_app_data) is not None
-    assert spy.call_count >= 4
+    assert spy.call_count >= 2 * count
 
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink is not supported")
@@ -146,7 +148,9 @@ def test_py_info_cached_symlink(mocker, tmp_path, session_app_data):
     first_result = PythonInfo.from_exe(sys.executable, session_app_data)
     assert first_result is not None
     count = spy.call_count
-    assert count >= 2  # at least two, one for the venv, one more for the host
+    # at least two, one for the venv, one more for the host
+    exp_count = 1 if first_result.executable == sys.executable else 2
+    assert count >= exp_count  # at least two, one for the venv, one more for the host
 
     new_exe = tmp_path / "a"
     new_exe.symlink_to(sys.executable)

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -16,7 +16,7 @@ from virtualenv.util.six import ensure_text
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink not supported")
 @pytest.mark.parametrize("case", ["mixed", "lower", "upper"])
-def test_discovery_via_path(monkeypatch, case, special_name_dir, caplog, session_app_data):
+def test_discovery_via_path(monkeypatch, case, tmp_path, caplog, session_app_data):
     caplog.set_level(logging.DEBUG)
     current = PythonInfo.current_system(session_app_data)
     core = "somethingVeryCryptic{}".format(".".join(str(i) for i in current.version_info[0:3]))
@@ -26,7 +26,7 @@ def test_discovery_via_path(monkeypatch, case, special_name_dir, caplog, session
     elif case == "upper":
         name = name.upper()
     exe_name = "{}{}{}".format(name, current.version_info.major, ".exe" if sys.platform == "win32" else "")
-    target = special_name_dir / current.distutils_install["scripts"]
+    target = tmp_path / current.distutils_install["scripts"]
     target.mkdir(parents=True)
     executable = target / exe_name
     os.symlink(sys.executable, ensure_text(str(executable)))


### PR DESCRIPTION
Resolves #1721 

Tested via:

```dockerfile
FROM opensuse/tumbleweed:latest

RUN zypper install -y python2 python2-devel python2-pip git gcc python3 python3-pip fish python3-devel

COPY . /opt/project

RUN python2 -m pip install -e /opt/project[testing]
RUN python2 -m pytest /opt/project -vv

RUN python3 -m pip install -e /opt/project[testing]
RUN python3 -m pytest /opt/project -vv
```