### PR TITLE
make tests work better on pytest 4.x and python 3.x

### DIFF
--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
+import sys
+
+import pytest
+
 from virtualenv.activation import BashActivator
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Github Actions ships with WSL bash")
 def test_bash(raise_on_non_source_class, activation_tester):
     class Bash(raise_on_non_source_class):
         def __init__(self, session):

--- a/tests/unit/seed/wheels/test_periodic_update.py
+++ b/tests/unit/seed/wheels/test_periodic_update.py
@@ -149,7 +149,7 @@ _UPDATE_SKIP = {
 }
 
 
-@pytest.mark.parametrize("u_log", _UPDATE_SKIP.values(), ids=_UPDATE_SKIP.keys())
+@pytest.mark.parametrize("u_log", list(_UPDATE_SKIP.values()), ids=list(_UPDATE_SKIP.keys()))
 def test_periodic_update_skip(u_log, mocker, for_py_version, session_app_data, freezer):
     freezer.move_to(_UP_NOW)
     mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
@@ -173,7 +173,7 @@ _UPDATE_YES = {
 }
 
 
-@pytest.mark.parametrize("u_log", _UPDATE_YES.values(), ids=_UPDATE_YES.keys())
+@pytest.mark.parametrize("u_log", list(_UPDATE_YES.values()), ids=list(_UPDATE_YES.keys()))
 def test_periodic_update_trigger(u_log, mocker, for_py_version, session_app_data, freezer):
     freezer.move_to(_UP_NOW)
     mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())


### PR DESCRIPTION
this came up while packaging virtualenv 20.x for freebsd ports:

```
_______ ERROR collecting tests/unit/seed/wheels/test_periodic_update.py ________
venv/lib/python3.8/site-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
venv/lib/python3.8/site-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
venv/lib/python3.8/site-packages/pluggy/manager.py:84: in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
venv/lib/python3.8/site-packages/_pytest/python.py:234: in pytest_pycollect_makeitem
    res = list(collector._genfunctions(name, obj))
venv/lib/python3.8/site-packages/_pytest/python.py:410: in _genfunctions
    self.ihook.pytest_generate_tests(metafunc=metafunc)
venv/lib/python3.8/site-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
venv/lib/python3.8/site-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
venv/lib/python3.8/site-packages/pluggy/manager.py:84: in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
venv/lib/python3.8/site-packages/_pytest/python.py:137: in pytest_generate_tests
    metafunc.parametrize(*marker.args, **marker.kwargs)
venv/lib/python3.8/site-packages/_pytest/python.py:1015: in parametrize
    ids = self._resolve_arg_ids(argnames, ids, parameters, item=self.definition)
venv/lib/python3.8/site-packages/_pytest/python.py:1069: in _resolve_arg_ids
    ids = idmaker(argnames, parameters, idfn, ids, self.config, item=item)
venv/lib/python3.8/site-packages/_pytest/python.py:1221: in idmaker
    ids = [
venv/lib/python3.8/site-packages/_pytest/python.py:1222: in <listcomp>
    _idvalset(valindex, parameterset, argnames, idfn, ids, config=config, item=item)
venv/lib/python3.8/site-packages/_pytest/python.py:1210: in _idvalset
    if ids is None or (idx >= len(ids) or ids[idx] is None):
E   TypeError: 'dict_keys' object is not subscriptable
```

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
