### PR TITLE
App data seeder: make pip by default periodically self-upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.0.0
   hooks:
   - id: check-ast
   - id: check-builtin-literals
@@ -15,10 +15,6 @@ repos:
   rev: v2.0.1
   hooks:
   - id: add-trailing-comma
-- repo: https://github.com/asottile/yesqa
-  rev: v1.1.0
-  hooks:
-  - id: yesqa
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.4.1
   hooks:

--- a/src/virtualenv/__main__.py
+++ b/src/virtualenv/__main__.py
@@ -39,7 +39,18 @@ class LogSession(object):
             "  creator {}".format(ensure_text(str(self.session.creator))),
         ]
         if self.session.seeder.enabled:
-            lines += ("  seeder {}".format(ensure_text(str(self.session.seeder))),)
+            lines += (
+                "  seeder {}".format(ensure_text(str(self.session.seeder))),
+                "    added seed packages: {}".format(
+                    ", ".join(
+                        sorted(
+                            "==".join(i.stem.split("-"))
+                            for i in self.session.creator.purelib.iterdir()
+                            if i.suffix == ".dist-info"
+                        ),
+                    ),
+                ),
+            )
         if self.session.activators:
             lines.append("  activators {}".format(",".join(i.__class__.__name__ for i in self.session.activators)))
         return os.linesep.join(lines)

--- a/src/virtualenv/seed/embed/base_embed.py
+++ b/src/virtualenv/seed/embed/base_embed.py
@@ -12,20 +12,19 @@ from ..seeder import Seeder
 
 @add_metaclass(ABCMeta)
 class BaseEmbed(Seeder):
-    packages = ["pip", "setuptools", "wheel"]
+    def validate_version(self):
+        pass
+
+    packages = {}
 
     def __init__(self, options):
         super(BaseEmbed, self).__init__(options, enabled=options.no_seed is False)
         self.download = options.download
         self.extra_search_dir = [i.resolve() for i in options.extra_search_dir if i.exists()]
 
-        def latest_is_none(key):
-            value = getattr(options, key)
-            return None if value == "latest" else value
-
-        self.pip_version = latest_is_none("pip")
-        self.setuptools_version = latest_is_none("setuptools")
-        self.wheel_version = latest_is_none("wheel")
+        self.pip_version = options.pip
+        self.setuptools_version = options.setuptools
+        self.wheel_version = options.wheel
 
         self.no_pip = options.no_pip
         self.no_setuptools = options.no_setuptools
@@ -68,13 +67,13 @@ class BaseEmbed(Seeder):
             help="a path containing wheels the seeder may also use beside bundled (can be set 1+ times)",
             default=[],
         )
