### PR TITLE
Correct the example in the CLI docs

### DIFF
--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -51,7 +51,7 @@ Options that take multiple values, like :option:`extra-search-dir` can be specif
 .. code-block:: ini
 
   [virtualenv]
-  extra-search-dir =
+  extra_search_dir =
       /path/to/dists
       /path/to/other/dists
 


### PR DESCRIPTION
Issue:
https://github.com/pypa/virtualenv/issues/1901

This PR:
* Corrects the example for configuration file to match the description.
