### PR TITLE
Better handling of conflicting --copies and --symlinks

### DIFF
--- a/docs/changelog/1784.bugfix.rst
+++ b/docs/changelog/1784.bugfix.rst
@@ -1,0 +1,3 @@
+Better handling of optionlicting :option:`copies` and :option:`symlinks`. Introduce priority of where the option is set
+to follow the order: CLI, env var, file, hardcoded. If both set at same level prefers copy over symlink. - by
+user:`gaborbernat`.

--- a/src/virtualenv/__main__.py
+++ b/src/virtualenv/__main__.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-import argparse
 import logging
 import os
 import sys
 from datetime import datetime
 
+from virtualenv.config.cli.parser import VirtualEnvOptions
 from virtualenv.util.six import ensure_text
 
 
@@ -46,7 +46,7 @@ class LogSession(object):
 
 
 def run_with_catch(args=None):
-    options = argparse.Namespace()
+    options = VirtualEnvOptions()
     try:
         run(args, options)
     except (KeyboardInterrupt, Exception) as exception:

--- a/src/virtualenv/report.py
+++ b/src/virtualenv/report.py
@@ -18,8 +18,7 @@ MAX_LEVEL = max(LEVELS.keys())
 LOGGER = logging.getLogger()
 
 
-def setup_report(verbose, quiet):
-    verbosity = max(verbose - quiet, 0)
+def setup_report(verbosity):
     _clean_handlers(LOGGER)
     if verbosity > MAX_LEVEL:
         verbosity = MAX_LEVEL  # pragma: no cover

--- a/src/virtualenv/run/plugin/discovery.py
+++ b/src/virtualenv/run/plugin/discovery.py
@@ -9,7 +9,7 @@ class Discovery(PluginLoader):
     """"""
 
 
-def get_discover(parser, args, options):
+def get_discover(parser, args):
     discover_types = Discovery.entry_points_for("virtualenv.discovery")
     discovery_parser = parser.add_argument_group(
         title="discovery", description="discover and provide a target interpreter"
@@ -21,7 +21,7 @@ def get_discover(parser, args, options):
         required=False,
         help="interpreter discovery method",
     )
-    options, _ = parser.parse_known_args(args, namespace=options)
+    options, _ = parser.parse_known_args(args)
     if options.app_data == "<temp folder>":
         options.app_data = TempAppData()
     if options.clear_app_data:

--- a/tests/unit/config/test_env_var.py
+++ b/tests/unit/config/test_env_var.py
@@ -1,18 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-from argparse import Namespace
 
 import pytest
 
 from virtualenv.config.ini import IniConfig
 from virtualenv.run import session_via_cli
 from virtualenv.util.path import Path
-
-
-def parse_cli(args):
-    options = Namespace()
-    return session_via_cli(args, options)
 
 
 @pytest.fixture()
@@ -24,13 +18,13 @@ def empty_conf(tmp_path, monkeypatch):
 
 def test_value_ok(monkeypatch, empty_conf):
     monkeypatch.setenv(str("VIRTUALENV_VERBOSE"), str("5"))
-    result = parse_cli(["venv"])
+    result = session_via_cli(["venv"])
     assert result.verbosity == 5
 
 
 def test_value_bad(monkeypatch, caplog, empty_conf):
     monkeypatch.setenv(str("VIRTUALENV_VERBOSE"), str("a"))
-    result = parse_cli(["venv"])
+    result = session_via_cli(["venv"])
     assert result.verbosity == 2
     assert len(caplog.messages) == 1
     assert "env var VIRTUALENV_VERBOSE failed to convert" in caplog.messages[0]
@@ -44,7 +38,7 @@ def test_extra_search_dir_via_env_var(tmp_path, monkeypatch):
     (tmp_path / "a").mkdir()
     (tmp_path / "b").mkdir()
     (tmp_path / "c").mkdir()
-    result = parse_cli(["venv"])
+    result = session_via_cli(["venv"])
     assert result.seeder.extra_search_dir == [Path("a").resolve(), Path("b").resolve(), Path("c").resolve()]
 
 
@@ -65,5 +59,5 @@ def test_value_alias(monkeypatch, mocker, empty_conf):
     monkeypatch.delenv(str("SYMLINKS"), raising=False)
     monkeypatch.delenv(str("VIRTUALENV_COPIES"), raising=False)
     monkeypatch.setenv(str("VIRTUALENV_ALWAYS_COPY"), str("1"))
-    result = parse_cli(["venv"])
+    result = session_via_cli(["venv"])
     assert result.creator.symlinks is False

--- a/tests/unit/config/test_ini.py
+++ b/tests/unit/config/test_ini.py
@@ -1,0 +1,28 @@
+from __future__ import unicode_literals
+
+from textwrap import dedent
+
+import pytest
+
+from virtualenv.info import fs_supports_symlink
+from virtualenv.run import session_via_cli
+from virtualenv.util.six import ensure_str
+
+
+@pytest.mark.skipif(not fs_supports_symlink(), reason="symlink is not supported")
+def test_ini_can_be_overwritten_by_flag(tmp_path, monkeypatch):
+    custom_ini = tmp_path / "conf.ini"
+    custom_ini.write_text(
+        dedent(
+            """
+        [virtualenv]
+        copies = True
+        """
+        )
+    )
+    monkeypatch.setenv(ensure_str("VIRTUALENV_CONFIG_FILE"), str(custom_ini))
+
+    result = session_via_cli(["venv", "--symlinks"])
+
+    symlinks = result.creator.symlinks
+    assert symlinks is True

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -349,7 +349,9 @@ def test_cross_major(cross_python, coverage_env, tmp_path, session_app_data, cur
 
 def test_create_parallel(tmp_path, monkeypatch, temp_app_data):
     def create(count):
-        subprocess.check_call([sys.executable, "-m", "virtualenv", str(tmp_path / "venv{}".format(count))])
+        subprocess.check_call(
+            [sys.executable, "-m", "virtualenv", "-vvv", str(tmp_path / "venv{}".format(count)), "--without-pip"]
+        )
 
     threads = [Thread(target=create, args=(i,)) for i in range(1, 4)]
     for thread in threads:
@@ -386,6 +388,7 @@ def test_create_long_path(current_fastest, tmp_path):
     subprocess.check_call([str(result.creator.script("pip")), "--version"])
 
 
+@pytest.mark.timeout(timeout=60)
 @pytest.mark.parametrize("creator", set(PythonInfo.current_system().creators().key_to_class) - {"builtin"})
 def test_create_distutils_cfg(creator, tmp_path, monkeypatch):
     result = cli_run([ensure_text(str(tmp_path / "venv")), "--activators", "", "--creator", creator])


### PR DESCRIPTION
Introduce priority of where the option is set to follow the order:
cli, env var, file, hardcoded. If both set at same level prefers copy
over symlink.

Resolves #1784.