-        for package in cls.packages:
+        for package, default in cls.packages.items():
             parser.add_argument(
                 "--{}".format(package),
                 dest=package,
                 metavar="version",
                 help="{} version to install, bundle for bundled".format(package),
-                default="latest",
+                default=default,
             )
         for package in cls.packages:
             parser.add_argument(

--- a/src/virtualenv/seed/embed/wheels/acquire.py
+++ b/src/virtualenv/seed/embed/wheels/acquire.py
@@ -4,142 +4,134 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import os
 import sys
-from collections import defaultdict
 from contextlib import contextmanager
-from copy import copy
+from operator import attrgetter
 from shutil import copy2
-from zipfile import ZipFile
 
 from virtualenv.info import IS_ZIPAPP
+from virtualenv.seed.embed.wheels.util import Wheel
 from virtualenv.util.path import Path
-from virtualenv.util.six import ensure_str, ensure_text
+from virtualenv.util.six import ensure_str
 from virtualenv.util.subprocess import Popen, subprocess
 from virtualenv.util.zipapp import ensure_file_on_disk
 
 from . import BUNDLE_SUPPORT, MAX
+from .periodic_update import periodic_update
 
 BUNDLE_FOLDER = Path(os.path.abspath(__file__)).parent
 
 
 class WheelDownloadFail(ValueError):
-    def __init__(self, packages, for_py_version, exit_code, out, err):
-        self.packages = packages
+    def __init__(self, distribution, version, for_py_version, exit_code, out, err):
+        self.distribution = distribution
+        self.version = version
         self.for_py_version = for_py_version
         self.exit_code = exit_code
         self.out = out.strip()
         self.err = err.strip()
 
 
-def get_wheels(for_py_version, wheel_cache_dir, extra_search_dir, packages, app_data, download):
+class Version:
+    #: the version bundled with virtualenv
+    bundle = "bundle"
+
+    #: the latest version available locally
+    latest = "latest"
+
+    #: periodically check that newer versions are available, otherwise use bundled
+    periodic_update = "periodic-update"
+
+    #: custom version handlers
+    non_version = bundle, latest, periodic_update
+
+    @staticmethod
+    def of_version(value):
+        return None if value in Version.non_version else value
+
+
+def get_wheel(distribution, version, for_py_version, search_dirs, download, cache_dir, app_data):
+    """
+    Get a wheel with the given distribution-version-for_py_version trio, by using the extra search dir + download
+    """
     # not all wheels are compatible with all python versions, so we need to py version qualify it
-    processed = copy(packages)
+    of_version = Version.of_version(version)
     # 1. acquire from bundle
-    acquire_from_bundle(processed, for_py_version, wheel_cache_dir)
+    wheel = from_bundle(distribution, of_version, for_py_version, cache_dir)
+
     # 2. acquire from extra search dir
-    acquire_from_dir(processed, for_py_version, wheel_cache_dir, extra_search_dir)
-    # 3. download from the internet
-    if download and processed:
-        download_wheel(processed, for_py_version, wheel_cache_dir, app_data)
+    if version == Version.latest or wheel is None:
+        found_wheel = from_dir(distribution, of_version, for_py_version, cache_dir, search_dirs)
+        if found_wheel is not None and (wheel is None or found_wheel.version_tuple >= wheel.version_tuple):
+            wheel = found_wheel
 
-    # in the end just get the wheels
-    wheels = _get_wheels(wheel_cache_dir, packages)
-    return {p: next(iter(ver_to_files))[1] for p, ver_to_files in wheels.items()}
+    # 3. trigger periodic update
+    if version == Version.periodic_update:
+        wheel = periodic_update(distribution, for_py_version, wheel, cache_dir, app_data)
 
+    # 4. download from the internet
+    if download:
+        download_wheel(distribution, of_version, for_py_version, cache_dir, app_data)
+        wheel = _get_wheels(cache_dir, distribution, of_version)[0]  # get latest from cache post download
 
-def acquire_from_bundle(packages, for_py_version, to_folder):
-    for pkg, version in list(packages.items()):
-        bundle = get_bundled_wheel(pkg, for_py_version)
-        if bundle is not None:
-            pkg_version = bundle.stem.split("-")[1]
-            exact_version_match = version == pkg_version
-            if exact_version_match:
-                del packages[pkg]
-            if version is None or exact_version_match:
-                bundled_wheel_file = to_folder / bundle.name
-                if not bundled_wheel_file.exists():
-                    logging.debug("get bundled wheel %s", bundle)
-                    if IS_ZIPAPP:
-                        from virtualenv.util.zipapp import extract
-
-                        extract(bundle, bundled_wheel_file)
-                    else:
-                        copy2(str(bundle), str(bundled_wheel_file))
+    return wheel
 
 
-def get_bundled_wheel(package, version_release):
-    return BUNDLE_FOLDER / (BUNDLE_SUPPORT.get(version_release, {}) or BUNDLE_SUPPORT[MAX]).get(package)
+def from_bundle(distribution, version, for_py_version, wheel_cache_dir):
+    """
+    Load the bundled wheel to a cache directory.
+    """
+    bundle = get_bundled_wheel(distribution, for_py_version)
+    if bundle is None:
+        return None
+    if version is None or version == bundle.version:
+        bundled_wheel_file = wheel_cache_dir / bundle.path.name
+        logging.debug("use bundled wheel %s", bundle)
+        if not bundled_wheel_file.exists():
+            logging.debug("copy bundled wheel to %s", bundled_wheel_file)
+            if IS_ZIPAPP:
+                from virtualenv.util.zipapp import extract
+
+                extract(bundle, bundled_wheel_file)
+            else:
+                copy2(str(bundle), str(bundled_wheel_file))
+        return Wheel(bundled_wheel_file)
 
 
-def acquire_from_dir(packages, for_py_version, to_folder, extra_search_dir):
-    if not packages:
-        return
-    for search_dir in extra_search_dir:
-        wheels = _get_wheels(search_dir, packages)
-        for pkg, ver_wheels in wheels.items():
-            stop = False
-            for _, filename in ver_wheels:
-                dest = to_folder / filename.name
+def get_bundled_wheel(distribution, for_py_version):
+    path = BUNDLE_FOLDER / (BUNDLE_SUPPORT.get(for_py_version, {}) or BUNDLE_SUPPORT[MAX]).get(distribution)
+    if path is None:
+        return None
+    return Wheel.from_path(path)
+
+
+def from_dir(distribution, version, for_py_version, cache_dir, directories):
+    """
+    Load a compatible wheel from a given folder.
+    """
+    for folder in directories:
+        for wheel in _get_wheels(folder, distribution, version):
+            dest = cache_dir / wheel.name
+            if wheel.support_py(for_py_version):
+                logging.debug("load extra search dir wheel %s", wheel)
                 if not dest.exists():
-                    if wheel_support_py(filename, for_py_version):
-                        logging.debug("get extra search dir wheel %s", filename)
-                        copy2(str(filename), str(dest))
-                        stop = True
-                else:
-                    stop = True
-                if stop and packages[pkg] is not None:
-                    del packages[pkg]
-                    break
+                    copy2(str(wheel.path), str(dest))
+                return Wheel(dest)
+    return None
 
 
-def wheel_support_py(filename, py_version):
-    name = "{}.dist-info/METADATA".format("-".join(filename.stem.split("-")[0:2]))
-    with ZipFile(ensure_text(str(filename)), "r") as zip_file:
-        metadata = zip_file.read(name).decode("utf-8")
-    marker = "Requires-Python:"
-    requires = next((i[len(marker) :] for i in metadata.splitlines() if i.startswith(marker)), None)
-    if requires is None:  # if it does not specify a python requires the assumption is compatible
-        return True
-    py_version_int = tuple(int(i) for i in py_version.split("."))
-    for require in (i.strip() for i in requires.split(",")):
-        # https://www.python.org/dev/peps/pep-0345/#version-specifiers
-        for operator, check in [
-            ("!=", lambda v: py_version_int != v),
-            ("==", lambda v: py_version_int == v),
-            ("<=", lambda v: py_version_int <= v),
-            (">=", lambda v: py_version_int >= v),
-            ("<", lambda v: py_version_int < v),
-            (">", lambda v: py_version_int > v),
-        ]:
-            if require.startswith(operator):
-                ver_str = require[len(operator) :].strip()
-                version = tuple((int(i) if i != "*" else None) for i in ver_str.split("."))[0:2]
-                if not check(version):
-                    return False
-                break
-    return True
-
-
-def _get_wheels(from_folder, packages):
-    wheels = defaultdict(list)
+def _get_wheels(from_folder, distribution, version):
+    wheels = []
     for filename in from_folder.iterdir():
-        if filename.suffix == ".whl":
-            data = filename.stem.split("-")
-            if len(data) >= 2:
-                pkg, version = data[0:2]
-                if pkg in packages:
-                    pkg_version = packages[pkg]
-                    if pkg_version is None or pkg_version == version:
-                        wheels[pkg].append((version, filename))
-    for versions in wheels.values():
-        versions.sort(
-            key=lambda a: tuple(int(i) if i.isdigit() else i for i in a[0].split(".")), reverse=True,
-        )
-    return wheels
+        wheel = Wheel.from_path(filename)
+        if wheel and wheel.distribution == distribution:
+            if version is None or wheel.version == version:
+                wheels.append(wheel)
+    return sorted(wheels, key=attrgetter("version_tuple", "distribution"), reverse=True)
 
 
-def download_wheel(packages, for_py_version, to_folder, app_data):
-    to_download = list(p if v is None else "{}=={}".format(p, v) for p, v in packages.items())
-    logging.debug("download wheels %s", to_download)
+def download_wheel(distribution, version, for_py_version, to_folder, app_data):
+    to_download = "{}{}".format(distribution, "" if version is None else "=={}".format(version))
+    logging.debug("download wheel %s", to_download)
     cmd = [
         sys.executable,
         "-m",
@@ -152,15 +144,15 @@ def download_wheel(packages, for_py_version, to_folder, app_data):
         for_py_version,
         "-d",
         str(to_folder),
+        to_download,
     ]
-    cmd.extend(to_download)
     # pip has no interface in python - must be a new sub-process
 
     with pip_wheel_env_run("{}.{}".format(*sys.version_info[0:2]), app_data) as env:
         process = Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         out, err = process.communicate()
         if process.returncode != 0:
-            raise WheelDownloadFail(packages, for_py_version, process.returncode, out, err)
+            raise WheelDownloadFail(distribution, version, for_py_version, process.returncode, out, err)
 
 
 @contextmanager
@@ -172,7 +164,7 @@ def pip_wheel_env_run(version, app_data):
             for k, v in {"PIP_USE_WHEEL": "1", "PIP_USER": "0", "PIP_NO_INPUT": "1"}.items()
         },
     )
