### PR TITLE
Reduce aggressiveness of clear argument

### DIFF
--- a/docs/changelog/1890.bugfix.rst
+++ b/docs/changelog/1890.bugfix.rst
@@ -1,0 +1,1 @@
+Maintain non-virtualenv files on ``--clear`` - by :user:`inno`.

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -85,7 +85,7 @@ class Creator(object):
             "--clear",
             dest="clear",
             action="store_true",
-            help="remove the destination directory if exist before starting (will overwrite files otherwise)",
+            help="clear out the non-root install and start from scratch",
             default=False,
         )
 
@@ -152,8 +152,13 @@ class Creator(object):
 
     def run(self):
         if self.dest.exists() and self.clear:
-            logging.debug("delete %s", self.dest)
-            safe_delete(self.dest)
+            # Ignore Python* paths due to their dynamic nature
+            created = ("Include", "Lib", "Scripts", "bin", "include", "lib")
+            for subdir in created:
+                createdpath = os.path.join(str(self.dest), subdir)
+                if os.path.isdir(createdpath):
+                    logging.debug("clear %s", createdpath)
+                    safe_delete(createdpath)
         self.create()
         self.set_pyenv_cfg()
         self.setup_ignore_vcs()

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -295,15 +295,20 @@ def test_create_clear_resets(tmp_path, creator, clear, caplog):
     caplog.set_level(logging.DEBUG)
     if creator == "venv" and clear is False:
         pytest.skip("venv without clear might fail")
-    marker = tmp_path / "magic"
+    marker = tmp_path / "bin" / "transient"
+    static_marker = tmp_path / "magic"
     cmd = [str(tmp_path), "--seeder", "app-data", "--without-pip", "--creator", creator, "-vvv"]
     cli_run(cmd)
 
     marker.write_text("")  # if we a marker file this should be gone on a clear run, remain otherwise
+    static_marker.write_text("")
+
     assert marker.exists()
+    assert static_marker.exists()
 
     cli_run(cmd + (["--clear"] if clear else []))
     assert marker.exists() is not clear
+    assert static_marker.exists()
 
 
 @pytest.mark.parametrize("creator", CURRENT_CREATORS)


### PR DESCRIPTION
Align with previous iterations ``--clear`` functionality. Retain initial
file tree by only removing directories likely created by virtualenv.

Resolves #1890 

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation
