### PR TITLE
Fix pip seeder with --extra-search-dir specified

### DIFF
--- a/docs/changelog/1834.bugfix.rst
+++ b/docs/changelog/1834.bugfix.rst
@@ -1,0 +1,1 @@
+Seeder pip now correctly handles ``--extra-search-dir`` - by :user:`frenzymadness`.

--- a/src/virtualenv/seed/embed/pip_invoke.py
+++ b/src/virtualenv/seed/embed/pip_invoke.py
@@ -43,7 +43,7 @@ class PipInvoke(BaseEmbed):
             folders = set()
             for context in (ensure_file_on_disk(get_bundled_wheel(p, version), self.app_data) for p in pkg_versions):
                 folders.add(stack.enter_context(context).parent)
+            folders.update(set(self.extra_search_dir))
             for folder in folders:
                 cmd.extend(["--find-links", str(folder)])
-                cmd.extend(self.extra_search_dir)
             yield cmd

--- a/src/virtualenv/seed/embed/pip_invoke.py
+++ b/src/virtualenv/seed/embed/pip_invoke.py
@@ -25,11 +25,16 @@ class PipInvoke(BaseEmbed):
             return
         with self.get_pip_install_cmd(creator.exe, creator.interpreter.version_release_str) as cmd:
             with pip_wheel_env_run(creator.interpreter.version_release_str, self.app_data) as env:
-                logging.debug("pip seed by running: %s", LogCmd(cmd, env))
-                process = Popen(cmd, env=env)
-                process.communicate()
+                self._execute(cmd, env)
+
+    @staticmethod
+    def _execute(cmd, env):
+        logging.debug("pip seed by running: %s", LogCmd(cmd, env))
+        process = Popen(cmd, env=env)
+        process.communicate()
         if process.returncode != 0:
             raise RuntimeError("failed seed with code {}".format(process.returncode))
+        return process
 
     @contextmanager
     def get_pip_install_cmd(self, exe, version):

--- a/tests/unit/seed/test_pip_invoke.py
+++ b/tests/unit/seed/test_pip_invoke.py
@@ -5,6 +5,7 @@ import pytest
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.run import cli_run
 from virtualenv.seed.embed.wheels import BUNDLE_SUPPORT
+from virtualenv.seed.embed.wheels.acquire import BUNDLE_FOLDER
 
 
 @pytest.mark.slow
@@ -12,6 +13,8 @@ from virtualenv.seed.embed.wheels import BUNDLE_SUPPORT
 def test_base_bootstrap_via_pip_invoke(tmp_path, coverage_env, current_fastest, no):
     bundle_ver = BUNDLE_SUPPORT[PythonInfo.current_system().version_release_str]
     create_cmd = [
+        "--extra-search-dir",
+        str(BUNDLE_FOLDER),
         "--seeder",
         "pip",
         str(tmp_path / "env"),

--- a/tests/unit/seed/test_pip_invoke.py
+++ b/tests/unit/seed/test_pip_invoke.py
@@ -4,17 +4,28 @@ import pytest
 
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.run import cli_run
+from virtualenv.seed.embed.pip_invoke import PipInvoke
 from virtualenv.seed.embed.wheels import BUNDLE_SUPPORT
 from virtualenv.seed.embed.wheels.acquire import BUNDLE_FOLDER
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("no", ["pip", "setuptools", "wheel", ""])
-def test_base_bootstrap_via_pip_invoke(tmp_path, coverage_env, current_fastest, no):
+def test_base_bootstrap_via_pip_invoke(tmp_path, coverage_env, mocker, current_fastest, no):
     bundle_ver = BUNDLE_SUPPORT[PythonInfo.current_system().version_release_str]
+
+    extra_search_dir = tmp_path / "extra"
+    extra_search_dir.mkdir()
+
+    original = PipInvoke._execute
+
+    def _execute(cmd, env):
+        assert set(cmd[-4:]) == {"--find-links", str(extra_search_dir), str(BUNDLE_FOLDER)}
+        return original(cmd, env)
+
+    run = mocker.patch.object(PipInvoke, "_execute", side_effect=_execute)
+
     create_cmd = [
-        "--extra-search-dir",
-        str(BUNDLE_FOLDER),
         "--seeder",
         "pip",
         str(tmp_path / "env"),
@@ -25,12 +36,16 @@ def test_base_bootstrap_via_pip_invoke(tmp_path, coverage_env, current_fastest, 
         bundle_ver["setuptools"].split("-")[1],
         "--creator",
         current_fastest,
+        "--extra-search-dir",
+        str(extra_search_dir),
     ]
     if no:
         create_cmd.append("--no-{}".format(no))
     result = cli_run(create_cmd)
     coverage_env()
+
     assert result
+    assert run.call_count == 1
 
     site_package = result.creator.purelib
     pip = site_package / "pip"


### PR DESCRIPTION
pip needs to have `--find-links` CLI argument for each directory
not just once for a list of directories.

Fixes: https://github.com/pypa/virtualenv/issues/1834

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

If you agree with the fix, I'll try to prepare a test for it and a changelog entry.