### PR TITLE
Use \n instead if \r\n as line separator

### DIFF
--- a/docs/changelog/1905.bugfix.rst
+++ b/docs/changelog/1905.bugfix.rst
@@ -1,0 +1,2 @@
+Use ``\n`` instead if ``\r\n`` as line separator for report (because Python already performs this transformation
+automatically upon write to the logging pipe) - by :user:`gaborbernat`.

--- a/src/virtualenv/__main__.py
+++ b/src/virtualenv/__main__.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
-import os
 import sys
 from datetime import datetime
 
@@ -52,7 +51,7 @@ class LogSession(object):
             )
         if self.session.activators:
             lines.append("  activators {}".format(",".join(i.__class__.__name__ for i in self.session.activators)))
-        return os.linesep.join(lines)
+        return "\n".join(lines)
 
 
 def run_with_catch(args=None):

--- a/src/virtualenv/config/ini.py
+++ b/src/virtualenv/config/ini.py
@@ -75,7 +75,7 @@ class IniConfig(object):
     def epilog(self):
         msg = "{}config file {} {} (change{} via env var {})"
         return msg.format(
-            os.linesep,
+            "\n",
             self.config_file,
             self.STATE[self.has_config_file],
             "d" if self.is_env_var else "",


### PR DESCRIPTION
The logging framework will write to a pipe, which then will blindly transform
all carriage returns to carriage return plus line feed, when on Windows. So
injecting the \r\n leaves us with double carriage return.