### PR TITLE
Fix activation paths in cygwin using cygpath

### DIFF
--- a/docs/changelog/1973.bugfix.rst
+++ b/docs/changelog/1973.bugfix.rst
@@ -1,0 +1,1 @@
+Fix cygwin path conversion using cygpath - by :user:`danyeaw`.

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import re
 import sys
 import sysconfig
 from abc import ABCMeta, abstractmethod
@@ -9,6 +8,7 @@ from abc import ABCMeta, abstractmethod
 from six import add_metaclass
 
 from virtualenv.util.six import ensure_text
+from virtualenv.util.subprocess import run_cmd
 
 from .activator import Activator
 
@@ -36,12 +36,8 @@ class ViaTemplateActivator(Activator):
         current_platform = sysconfig.get_platform()
         platforms = ["mingw", "cygwin", "msys"]
         if any(platform in current_platform for platform in platforms):
-            pattern = re.compile("^([A-Za-z]):(.*)")
-            match = pattern.match(str(creator.dest))
-            if match:
-                virtual_env = "/" + match.group(1).lower() + match.group(2)
-            else:
-                virtual_env = str(creator.dest)
+            code, out, err = run_cmd(["cygpath", str(creator.dest)])
+            virtual_env = out.decode().strip()
         else:
             virtual_env = str(creator.dest)
         return {


### PR DESCRIPTION
This PR fixes #1969. It removes use of a regex to transform the path when using cygwin or MSYS2 and instead makes use of the cygpath utility.

@davidcoghlan would you be able to test in cygwin please?

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [X] ran the linter to address style issues (``tox -e fix_lint``)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in ``docs/changelog`` folder
- [X] updated/extended the documentation
