### PR TITLE
Fix activator path in cygwin and msys2

### DIFF
--- a/docs/changelog/1940.bugfix.rst
+++ b/docs/changelog/1940.bugfix.rst
@@ -1,0 +1,1 @@
+Provide correct path for bash activator in cygwin or msys2 - by :user:`danyeaw`.

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import re
 import sys
+import sysconfig
 from abc import ABCMeta, abstractmethod
 
 from six import add_metaclass
@@ -31,9 +33,18 @@ class ViaTemplateActivator(Activator):
         return generated
 
     def replacements(self, creator, dest_folder):
+        if "mingw" or "cygwin" or "msys" in sysconfig.get_platform():
+            pattern = re.compile("^([A-Za-z]):(.*)")
+            match = pattern.match(str(creator.dest))
+            if match:
+                virtual_env = "/" + match.group(1).lower() + match.group(2)
+            else:
+                virtual_env = str(creator.dest)
+        else:
+            virtual_env = str(creator.dest)
         return {
             "__VIRTUAL_PROMPT__": "" if self.flag_prompt is None else self.flag_prompt,
-            "__VIRTUAL_ENV__": ensure_text(str(creator.dest)),
+            "__VIRTUAL_ENV__": ensure_text(virtual_env),
             "__VIRTUAL_NAME__": creator.env_name,
             "__BIN_NAME__": ensure_text(str(creator.bin_dir.relative_to(creator.dest))),
             "__PATH_SEP__": ensure_text(os.pathsep),


### PR DESCRIPTION
Closes #1940. In cygwin and MSYS2, the path is in POSIX format. This PR converts the Windows path to POSIX format using the cygpath utility so that it is added to the bash activation script in the correct format.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [X] ran the linter to address style issues (``tox -e fix_lint``)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in ``docs/changelog`` folder
- [X] updated/extended the documentation
