### PR TITLE
Allow all command line option flags to be used in config file/env-var

### DIFF
--- a/docs/changelog/1763.feature.rst
+++ b/docs/changelog/1763.feature.rst
@@ -1,0 +1,2 @@
+Extend environment variables checked for configuration to also check aliases (e.g. setting either
+``VIRTUALENV_COPIES`` or ``VIRTUALENV_ALWAYS_COPY`` will work) - by :user:`gaborbernat`.

--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -36,8 +36,10 @@ virtualenv looks for a standard ini configuration file. The exact location depen
 as determined by :pypi:`appdirs` application configuration definition. The configuration file location is printed as at
 the end of the output when ``--help`` is passed.
 
-The keys of the settings are derived from the long command line option. For example, :option:`--python <python>`
-would be specified as:
+The keys of the settings are derived from th command line option (left strip the ``-`` characters, and replace ``-``
+with ``_``). Where multiple flags are available first found wins (where order is as it shows up under the ``--help``).
+
+For example, :option:`--python <python>` would be specified as:
 
 .. code-block:: ini
 
@@ -58,9 +60,9 @@ Options that take multiple values, like :option:`extra-search-dir` can be specif
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
-Each command line option has a corresponding environment variables with the name format
-``VIRTUALENV_<UPPER_NAME>``. The ``UPPER_NAME`` is the name of the command line options capitalized and
-dashes (``'-'``) replaced with underscores (``'_'``).
+Default values may be also specified via environment variables. The keys of the settings are derived from the
+command line option (left strip the ``-`` characters, and replace ``-`` with ``_``, finally capitalize the name). Where
+multiple flags are available first found wins (where order is as it shows up under the ``--help``).
 
 For example, to use a custom Python binary, instead of the one virtualenv is run with, you can set the environment
 variable ``VIRTUALENV_PYTHON`` like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ testing =
     pytest-mock >= 2.0.0, <3
     pytest-env >= 0.6.2, <1
     pytest-timeout >= 1.3.4, <2
-    xonsh >= 0.9.13, <1; python_version > '3.4'
+    xonsh >= 0.9.16, <1; python_version > '3.4'
 
 [options.package_data]
 virtualenv.activation.bash = *.sh

--- a/src/virtualenv/create/via_global_ref/api.py
+++ b/src/virtualenv/create/via_global_ref/api.py
@@ -34,7 +34,9 @@ class ViaGlobalRefMeta(CreatorMeta):
 class ViaGlobalRefApi(Creator):
     def __init__(self, options, interpreter):
         super(ViaGlobalRefApi, self).__init__(options, interpreter)
-        self.symlinks = getattr(options, "copies", False) is False
+        copies = getattr(options, "copies", False)
+        symlinks = getattr(options, "symlinks", False)
+        self.symlinks = symlinks is True and copies is False
         self.enable_system_site_package = options.system_site
 
     @classmethod

--- a/tests/unit/seed/test_boostrap_link_via_app_data.py
+++ b/tests/unit/seed/test_boostrap_link_via_app_data.py
@@ -16,7 +16,7 @@ from virtualenv.util.subprocess import Popen
 
 
 @pytest.mark.slow
-@pytest.mark.timeout(timeout=60)
+@pytest.mark.timeout(timeout=120)
 @pytest.mark.parametrize("copies", [False, True] if fs_supports_symlink() else [True])
 def test_seed_link_via_app_data(tmp_path, coverage_env, current_fastest, copies):
     current = PythonInfo.current_system()


### PR DESCRIPTION
Extend config file and environment variables checked for configuration to also check aliases (e.g. setting either ``VIRTUALENV_COPIES`` or ``VIRTUALENV_ALWAYS_COPY`` will work).

Resolves #1761.