### PR TITLE
Ensure makefile is present on CPython2 POSIX

### DIFF
--- a/docs/changelog/1783.bugfix.rst
+++ b/docs/changelog/1783.bugfix.rst
@@ -1,0 +1,1 @@
+On CPython2 POSIX platforms ensure ``syconfig.get_makefile_filename`` exists within the virtual environment (this is used by some c-extension based libraries - e.g. numpy - for building) - by :user:`gaborbernat`.

--- a/src/virtualenv/create/debug.py
+++ b/src/virtualenv/create/debug.py
@@ -55,7 +55,7 @@ def run():
     try:
         import sysconfig
 
-        result["makefile_filename"] = sysconfig.get_makefile_filename()
+        result["makefile_filename"] = encode_path(sysconfig.get_makefile_filename())
     except ImportError:
         pass
 
@@ -92,11 +92,16 @@ def run():
         import json
 
         result["json"] = repr(json)
-        print(json.dumps(result, indent=2))
-    except (ImportError, ValueError, TypeError) as exception:  # pragma: no cover
-        result["json"] = repr(exception)  # pragma: no cover
-        print(repr(result))  # pragma: no cover
-        raise SystemExit(1)  # pragma: no cover
+    except ImportError as exception:
+        result["json"] = repr(exception)
+    else:
+        try:
+            content = json.dumps(result, indent=2)
+            sys.stdout.write(content)
+        except (ValueError, TypeError) as exception:  # pragma: no cover
+            sys.stderr.write(repr(exception))
+            sys.stdout.write(repr(result))  # pragma: no cover
+            raise SystemExit(1)  # pragma: no cover
 
 
 if __name__ == "__main__":

--- a/src/virtualenv/create/debug.py
+++ b/src/virtualenv/create/debug.py
@@ -51,6 +51,14 @@ def run():
     result["sys"]["fs_encoding"] = sys.getfilesystemencoding()
     result["sys"]["io_encoding"] = getattr(sys.stdout, "encoding", None)
     result["version"] = sys.version
+
+    try:
+        import sysconfig
+
+        result["makefile_filename"] = sysconfig.get_makefile_filename()
+    except ImportError:
+        pass
+
     import os  # landmark
 
     result["os"] = repr(os)

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython2.py
@@ -54,7 +54,23 @@ class CPython2(CPython, Python2):
         return dirs
 
 
-class CPython2Posix(CPython2, CPythonPosix):
+@add_metaclass(abc.ABCMeta)
+class CPython2PosixBase(CPython2, CPythonPosix):
+    """common to macOs framework builds and other posix CPython2"""
+
+    @classmethod
+    def sources(cls, interpreter):
+        for src in super(CPython2PosixBase, cls).sources(interpreter):
+            yield src
+
+        # check if the makefile exists and if so make it available under the virtual environment
+        make_file = Path(interpreter.sysconfig["makefile_filename"])
+        if make_file.exists() and str(make_file).startswith(interpreter.prefix):
+            under_prefix = make_file.relative_to(Path(interpreter.prefix))
+            yield PathRefToDest(make_file, dest=lambda self, s: self.dest / under_prefix)
+
+
+class CPython2Posix(CPython2PosixBase):
     """CPython 2 on POSIX (excluding macOs framework builds)"""
 
     @classmethod

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -14,7 +14,7 @@ from virtualenv.util.path import Path
 from virtualenv.util.six import ensure_text
 
 from .common import CPython, CPythonPosix, is_mac_os_framework
-from .cpython2 import CPython2
+from .cpython2 import CPython2PosixBase
 from .cpython3 import CPython3
 
 
@@ -65,7 +65,7 @@ class CPythonmacOsFramework(CPython):
         raise NotImplementedError
 
 
-class CPython2macOsFramework(CPythonmacOsFramework, CPython2, CPythonPosix):
+class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
     def image_ref(cls, interpreter):
         return Path(interpreter.prefix) / "Python"

--- a/src/virtualenv/create/via_global_ref/builtin/ref.py
+++ b/src/virtualenv/create/via_global_ref/builtin/ref.py
@@ -122,6 +122,8 @@ class PathRefToDest(PathRef):
         dest = self.dest(creator, self.src)
         method = self.method(symlinks)
         dest_iterable = dest if isinstance(dest, list) else (dest,)
+        if not dest.parent.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
         for dst in dest_iterable:
             method(self.src, dst)
 

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -75,6 +75,15 @@ class PythonInfo(object):
         self.stdout_encoding = u(getattr(sys.stdout, "encoding", None))
 
         self.sysconfig_paths = {u(i): u(sysconfig.get_path(i, expand=False)) for i in sysconfig.get_path_names()}
+
+        self.sysconfig = {
+            u(k): u(v)
+            for k, v in [  # a list of content to store from sysconfig
+                ("makefile_filename", sysconfig.get_makefile_filename()),
+            ]
+            if k is not None
+        }
+
         config_var_keys = set()
         for element in self.sysconfig_paths.values():
             for k in _CONF_VAR_RE.findall(element):

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -159,6 +159,7 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
     assert not content, "\n".join(ensure_text(str(i)) for i in content)
     assert creator.env_name == ensure_text(dest.name)
     debug = creator.debug
+    assert "exception" not in debug, "{}\n{}\n{}".format(debug.get("exception"), debug.get("out"), debug.get("err"))
     sys_path = cleanup_sys_path(debug["sys"]["path"])
     system_sys_path = cleanup_sys_path(system["sys"]["path"])
     our_paths = set(sys_path) - set(system_sys_path)


### PR DESCRIPTION
On CPython2 POSIX platforms ensure syconfig.get_makefile_filename exists
within the virtual environment (this is used by some c-extension based
libraries - e.g. numpy - for building).

Resvoles #1783.