### PR TITLE
Fix typos in the documentation

### DIFF
--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -36,7 +36,7 @@ virtualenv looks for a standard ini configuration file. The exact location depen
 as determined by :pypi:`appdirs` application configuration definition. The configuration file location is printed as at
 the end of the output when ``--help`` is passed.
 
-The keys of the settings are derived from th command line option (left strip the ``-`` characters, and replace ``-``
+The keys of the settings are derived from the command line option (left strip the ``-`` characters, and replace ``-``
 with ``_``). Where multiple flags are available first found wins (where order is as it shows up under the ``--help``).
 
 For example, :option:`--python <python>` would be specified as:

--- a/src/virtualenv/run/__init__.py
+++ b/src/virtualenv/run/__init__.py
@@ -117,7 +117,7 @@ def add_version_flag(parser):
         "--version",
         action="version",
         version="%(prog)s {} from {}".format(__version__, virtualenv.__file__),
-        help="display the version of the virtualenv package and it's location, then exit",
+        help="display the version of the virtualenv package and its location, then exit",
     )
 
 


### PR DESCRIPTION
This PR:
* Fixes two typos:
  1. in the documentation for CLI
  2. In the source for the command line flag

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- ~~[ ] ensured there are test(s) validating the fix~~
- ~~[ ] added news fragment in ``docs/changelog`` folder~~
- [x] updated/extended the documentation
