### PR TITLE
Improve error message for no .dist-info

### DIFF
--- a/docs/changelog/1867.bugfix.rst
+++ b/docs/changelog/1867.bugfix.rst
@@ -1,0 +1,1 @@
+Improve error message for no ``.dist-info`` inside the ``app-data`` copy seeder - by :user:`gaborbernat`.

--- a/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
@@ -97,12 +97,15 @@ class PipInstall(object):
         if self._extracted is False:
             return None  # pragma: no cover
         if self.__dist_info is None:
+            files = []
             for filename in self._image_dir.iterdir():
+                files.append(filename.name)
                 if filename.suffix == ".dist-info":
                     self.__dist_info = filename
                     break
             else:
-                raise RuntimeError("no dist info")  # pragma: no cover
+                msg = "no .dist-info at {}, has {}".format(self._image_dir, ", ".join(files))  # pragma: no cover
+                raise RuntimeError(msg)  # pragma: no cover
         return self.__dist_info
 
     @abstractmethod


### PR DESCRIPTION
Inside the copy app-data installer.