### PR TITLE
Fix deadsnakes typo in Installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -99,7 +99,7 @@ request on our issue tracker.
 Linux
 ~~~~~
 - installations from `python.org <https://www.python.org/downloads/>`_
-- Ubuntu 16.04+ (both upstream and `deasnakes <https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa>`_ builds)
+- Ubuntu 16.04+ (both upstream and `deadsnakes <https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa>`_ builds)
 - Fedora
 - RHEL and CentOS
 - OpenSuse


### PR DESCRIPTION
Quick fix for a typo in docs/installation.rst, so I ran the linter just-in-case and skipped the rest of the checklist.

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ~~ensured there are test(s) validating the fix~~
- [ ] ~~added news fragment in ``docs/changelog`` folder~~
- [ ] ~~updated/extended the documentation~~
