### PR TITLE
Don't preimport threading early

### DIFF
--- a/docs/changelog/1897.bugfix.rst
+++ b/docs/changelog/1897.bugfix.rst
@@ -1,4 +1,1 @@
-No longer preimport threading to fix support for gpython__ and gevent__ - by :user:`navytux`.
-
-__ https://pypi.org/project/pygolang/#gpython
-__ https://www.gevent.org/
+No longer preimport threading to fix support for `gpython <https://pypi.org/project/pygolang/#gpython>`_ and `gevent <https://www.gevent.org/>`_ - by :user:`navytux`.

--- a/docs/changelog/1897.bugfix.rst
+++ b/docs/changelog/1897.bugfix.rst
@@ -1,0 +1,4 @@
+No longer preimport threading to fix support for gpython__ and gevent__ - by :user:`navytux`.
+
+__ https://pypi.org/project/pygolang/#gpython
+__ https://www.gevent.org/

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -46,9 +46,8 @@ if sys.version_info > (3, 4):
 
         fullname = None
 
-        # lock[0] is threading.Lock(), but initialized lazily to avoid importing
-        # threading very early at startup, because there are gevent-based
-        # applications that need to be first to import threading by themselves.
+        # lock[0] is threading.Lock(), but initialized lazily to avoid importing threading very early at startup,
+        # because there are gevent-based applications that need to be first to import threading by themselves.
         # See https://github.com/pypa/virtualenv/issues/1895 for details.
         lock = []
 
@@ -59,12 +58,10 @@ if sys.version_info > (3, 4):
                     import threading
 
                     lock = threading.Lock()
-                    # there is possibility that two threads T1 and T2 are
-                    # simultaneously running into find_spec, observing .lock as
-                    # empty, and further going into hereby initialization.
-                    # However due to the GIL, list.append() operation is atomic
-                    # and this way only one of the threads will "win" to put
-                    # the lock - that every thread will use - into .lock[0].
+                    # there is possibility that two threads T1 and T2 are simultaneously running into find_spec,
+                    # observing .lock as empty, and further going into hereby initialization. However due to the GIL,
+                    # list.append() operation is atomic and this way only one of the threads will "win" to put the lock
+                    # - that every thread will use - into .lock[0].
                     # https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe
                     self.lock.append(lock)
 

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -39,18 +39,36 @@ if sys.version_info > (3, 4):
     # https://docs.python.org/3/library/importlib.html#setting-up-an-importer
     from importlib.abc import MetaPathFinder
     from importlib.util import find_spec
-    from threading import Lock
     from functools import partial
 
     class _Finder(MetaPathFinder):
         """A meta path finder that allows patching the imported distutils modules"""
 
         fullname = None
-        lock = Lock()
+
+        # lock[0] is threading.Lock(), but initialized lazily to avoid importing
+        # threading very early at startup, because there are gevent-based
+        # applications that need to be first to import threading by themselves.
+        # See https://github.com/pypa/virtualenv/issues/1895 for details.
+        lock = []
 
         def find_spec(self, fullname, path, target=None):
             if fullname in _DISTUTILS_PATCH and self.fullname is None:
