### PR TITLE
App data seeder by default should use bundled only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.0.0
   hooks:
   - id: check-ast
   - id: check-builtin-literals
@@ -15,10 +15,6 @@ repos:
   rev: v2.0.1
   hooks:
   - id: add-trailing-comma
-- repo: https://github.com/asottile/yesqa
-  rev: v1.1.0
-  hooks:
-  - id: yesqa
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.4.1
   hooks:

--- a/docs/changelog/1821.bugfix.rst
+++ b/docs/changelog/1821.bugfix.rst
@@ -1,0 +1,2 @@
+By default install only bundled packages (latest compatible wheel between the embed packages that come with virtualenv,
+and wheels found inside the provided :option:`extra-search-dir`) - by :user:`gaborbernat`.

--- a/docs/changelog/1821.feature.rst
+++ b/docs/changelog/1821.feature.rst
@@ -1,0 +1,1 @@
+Display the installed seed package versions in the final summary output - by :user:`gaborbernat`.

--- a/src/virtualenv/__main__.py
+++ b/src/virtualenv/__main__.py
@@ -39,7 +39,18 @@ class LogSession(object):
             "  creator {}".format(ensure_text(str(self.session.creator))),
         ]
         if self.session.seeder.enabled:
-            lines += ("  seeder {}".format(ensure_text(str(self.session.seeder))),)
+            lines += (
+                "  seeder {}".format(ensure_text(str(self.session.seeder))),
+                "    added seed packages: {}".format(
+                    ", ".join(
+                        sorted(
+                            "==".join(i.stem.split("-"))
+                            for i in self.session.creator.purelib.iterdir()
+                            if i.suffix == ".dist-info"
+                        ),
+                    ),
+                ),
+            )
         if self.session.activators:
             lines.append("  activators {}".format(",".join(i.__class__.__name__ for i in self.session.activators)))
         return os.linesep.join(lines)

--- a/src/virtualenv/seed/embed/base_embed.py
+++ b/src/virtualenv/seed/embed/base_embed.py
@@ -8,38 +8,39 @@ from virtualenv.util.path import Path
 from virtualenv.util.six import ensure_str, ensure_text
 
 from ..seeder import Seeder
+from .wheels.acquire import Version
 
 
 @add_metaclass(ABCMeta)
 class BaseEmbed(Seeder):
-    packages = ["pip", "setuptools", "wheel"]
+    distributions = {
+        "pip": Version.bundle,
+        "setuptools": Version.bundle,
+        "wheel": Version.bundle,
+    }
 
     def __init__(self, options):
         super(BaseEmbed, self).__init__(options, enabled=options.no_seed is False)
         self.download = options.download
         self.extra_search_dir = [i.resolve() for i in options.extra_search_dir if i.exists()]
 
-        def latest_is_none(key):
-            value = getattr(options, key)
-            return None if value == "latest" else value
-
-        self.pip_version = latest_is_none("pip")
-        self.setuptools_version = latest_is_none("setuptools")
-        self.wheel_version = latest_is_none("wheel")
+        self.pip_version = options.pip
+        self.setuptools_version = options.setuptools
+        self.wheel_version = options.wheel
 
         self.no_pip = options.no_pip
         self.no_setuptools = options.no_setuptools
         self.no_wheel = options.no_wheel
         self.app_data = options.app_data.folder
 
-        if not self.package_version():
+        if not self.distribution_to_versions():
             self.enabled = False
 
-    def package_version(self):
+    def distribution_to_versions(self):
         return {
-            package: getattr(self, "{}_version".format(package))
-            for package in self.packages
-            if getattr(self, "no_{}".format(package)) is False
+            distribution: getattr(self, "{}_version".format(distribution))
+            for distribution in self.distributions
+            if getattr(self, "no_{}".format(distribution)) is False
         }
 
     @classmethod
@@ -50,14 +51,14 @@ class BaseEmbed(Seeder):
             "--never-download",
             dest="download",
             action="store_false",
