### PR TITLE
Do not print error if exit with SystemExit

### DIFF
--- a/docs/changelog/1885.bugfix.rst
+++ b/docs/changelog/1885.bugfix.rst
@@ -1,0 +1,1 @@
+Do not print error message if the application exists with ``SystemExit(0)`` - by :user:`gaborbernat`.

--- a/src/virtualenv/__main__.py
+++ b/src/virtualenv/__main__.py
@@ -66,7 +66,8 @@ def run_with_catch(args=None):
             if getattr(options, "with_traceback", False):
                 raise
             else:
-                logging.error("%s: %s", type(exception).__name__, exception)
+                if not (isinstance(exception, SystemExit) and exception.code == 0):
+                    logging.error("%s: %s", type(exception).__name__, exception)
                 code = exception.code if isinstance(exception, SystemExit) else 1
                 sys.exit(code)
         finally:


### PR DESCRIPTION
In this case, Python will automatically convey the content by setting the
exit code and we do not print on stderr when exiting with success.

Resolves #1885.