### PR TITLE
Fix cygwin NoneType error if POSIX path in dest

### DIFF
--- a/docs/changelog/1962.bugfix.rst
+++ b/docs/changelog/1962.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Nonetype error in cygwin if POSIX path in dest - by :user:`danyeaw`.

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -38,7 +38,10 @@ class ViaTemplateActivator(Activator):
         if any(platform in current_platform for platform in platforms):
             pattern = re.compile("^([A-Za-z]):(.*)")
             match = pattern.match(str(creator.dest))
-            virtual_env = "/" + match.group(1).lower() + match.group(2)
+            if match:
+                virtual_env = "/" + match.group(1).lower() + match.group(2)
+            else:
+                virtual_env = str(creator.dest)
         else:
             virtual_env = str(creator.dest)
         return {

--- a/tests/unit/activation/test_activation_support.py
+++ b/tests/unit/activation/test_activation_support.py
@@ -84,3 +84,16 @@ def test_win_path_no_conversion(mocker, activator_class):
     mocker.stub(creator.bin_dir.relative_to)
     resource = activator.replacements(creator, "")
     assert resource["__VIRTUAL_ENV__"] == "C:/tools/msys64/home"
+
+
+@pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
+@pytest.mark.parametrize("activator_class", [BashActivator])
+def test_cygwin_path_no_conversion(mocker, activator_class):
+    mocker.patch("sysconfig.get_platform", return_value="cygwin")
+    activator = activator_class(Namespace(prompt=None))
+    creator = Creator()
+    creator.dest = "/c/tools/msys64/home"
+    creator.bin_dir = Path("/c/tools/msys64/home/bin")
+    mocker.stub(creator.bin_dir.relative_to)
+    resource = activator.replacements(creator, "")
+    assert resource["__VIRTUAL_ENV__"] == "/c/tools/msys64/home"


### PR DESCRIPTION
Closes #1962. Corrects an AttributeError for a regex match not found if the cygwin path is already in POSIX format.

I am not able to reproduce the issue in #1962, but this PR guards against trying modify the virtualenv path if the regex doesn't return a match.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [X] ran the linter to address style issues (``tox -e fix_lint``)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in ``docs/changelog`` folder
- [X] updated/extended the documentation
