### PR TITLE
Do not write .gitignore if already exists

### DIFF
--- a/docs/changelog/1862.bugfix.rst
+++ b/docs/changelog/1862.bugfix.rst
@@ -1,0 +1,1 @@
+Do not generate/overwrite ``.gitignore`` if it already exists at destination path - by :user:`gaborbernat`.

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -168,14 +168,16 @@ class Creator(object):
     def setup_ignore_vcs(self):
         """Generate ignore instructions for version control systems."""
         # mark this folder to be ignored by VCS, handle https://www.python.org/dev/peps/pep-0610/#registered-vcs
-        (self.dest / ".gitignore").write_text(
-            dedent(
-                """
-                # created by virtualenv automatically
-                *
-                """,
-            ).lstrip(),
-        )
+        git_ignore = self.dest / ".gitignore"
+        if not git_ignore.exists():
+            git_ignore.write_text(
+                dedent(
+                    """
+                    # created by virtualenv automatically
+                    *
+                    """,
+                ).lstrip(),
+            )
         # Mercurial - does not support the .hgignore file inside a subdirectory directly, but only if included via the
         # subinclude directive from root, at which point on might as well ignore the directory itself, see
         # https://www.selenic.com/mercurial/hgignore.5.html for more details

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -237,6 +237,13 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
     assert git_ignore.splitlines() == ["# created by virtualenv automatically", "*"]
 
 
+def test_create_gitignore_exists(tmp_path):
+    git_ignore = tmp_path / ".gitignore"
+    git_ignore.write_text("magic")
+    cli_run([str(tmp_path), "--without-pip", "--activators", ""])
+    assert git_ignore.read_text() == "magic"
+
+
 @pytest.mark.skipif(not CURRENT.has_venv, reason="requires interpreter with venv")
 def test_venv_fails_not_inline(tmp_path, capsys, mocker):
     if hasattr(os, "geteuid"):


### PR DESCRIPTION
This ensures that we do not overwrite an existing .gitignore when the
target directory is not created by virtualenv.

Resolves #1862.