### PR TITLE
Updated importlib-metadata constraint

### DIFF
--- a/docs/changelog/1953.bugfix.rst
+++ b/docs/changelog/1953.bugfix.rst
@@ -1,0 +1,1 @@
+Relax importlib requirement to allow version<3 - by :user:`usamasadiq`

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     distlib>=0.3.1,<1
     filelock>=3.0.0,<4
     six>=1.9.0,<2   # keep it >=1.9.0 as it may cause problems on LTS platforms
-    importlib-metadata>=0.12,<2;python_version<"3.8"
+    importlib-metadata>=0.12,<3;python_version<"3.8"
     importlib-resources>=1.0;python_version<"3.7"
     pathlib2>=2.3.3,<3;python_version < '3.4' and sys.platform != 'win32'
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*


### PR DESCRIPTION
On Python<3.8, `importlib-metadata==2.0.0` causes dependency conflicts because of the pinned constraint `python<3.8`. There is no breaking change in the importlib-metadata [version 2.0.0](https://importlib-metadata.readthedocs.io/en/latest/changelog%20%28links%29.html#v2-0-0).

[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development)
- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation
