### PR TITLE
Call towncrier via python instead of doing poor path reconstruction

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,9 +59,9 @@ extlinks = {
 
 def generate_draft_news():
     root = Path(__file__).parents[1]
-    exe = Path(sys.executable)
-    towncrier = exe.with_name("towncrier{}".format(exe.suffix))
-    new = subprocess.check_output([str(towncrier), "--draft", "--version", "NEXT"], cwd=root, universal_newlines=True)
+    new = subprocess.check_output(
+        [sys.executable, "-m", "towncrier", "--draft", "--version", "NEXT"], cwd=root, universal_newlines=True,
+    )
     (root / "docs" / "_draft.rst").write_text("" if "No significant changes" in new else new)
 
 


### PR DESCRIPTION
Trying to append an executable suffix to towncrier does not work
on Linux, as it can create absurd names like `towncrier.7` (`.7` coming
from `python3.7`).  Let's instead call it via `python -m towncrier`.
This should avoid relying on correct `PATH` (as I presume the original
code is meant to), while working correctly on all systems
and not requiring Python and towncrier to reside in the same directory.

Fixes #1847

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