-    with ensure_file_on_disk(get_bundled_wheel("pip", version), app_data) as pip_wheel_path:
+    with ensure_file_on_disk(get_bundled_wheel("pip", version).path, app_data) as pip_wheel_path:
         # put the bundled wheel onto the path, and use it to do the bootstrap operation
         env[str("PYTHONPATH")] = str(pip_wheel_path)
         yield env

--- a/src/virtualenv/seed/embed/wheels/periodic_update.py
+++ b/src/virtualenv/seed/embed/wheels/periodic_update.py
@@ -1,0 +1,195 @@
+"""
+Periodically update bundled versions.
+"""
+
+import calendar
+import json
+import logging
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from shutil import copy2
+
+from six.moves.urllib.request import urlopen
+
+from virtualenv.seed.embed.wheels.util import Wheel
+from virtualenv.util.lock import ReentrantFileLock, Timeout
+from virtualenv.util.path import Path, safe_delete
+from virtualenv.util.subprocess import DETACHED_PROCESS, Popen
+
+
+def periodic_update(distribution, for_py_version, wheel, cache_dir, app_data):
+    if distribution != "pip":
+        raise RuntimeError("only pip may be periodically updated")
+
+    needs_update = False
+    with update_log_for_distribution(cache_dir.parent, distribution, no_block=True) as update_log:
+        if update_log.needs_update:
+            update_log.started = datetime.now()
+            update_log.update()
+            needs_update = True
+    if needs_update:
+        trigger_update(distribution, for_py_version, wheel, app_data)
+    # TODO: only upgrade when an hour passed since periodic update - to keep most CI stable
+    for filename, release_date in (
+        (update_log.updated, update_log.updated_release_date),
+        (update_log.previous_updated, update_log.previous_updated_release_date),
+    ):
+        if filename is None or filename == wheel.name:
+            continue
+        updated_wheel = Wheel(cache_dir / filename)
+        # use it only if released long enough time ago - use version number to approximate release
+        # only use if it has been released for at least 28 days
+        if datetime.now() - release_date > timedelta(days=28):
+            logging.debug("using periodically updated wheel %s", updated_wheel)
+            return updated_wheel
+    return wheel
+
+
+@contextmanager
+def update_log_for_distribution(folder, distribution, no_block=False):
+    root_lock, lock_name = ReentrantFileLock(folder), "{}.update.lock".format(distribution)
+    try:
+        with root_lock.lock_for_key(lock_name, no_block=no_block):
+            update_log = UpdateLog(folder / "{}.update.json".format(distribution))
+            yield update_log
+    except Timeout:
+        return
+
+
+class UpdateLog(object):
+    datetime_fmt = "%Y-%m-%dT%H:%M:%SZ"
+
+    def __init__(self, path):
+        content = {}
+        if path.exists():
+            try:
+                with open(str(path), "rt") as file_handler:
+                    content = json.load(file_handler)
+            except (IOError, ValueError):
+                pass
+        self.started = self._load_datetime(content, "started")
+        self.completed = self._load_datetime(content, "completed")
+
+        self.updated = content.get("updated")
+        self.updated_release_date = content.get("updated_release_date")
+
+        self.previous_updated = content.get("previous_updated")
+        self.previous_updated_release_date = content.get("previous_updated_release_date")
+        self.path = path
+
+    def _load_datetime(self, content, key):
+        value = content.get(key)
+        if value:
+            return datetime.strptime(value, self.datetime_fmt)
+        return None
+
+    def _dump_datetime(self, value):
+        if value is None:
+            return None
+        return datetime.strftime(value, self.datetime_fmt)
+
+    @property
+    def needs_update(self):
+        now = datetime.now()
+        if self.completed is None:  # never completed
+            return self._check_start(now)
+        else:
+            delta_since_last_completed = now - self.completed
+            if delta_since_last_completed < timedelta(days=13):
+                return False
+            return self._check_start(now)
+
+    def _check_start(self, now):
+        if self.started is None:  # never started
+            return True
+        delta_since_last_start = now - self.started
+        if delta_since_last_start >= timedelta(hours=1):  # over an hour ago -> operations crashed, try again
+            return True
+        return False
+
+    def update(self):
+        content = {
+            "started": self._dump_datetime(self.started),
+            "completed": self._dump_datetime(self.completed),
+            "updated": self.updated,
+            "updated_release_date": self._dump_datetime(self.updated_release_date),
+            "previous_updated": self.previous_updated,
+            "previous_updated_release_date": self._dump_datetime(self.previous_updated_release_date),
+        }
+        with open(str(self.path), "wt") as file_handler:
+            json.dump(content, file_handler, sort_keys=True, indent=4)
+
+
+def trigger_update(distribution, for_py_version, wheel, app_data):
+    cmd = [
+        sys.executable,
+        "-c",
+        "from virtualenv.seed.embed.wheels.periodic_update import do_update;"
+        "do_update({!r}, {!r}, {!r}, {!r})".format(distribution, for_py_version, str(wheel.path), str(app_data.path)),
+    ]
+    kwargs = {"stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+    if sys.platform == "win32":
+        kwargs["creation_flags"] = DETACHED_PROCESS
+    process = Popen(cmd, **kwargs)
+    logging.info(
+        "triggered periodic upgrade of %s==%s (for python %s) via background process having PID %d",
+        distribution,
+        wheel.version,
+        for_py_version,
+        process.pid,
+    )
+    # process.communicate()
+
+
+def do_update(distribution, for_py_version, wheel_filename, app_data):
+    temp_dir = Path(tempfile.mkdtemp())
+    try:
+        copy2(wheel_filename, temp_dir)
+        from .acquire import download_wheel
+
+        download_wheel(distribution, None, for_py_version, temp_dir, ReentrantFileLock(app_data))
+        local_wheel = Path(wheel_filename)
+        new_wheels = [f for f in temp_dir.iterdir() if f.name != local_wheel.name]
+        if new_wheels:
+            new_wheel = new_wheels[0]
+            dest = local_wheel.parent / new_wheel.name
+            if not dest.exists():
+                copy2(new_wheel, dest)
+        else:
+            dest = local_wheel
+        release_date = _get_release_date(dest)
+        with update_log_for_distribution(local_wheel.parent.parent, distribution, no_block=False) as u_log:
+            if u_log.updated is not None:
+                u_log.previous_updated = u_log.updated
+                u_log.previous_updated_release_date = u_log.updated_release_date
+            u_log.updated = dest.name
+            u_log.updated_release_date = release_date
+            u_log.completed = datetime.now()
+            u_log.update()
+
+    finally:
+        safe_delete(temp_dir)
+
+
+def _get_release_date(dest):
+    wheel = Wheel(dest)
+    # the most accurate is to ask PyPi - https://pypi.org/pypi/pip/json
+    try:
+        with urlopen("https://pypi.org/pypi/{}/json".format(wheel.distribution)) as file_handler:
+            content = json.load(file_handler)
+        return datetime.strptime(content["releases"][wheel.version][0]["upload_time"], "%Y-%m-%dT%H:%M:%S")
+    except Exception:  # noqa
+        pass
+    # otherwise can approximate from the version number https://pip.pypa.io/en/latest/development/release-process/
+    released = datetime(year=2000 + wheel.version_tuple[0], month=wheel.version_tuple[1] * 3 + 1, day=1)
+    released += timedelta(days=calendar.monthrange(released.year, released.month)[1])
+    return released
+
+
+__all__ = (
+    "periodic_update",
+    "do_update",
+)

--- a/src/virtualenv/seed/embed/wheels/util.py
+++ b/src/virtualenv/seed/embed/wheels/util.py
@@ -1,0 +1,72 @@
+from zipfile import ZipFile
+
+from virtualenv.util.six import ensure_text
+
+
+class Wheel(object):
+    def __init__(self, path):
+        # https://www.python.org/dev/peps/pep-0427/#file-name-convention
+        # The wheel filename is {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl
+        self.path = path
+        self._parts = path.stem.split("-")
+
+    @classmethod
+    def from_path(cls, path):
+        if path.suffix == ".whl" and len(path.stem.split("-")) >= 5:
+            return cls(path)
+        return None
+
+    @property
+    def distribution(self):
+        return self._parts[0]
+
+    @property
+    def version(self):
+        return self._parts[1]
+
+    @property
+    def version_tuple(self):
+        result = []
+        for part in self.version.split(".")[0:3]:
+            try:
+                result.append(int(part))
+            except ValueError:
+                break
+        return tuple(result)
+
+    @property
+    def name(self):
+        return self.path.name
+
+    def support_py(self, py_version):
+        name = "{}.dist-info/METADATA".format("-".join(self.path.stem.split("-")[0:2]))
+        with ZipFile(ensure_text(str(self.path)), "r") as zip_file:
+            metadata = zip_file.read(name).decode("utf-8")
+        marker = "Requires-Python:"
+        requires = next((i[len(marker) :] for i in metadata.splitlines() if i.startswith(marker)), None)
+        if requires is None:  # if it does not specify a python requires the assumption is compatible
+            return True
+        py_version_int = tuple(int(i) for i in py_version.split("."))
+        for require in (i.strip() for i in requires.split(",")):
+            # https://www.python.org/dev/peps/pep-0345/#version-specifiers
+            for operator, check in [
+                ("!=", lambda v: py_version_int != v),
+                ("==", lambda v: py_version_int == v),
+                ("<=", lambda v: py_version_int <= v),
+                (">=", lambda v: py_version_int >= v),
+                ("<", lambda v: py_version_int < v),
+                (">", lambda v: py_version_int > v),
+            ]:
+                if require.startswith(operator):
+                    ver_str = require[len(operator) :].strip()
+                    version = tuple((int(i) if i != "*" else None) for i in ver_str.split("."))[0:2]
+                    if not check(version):
+                        return False
+                    break
+        return True
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__, self.path)
+
+    def __str__(self):
+        return str(self.path)