-                with self.lock:
+                # initialize lock[0] lazily
+                if len(self.lock) == 0:
+                    import threading
+
+                    lock = threading.Lock()
+                    # there is possibility that two threads T1 and T2 are
+                    # simultaneously running into find_spec, observing .lock as
+                    # empty, and further going into hereby initialization.
+                    # However due to the GIL, list.append() operation is atomic
+                    # and this way only one of the threads will "win" to put
+                    # the lock - that every thread will use - into .lock[0].
+                    # https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe
+                    self.lock.append(lock)
+
+                with self.lock[0]:
                     self.fullname = fullname
                     try:
                         spec = find_spec(fullname, path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,11 +188,11 @@ COVERAGE_RUN = os.environ.get(str(COV_ENV_VAR))
 
 
 @pytest.fixture(autouse=True)
-def coverage_env(monkeypatch, link):
+def coverage_env(monkeypatch, link, request):
     """
     Enable coverage report collection on the created virtual environments by injecting the coverage project
     """
-    if COVERAGE_RUN:
+    if COVERAGE_RUN and "no_coverage" not in request.fixturenames:
         # we inject right after creation, we cannot collect coverage on site.py - used for helper scripts, such as debug
         from virtualenv import run
 
@@ -228,6 +228,12 @@ def coverage_env(monkeypatch, link):
             pass
 
         yield finish
+
+
+# no_coverage tells coverage_env to disable coverage injection for no_coverage user.
+@pytest.fixture
+def no_coverage():
+    pass
 
 
 class EnableCoverage(object):

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -557,3 +557,16 @@ def test_zip_importer_can_import_setuptools(tmp_path):
     env = os.environ.copy()
     env[str("PYTHONPATH")] = str(zip_path)
     subprocess.check_call([str(result.creator.exe), "-c", "from setuptools.dist import Distribution"], env=env)
+
+
+# verify that python in created virtualenv does not preimport threading.
+# https://github.com/pypa/virtualenv/issues/1895
+def test_no_preimport_threading(tmp_path):
+    session = cli_run([ensure_text(str(tmp_path))])
+    out = subprocess.check_output(
+        [session.creator.exe, "-c", r"import sys; print('\n'.join(sorted(sys.modules)))"], universal_newlines=True,
+    )
+    preimport = set()
+    for mod in out.splitlines():
+        preimport.add(mod)
+    assert "threading" not in preimport

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -564,7 +564,7 @@ def test_zip_importer_can_import_setuptools(tmp_path):
 def test_no_preimport_threading(tmp_path):
     session = cli_run([ensure_text(str(tmp_path))])
     out = subprocess.check_output(
-        [session.creator.exe, "-c", r"import sys; print('\n'.join(sorted(sys.modules)))"], universal_newlines=True,
+        [str(session.creator.exe), "-c", r"import sys; print('\n'.join(sorted(sys.modules)))"], universal_newlines=True,
     )
     preimport = set()
     for mod in out.splitlines():

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -563,10 +563,12 @@ def test_zip_importer_can_import_setuptools(tmp_path):
 # https://github.com/pypa/virtualenv/issues/1895
 def test_no_preimport_threading(tmp_path):
     session = cli_run([ensure_text(str(tmp_path))])
+    # disable coverage for spawned subprocess.
+    # When coverage is active, it imports threading in default mode.
+    env = os.environ.copy()
+    env.pop("COVERAGE_PROCESS_START", None)
     out = subprocess.check_output(
-        [str(session.creator.exe), "-c", r"import sys; print('\n'.join(sorted(sys.modules)))"], universal_newlines=True,
+        [str(session.creator.exe), "-c", r"import sys; print('\n'.join(sorted(sys.modules)))"], universal_newlines=True, env=env,
     )
-    preimport = set()
-    for mod in out.splitlines():
-        preimport.add(mod)
-    assert "threading" not in preimport
+    imported = set(out.splitlines())
+    assert "threading" not in imported

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -561,14 +561,12 @@ def test_zip_importer_can_import_setuptools(tmp_path):
 
 # verify that python in created virtualenv does not preimport threading.
 # https://github.com/pypa/virtualenv/issues/1895
-def test_no_preimport_threading(tmp_path):
+#
+# coverage is disabled, because when coverage is active, it imports threading in default mode.
+def test_no_preimport_threading(tmp_path, no_coverage):
     session = cli_run([ensure_text(str(tmp_path))])
-    # disable coverage for spawned subprocess.
-    # When coverage is active, it imports threading in default mode.
-    env = os.environ.copy()
-    env.pop("COVERAGE_PROCESS_START", None)
     out = subprocess.check_output(
-        [str(session.creator.exe), "-c", r"import sys; print('\n'.join(sorted(sys.modules)))"], universal_newlines=True, env=env,
+        [str(session.creator.exe), "-c", r"import sys; print('\n'.join(sorted(sys.modules)))"], universal_newlines=True,
     )
     imported = set(out.splitlines())
     assert "threading" not in imported

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -563,6 +563,9 @@ def test_zip_importer_can_import_setuptools(tmp_path):
 # https://github.com/pypa/virtualenv/issues/1895
 #
 # coverage is disabled, because when coverage is active, it imports threading in default mode.
+@pytest.mark.xfail(
+    IS_PYPY and PY3 and sys.platform.startswith("darwin"), reason="https://foss.heptapod.net/pypy/pypy/-/issues/3269",
+)
 def test_no_preimport_threading(tmp_path, no_coverage):
     session = cli_run([ensure_text(str(tmp_path))])
     out = subprocess.check_output(


### PR DESCRIPTION
Gevent-based applications need to be able to import threading, socket,
ssl, etc... modules early to be able to monkey-patch them to use
lightweight greenlets instead of OS threads. This patching has to be
done as early as possible in the lifetime of the process

http://www.gevent.org/intro.html#monkey-patching

However starting from caae48bf (use import hooks to patch
distutils/setuptools (#1688)) threading became always preimported which,
for example, rendered gpython[1] unusable:

	(py38.virtualenv) kirr@deco:~/tmp/trashme$ gpython
	Traceback (most recent call last):
	  File "/home/kirr/tmp/trashme/py38.virtualenv/bin/gpython", line 8, in <module>
	    sys.exit(main())
	  File "/home/kirr/tmp/trashme/py38.virtualenv/lib/python3.8/site-packages/gpython/__init__.py", line 151, in main
	    raise RuntimeError('gpython: internal error: the following modules are pre-imported, but must be not:'
	RuntimeError: gpython: internal error: the following modules are pre-imported, but must be not:

	        ['threading']

	sys.modules:

	        ['__future__', '__main__', '_abc', '_bootlocale', '_codecs', '_collections', '_collections_abc', '_frozen_importlib', '_frozen_importlib_external', '_functools', '_heapq', '_imp', '_io', '_locale', '_operator', '_signal', '_sitebuiltins', '_sre', '_stat', '_thread', '_virtualenv', '_warnings', '_weakref', '_weakrefset', 'abc', 'builtins', 'codecs', 'collections', 'contextlib', 'copyreg', 'encodings', 'encodings.aliases', 'encodings.latin_1', 'encodings.utf_8', 'enum', 'functools', 'genericpath', 'gpython', 'heapq', 'importlib', 'importlib._bootstrap', 'importlib._bootstrap_external', 'importlib.abc', 'importlib.machinery', 'importlib.util', 'io', 'itertools', 'keyword', 'marshal', 'operator', 'os', 'os.path', 'posix', 'posixpath', 're', 'reprlib', 'site', 'sitecustomize', 'sre_compile', 'sre_constants', 'sre_parse', 'stat', 'sys', 'threading', 'time', 'types', 'warnings', 'zipimport', 'zope']

Fix it by importing threading lazily.

Fixes: https://github.com/pypa/virtualenv/issues/1895

[1] https://pypi.org/project/pygolang/#gpython

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation  (no need for this PR)