-            help="pass to disable download of the latest {} from PyPI".format("/".join(cls.packages)),
+            help="pass to disable download of the latest {} from PyPI".format("/".join(cls.distributions)),
             default=True,
         )
         group.add_argument(
             "--download",
             dest="download",
             action="store_true",
-            help="pass to enable download of the latest {} from PyPI".format("/".join(cls.packages)),
+            help="pass to enable download of the latest {} from PyPI".format("/".join(cls.distributions)),
             default=False,
         )
         parser.add_argument(
@@ -65,23 +66,23 @@ class BaseEmbed(Seeder):
             metavar="d",
             type=Path,
             nargs="+",
-            help="a path containing wheels the seeder may also use beside bundled (can be set 1+ times)",
+            help="a path containing wheels that extend the bundled list (can be set 1+ times)",
             default=[],
         )
-        for package in cls.packages:
+        for distribution, default in cls.distributions.items():
             parser.add_argument(
-                "--{}".format(package),
-                dest=package,
+                "--{}".format(distribution),
+                dest=distribution,
                 metavar="version",
-                help="{} version to install, bundle for bundled".format(package),
-                default="latest",
+                help="{} version to install, bundle for bundled".format(distribution),
+                default=default,
             )
-        for package in cls.packages:
+        for distribution in cls.distributions:
             parser.add_argument(
-                "--no-{}".format(package),
-                dest="no_{}".format(package),
+                "--no-{}".format(distribution),
+                dest="no_{}".format(distribution),
                 action="store_true",
-                help="do not install {}".format(package),
+                help="do not install {}".format(distribution),
                 default=False,
             )
 
@@ -91,11 +92,11 @@ class BaseEmbed(Seeder):
         if self.extra_search_dir:
             result += "extra_search_dir={},".format(", ".join(ensure_text(str(i)) for i in self.extra_search_dir))
         result += "download={},".format(self.download)
-        for package in self.packages:
-            if getattr(self, "no_{}".format(package)):
+        for distribution in self.distributions:
+            if getattr(self, "no_{}".format(distribution)):
                 continue
             result += " {}{},".format(
-                package, "={}".format(getattr(self, "{}_version".format(package), None) or "latest"),
+                distribution, "={}".format(getattr(self, "{}_version".format(distribution), None) or "latest"),
             )
         return result[:-1] + ")"
 

--- a/src/virtualenv/seed/embed/wheels/util.py
+++ b/src/virtualenv/seed/embed/wheels/util.py
@@ -1,0 +1,72 @@
+from zipfile import ZipFile
+
+from virtualenv.util.six import ensure_text
+
+
+class Wheel(object):
+    def __init__(self, path):
+        # https://www.python.org/dev/peps/pep-0427/#file-name-convention
+        # The wheel filename is {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl
+        self.path = path
+        self._parts = path.stem.split("-")
+
+    @classmethod
+    def from_path(cls, path):
+        if path.suffix == ".whl" and len(path.stem.split("-")) >= 5:
+            return cls(path)
+        return None
+
+    @property
+    def distribution(self):
+        return self._parts[0]
+
+    @property
+    def version(self):
+        return self._parts[1]
+
+    @property
+    def version_tuple(self):
+        result = []
+        for part in self.version.split(".")[0:3]:
+            try:
+                result.append(int(part))
+            except ValueError:
+                break
+        return tuple(result)
+
+    @property
+    def name(self):
+        return self.path.name
+
+    def support_py(self, py_version):
+        name = "{}.dist-info/METADATA".format("-".join(self.path.stem.split("-")[0:2]))
+        with ZipFile(ensure_text(str(self.path)), "r") as zip_file:
+            metadata = zip_file.read(name).decode("utf-8")
+        marker = "Requires-Python:"
+        requires = next((i[len(marker) :] for i in metadata.splitlines() if i.startswith(marker)), None)
+        if requires is None:  # if it does not specify a python requires the assumption is compatible
+            return True
+        py_version_int = tuple(int(i) for i in py_version.split("."))
+        for require in (i.strip() for i in requires.split(",")):
+            # https://www.python.org/dev/peps/pep-0345/#version-specifiers
+            for operator, check in [
+                ("!=", lambda v: py_version_int != v),
+                ("==", lambda v: py_version_int == v),
+                ("<=", lambda v: py_version_int <= v),
+                (">=", lambda v: py_version_int >= v),
+                ("<", lambda v: py_version_int < v),
+                (">", lambda v: py_version_int > v),
+            ]:
+                if require.startswith(operator):
+                    ver_str = require[len(operator) :].strip()
+                    version = tuple((int(i) if i != "*" else None) for i in ver_str.split("."))[0:2]
+                    if not check(version):
+                        return False
+                    break
+        return True
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__, self.path)
+
+    def __str__(self):
+        return str(self.path)

--- a/src/virtualenv/seed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/via_app_data/pip_install/base.py
@@ -54,11 +54,11 @@ class PipInstall(object):
 
     def build_image(self):
         # 1. first extract the wheel
-        logging.debug("build install image to %s of %s", self._image_dir, self._wheel.name)
+        logging.debug("build install image for %s to %s", self._wheel.name, self._image_dir)
         with zipfile.ZipFile(str(self._wheel)) as zip_ref:
             zip_ref.extractall(str(self._image_dir))
             self._extracted = True
-        # 2. now add additional files not present in the package
+        # 2. now add additional files not present in the distribution
         new_files = self._generate_new_files()
         # 3. finally fix the records file
         self._fix_records(new_files)

--- a/src/virtualenv/seed/via_app_data/via_app_data.py
+++ b/src/virtualenv/seed/via_app_data/via_app_data.py
@@ -4,13 +4,15 @@ from __future__ import absolute_import, unicode_literals
 import logging
 from contextlib import contextmanager
 from functools import partial
+from subprocess import CalledProcessError
 from threading import Lock, Thread
+
+import six
 
 from virtualenv.info import fs_supports_symlink
 from virtualenv.seed.embed.base_embed import BaseEmbed
-from virtualenv.seed.embed.wheels.acquire import WheelDownloadFail, get_wheels
-from virtualenv.util.path import safe_delete
 
+from ..embed.wheels.acquire import get_wheel
 from .pip_install.copy import CopyPipInstall
 from .pip_install.symlink import SymlinkPipInstall
 
@@ -40,13 +42,13 @@ class FromAppData(BaseEmbed):
             return
         base_cache = self.base_cache / creator.interpreter.version_release_str
         with self._get_seed_wheels(creator, base_cache) as name_to_whl:
-            pip_version = name_to_whl["pip"].stem.split("-")[1] if "pip" in name_to_whl else None
+            pip_version = name_to_whl["pip"].version_tuple if "pip" in name_to_whl else None
             installer_class = self.installer_class(pip_version)
 
             def _install(name, wheel):
                 logging.debug("install %s from wheel %s via %s", name, wheel, installer_class.__name__)
-                image_folder = base_cache.path / "image" / installer_class.__name__ / wheel.stem
-                installer = installer_class(wheel, creator, image_folder)
+                image_folder = base_cache.path / "image" / installer_class.__name__ / wheel.path.stem
+                installer = installer_class(wheel.path, creator, image_folder)
                 if not installer.has_image():
                     installer.build_image()
                 installer.install(creator.interpreter.version_info)
@@ -61,37 +63,29 @@ class FromAppData(BaseEmbed):
     def _get_seed_wheels(self, creator, base_cache):
         with base_cache.lock_for_key("wheels"):
             wheels_to = base_cache.path / "wheels"
-            if wheels_to.exists():
-                safe_delete(wheels_to)
             wheels_to.mkdir(parents=True, exist_ok=True)
             name_to_whl, lock, fail = {}, Lock(), {}
 
-            def _get(package, version):
-                wheel_loader = partial(
-                    get_wheels,
-                    creator.interpreter.version_release_str,
-                    wheels_to,
-                    self.extra_search_dir,
-                    {package: version},
-                    self.app_data,
-                )
+            def _get(distribution, version):
+                for_py_version = creator.interpreter.version_release_str
+                loader = partial(get_wheel, distribution, version, for_py_version, self.extra_search_dir)
                 failure, result = None, None
                 # fallback to download in case the exact version is not available
                 for download in [True] if self.download else [False, True]:
                     failure = None
                     try:
-                        result = wheel_loader(download)
+                        result = loader(download, wheels_to, self.app_data)
                         if result:
                             break
                     except Exception as exception:
                         failure = exception
                 if failure:
-                    if isinstance(failure, WheelDownloadFail):
-                        msg = "failed to download {}".format(package)
+                    if isinstance(failure, CalledProcessError):
+                        msg = "failed to download {}".format(distribution)
                         if version is not None:
                             msg += " version {}".format(version)
-                        msg += ", pip download exit code {}".format(failure.exit_code)
-                        output = failure.out + failure.err
+                        msg += ", pip download exit code {}".format(failure.returncode)
+                        output = failure.output if six.PY2 else (failure.output + failure.stderr)
                         if output:
                             msg += "\n"
                             msg += output
@@ -99,13 +93,15 @@ class FromAppData(BaseEmbed):
                         msg = repr(failure)
                     logging.error(msg)
                     with lock:
-                        fail[package] = version
+                        fail[distribution] = version
                 else:
                     with lock:
-                        name_to_whl.update(result)
+                        name_to_whl[distribution] = result
 
-            package_versions = self.package_version()
-            threads = list(Thread(target=_get, args=(pkg, v)) for pkg, v in package_versions.items())
+            threads = list(
+                Thread(target=_get, args=(distribution, version))
+                for distribution, version in self.distribution_to_versions().items()
+            )
             for thread in threads:
                 thread.start()
             for thread in threads:
@@ -114,11 +110,10 @@ class FromAppData(BaseEmbed):
                 raise RuntimeError("seed failed due to failing to download wheels {}".format(", ".join(fail.keys())))
             yield name_to_whl
 
-    def installer_class(self, pip_version):
-        if self.symlinks and pip_version:
+    def installer_class(self, pip_version_tuple):
+        if self.symlinks and pip_version_tuple:
             # symlink support requires pip 19.3+
-            pip_version_int = tuple(int(i) for i in pip_version.split(".")[0:2])
-            if pip_version_int >= (19, 3):
+            if pip_version_tuple >= (19, 3):
                 return SymlinkPipInstall
         return CopyPipInstall
 

--- a/src/virtualenv/util/lock.py
+++ b/src/virtualenv/util/lock.py
@@ -104,3 +104,9 @@ class ReentrantFileLock(object):
                 self._release(lock)
         finally:
             self._del_lock(lock)
+
+
+__all__ = (
+    "Timeout",
+    "ReentrantFileLock",
+)

--- a/tests/unit/activation/conftest.py
+++ b/tests/unit/activation/conftest.py
@@ -74,7 +74,8 @@ class ActivationTester(object):
             _raw, _ = process.communicate()
             raw = _raw.decode("utf-8")
         except subprocess.CalledProcessError as exception:
-            assert not exception.returncode, ensure_text(exception.output)
+            output = ensure_text((exception.output + exception.stderr) if six.PY3 else exception.output)
+            assert not exception.returncode, output
             return
 
         out = re.sub(r"pydev debugger: process \d+ is connecting\n\n", "", raw, re.M).strip().splitlines()

--- a/tests/unit/seed/embed/wheels/test_acquire.py
+++ b/tests/unit/seed/embed/wheels/test_acquire.py
@@ -1,11 +1,11 @@
-from virtualenv.seed.embed.wheels.acquire import get_bundled_wheel, wheel_support_py
+from virtualenv.seed.embed.wheels.acquire import get_bundled_wheel
 
 
 def test_wheel_support_no_python_requires(mocker):
-    wheel = get_bundled_wheel(package="setuptools", version_release=None)
+    wheel = get_bundled_wheel("setuptools", for_py_version=None)
     zip_mock = mocker.MagicMock()
-    mocker.patch("virtualenv.seed.embed.wheels.acquire.ZipFile", new=zip_mock)
+    mocker.patch("virtualenv.seed.embed.wheels.util.ZipFile", new=zip_mock)
     zip_mock.return_value.__enter__.return_value.read = lambda name: b""
 
-    supports = wheel_support_py(wheel, "3.8")
+    supports = wheel.support_py("3.8")
     assert supports is True


### PR DESCRIPTION
This means latest compatible version between embed wheels and the ones
found under the path provided by ``--extra-search-dir``. Report at the
end the installed wheel versions.

Resolves https://github.com/pypa/virtualenv/issues/1821.