--- a/src/virtualenv/util/subprocess/__init__.py
+++ b/src/virtualenv/util/subprocess/__init__.py
@@ -12,6 +12,8 @@ if six.PY2 and sys.platform == "win32":
 else:
     Popen = subprocess.Popen
 
+DETACHED_PROCESS = 0x00000008
+
 
 def run_cmd(cmd):
     try:
@@ -29,4 +31,5 @@ __all__ = (
     "subprocess",
     "Popen",
     "run_cmd",
+    "DETACHED_PROCESS",
 )

--- a/tests/unit/seed/embed/wheels/test_acquire.py
+++ b/tests/unit/seed/embed/wheels/test_acquire.py
@@ -1,11 +1,11 @@
-from virtualenv.seed.embed.wheels.acquire import get_bundled_wheel, wheel_support_py
+from virtualenv.seed.embed.wheels.acquire import get_bundled_wheel
 
 
 def test_wheel_support_no_python_requires(mocker):
-    wheel = get_bundled_wheel(package="setuptools", version_release=None)
+    wheel = get_bundled_wheel("setuptools", for_py_version=None)
     zip_mock = mocker.MagicMock()
-    mocker.patch("virtualenv.seed.embed.wheels.acquire.ZipFile", new=zip_mock)
+    mocker.patch("virtualenv.seed.embed.wheels.util.ZipFile", new=zip_mock)
     zip_mock.return_value.__enter__.return_value.read = lambda name: b""
 
-    supports = wheel_support_py(wheel, "3.8")
+    supports = wheel.support_py("3.8")
     assert supports is True


### PR DESCRIPTION
A conservative implementation of the outcome from https://discuss.python.org/t/how-should-virtualenv-behave-respective-of-seed-packages-e-g-pip-by-default/4146 poll.

The goal of the PR is to try to pull in new pip versions, however:
- do not degrade virtual environment creation performance significantly,
- do not trigger during CI runs (the feature is aimed mostly at end-users, that install virtualenv themselves).

The proposed change would make pip upgrade periodically:
- every two weeks try to upgrade pip to a newer version
- the upgrade runs not inline, but instead as a new background process (this makes the performance overhead not significant)
- upgrade the seeded pip to a new version if there's a newer version that satisfies the following criteria

  - was discovered at least an hour ago (this is to ensure that CI environments don't start with an old version and mid-way through they switch to a newer version)
  - was released at least 28 days ago (allow 4 weeks for pip to do a bugfix release).

I consider this a reasonable middle-ground. We will mostly use bundled versions (and almost always in the CI), but for end-users, once a pip version is out there for a long time we do switch to it, as we consider that a proof of stability.

People who would like to always get the latest version should either set the environment variable ``VIRTUALENV_DOWNLOAD=1`` or set ``download`` inside the ``virtualenv.ini`` file (or pass in the ``--download`` flag).

People who would like to always pin to a given version should either set the environment variable ``VIRTUALENV_PIP=20.1`` or set ``pip`` inside the ``virtualenv.ini`` file (or pass in the ``--pip`` flag).

Resolves https://github.com/pypa/virtualenv/issues/1821