### PR TITLE
Fix read and write racing on multiple processes.

### DIFF
--- a/docs/changelog/1938.bugfix.rst
+++ b/docs/changelog/1938.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that reading and writing on the same file may cause race on multiple processes.

--- a/src/virtualenv/app_data/via_disk_folder.py
+++ b/src/virtualenv/app_data/via_disk_folder.py
@@ -137,7 +137,10 @@ class JSONStoreDisk(ContentStore):
         except Exception:  # noqa
             pass
         if bad_format:
-            self.remove()
+            try:
+                self.remove()
+            except OSError:  # reading and writing on the same file may cause race on multiple processes
+                pass
         return None
 
     def remove(self):


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

This PR address an issue that read/write on the update log can cause competition on multiple processes.
Close #1938 