### PR TITLE
Fix activator path in cygwin and msys2

### DIFF
--- a/docs/changelog/1940.bugfix.rst
+++ b/docs/changelog/1940.bugfix.rst
@@ -1,0 +1,1 @@
+Provide correct path for bash activator in cygwin or msys2 - by :user:`danyeaw`.

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import re
 import sys
+import sysconfig
 from abc import ABCMeta, abstractmethod
 
 from six import add_metaclass
@@ -31,9 +33,17 @@ class ViaTemplateActivator(Activator):
         return generated
 
     def replacements(self, creator, dest_folder):
+        current_platform = sysconfig.get_platform()
+        platforms = ["mingw", "cygwin", "msys"]
+        if any(platform in current_platform for platform in platforms):
+            pattern = re.compile("^([A-Za-z]):(.*)")
+            match = pattern.match(str(creator.dest))
+            virtual_env = "/" + match.group(1).lower() + match.group(2)
+        else:
+            virtual_env = str(creator.dest)
         return {
             "__VIRTUAL_PROMPT__": "" if self.flag_prompt is None else self.flag_prompt,
-            "__VIRTUAL_ENV__": ensure_text(str(creator.dest)),
+            "__VIRTUAL_ENV__": ensure_text(virtual_env),
             "__VIRTUAL_NAME__": creator.env_name,
             "__BIN_NAME__": ensure_text(str(creator.bin_dir.relative_to(creator.dest))),
             "__PATH_SEP__": ensure_text(os.pathsep),

--- a/tests/unit/activation/test_activation_support.py
+++ b/tests/unit/activation/test_activation_support.py
@@ -13,6 +13,8 @@ from virtualenv.activation import (
     PythonActivator,
 )
 from virtualenv.discovery.py_info import PythonInfo
+from virtualenv.info import IS_WIN
+from virtualenv.util.path import Path
 
 
 @pytest.mark.parametrize(
@@ -53,3 +55,32 @@ def test_activator_no_support_posix(mocker, activator_class):
     interpreter = mocker.Mock(spec=PythonInfo)
     interpreter.os = "posix"
     assert not activator.supports(interpreter)
+
+
+class Creator:
+    def __init__(self):
+        self.dest = "C:/tools/msys64/home"
+        self.env_name = "venv"
+        self.bin_dir = Path("C:/tools/msys64/home/bin")
+
+
+@pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
+@pytest.mark.parametrize("activator_class", [BashActivator])
+def test_cygwin_msys2_path_conversion(mocker, activator_class):
+    mocker.patch("sysconfig.get_platform", return_value="mingw")
+    activator = activator_class(Namespace(prompt=None))
+    creator = Creator()
+    mocker.stub(creator.bin_dir.relative_to)
+    resource = activator.replacements(creator, "")
+    assert resource["__VIRTUAL_ENV__"] == "/c/tools/msys64/home"
+
+
+@pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
+@pytest.mark.parametrize("activator_class", [BashActivator])
+def test_win_path_no_conversion(mocker, activator_class):
+    mocker.patch("sysconfig.get_platform", return_value="win-amd64")
+    activator = activator_class(Namespace(prompt=None))
+    creator = Creator()
+    mocker.stub(creator.bin_dir.relative_to)
+    resource = activator.replacements(creator, "")
+    assert resource["__VIRTUAL_ENV__"] == "C:/tools/msys64/home"


### PR DESCRIPTION
Closes #1940. In cygwin and MSYS2, the path is in POSIX format. This PR converts the Windows path to POSIX format using a regex so that it is added to the bash activation script in the correct format.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [X] ran the linter to address style issues (``tox -e fix_lint``)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in ``docs/changelog`` folder
- [X] updated/extended the documentation