### PR TITLE
Use correct example URL for zipapp

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,7 +59,7 @@ with a python interpreter:
 The root level zipapp is always the current latest release. To get the last supported zipapp against a given python
 minor release use the link ``https://bootstrap.pypa.io/virtualenv/x.y/virtualenv.pyz``, e.g. for the last virtualenv
 supporting Python 2.7 use
-`https://bootstrap.pypa.io/virtualenv/2.7/virtualenv.pyz <https://bootstrap.pypa.io/2.7/virtualenv/virtualenv.pyz>`_.
+`https://bootstrap.pypa.io/virtualenv/2.7/virtualenv.pyz <https://bootstrap.pypa.io/virtualenv/2.7/virtualenv.pyz>`_.
 
 via ``setup.py``
 ----------------


### PR DESCRIPTION
The URL was incorrect and a 404.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation

This is a minor fix and does not require a changelog entry