### PR TITLE
Resolve symlinks when looking for the python interpreter

### DIFF
--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -35,8 +35,10 @@ class PythonInfo(object):
         def u(v):
             return v.decode("utf-8") if isinstance(v, bytes) else v
 
-        def abs_path(v):
-            return None if v is None else os.path.abspath(v)  # unroll relative elements from path (e.g. ..)
+        def real_path(v):
+            return (
+                None if v is None else os.path.realpath(v)
+            )  # unroll relative elements from path (e.g. ..) and resolve symlinks
 
         # qualifies the python
         self.platform = u(sys.platform)
@@ -52,16 +54,16 @@ class PythonInfo(object):
         self.os = u(os.name)
 
         # information about the prefix - determines python home
-        self.prefix = u(abs_path(getattr(sys, "prefix", None)))  # prefix we think
-        self.base_prefix = u(abs_path(getattr(sys, "base_prefix", None)))  # venv
-        self.real_prefix = u(abs_path(getattr(sys, "real_prefix", None)))  # old virtualenv
+        self.prefix = u(real_path(getattr(sys, "prefix", None)))  # prefix we think
+        self.base_prefix = u(real_path(getattr(sys, "base_prefix", None)))  # venv
+        self.real_prefix = u(real_path(getattr(sys, "real_prefix", None)))  # old virtualenv
 
         # information about the exec prefix - dynamic stdlib modules
-        self.base_exec_prefix = u(abs_path(getattr(sys, "base_exec_prefix", None)))
-        self.exec_prefix = u(abs_path(getattr(sys, "exec_prefix", None)))
+        self.base_exec_prefix = u(real_path(getattr(sys, "base_exec_prefix", None)))
+        self.exec_prefix = u(real_path(getattr(sys, "exec_prefix", None)))
 
-        self.executable = u(abs_path(sys.executable))  # the executable we were invoked via
-        self.original_executable = u(abs_path(self.executable))  # the executable as known by the interpreter
+        self.executable = u(real_path(sys.executable))  # the executable we were invoked via
+        self.original_executable = u(real_path(self.executable))  # the executable as known by the interpreter
         self.system_executable = self._fast_get_system_executable()  # the executable we are based of (if available)
 
         try:

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -309,5 +309,7 @@ def test_py_info_to_system_raises(session_app_data, mocker, caplog, skip_if_test
     assert result is None
     log = caplog.records[-1]
     assert log.levelno == logging.INFO
-    expected = "ignore {} due cannot resolve system due to RuntimeError('failed to detect ".format(sys.executable)
+    expected = "ignore {} due cannot resolve system due to RuntimeError('failed to detect ".format(
+        os.path.realpath(sys.executable)
+    )
     assert expected in log.message


### PR DESCRIPTION
This makes the symlink point to the actual python exec, i.e. python3.6 instead of plain python3.
By doing this we ensure that the environment will survive a change in the default python3 version of the host system,
which can be caused by update-alternatives, an upgrade of the OS, etc.

This addresses [1974](https://github.com/pypa/virtualenv/issues/1974)

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
