### PR TITLE
Remove upper bound on importlib-resources (2.0 works)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     six>=1.9.0,<2   # keep it >=1.9.0 as it may cause problems on LTS platforms
     contextlib2>=0.6.0,<1;python_version<"3.3"
     importlib-metadata>=0.12,<2;python_version<"3.8"
-    importlib-resources>=1.0,<2;python_version<"3.7"
+    importlib-resources>=1.0;python_version<"3.7"
     pathlib2>=2.3.3,<3;python_version < '3.4' and sys.platform != 'win32'
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 package_dir =


### PR DESCRIPTION
this fixes a diamond incompatibility with pre-commit when installed on python<3.8