### PR TITLE
Fix `VIRTUALENV_PYTHON` environment lookup

### DIFF
--- a/docs/changelog/1998.bugfix.rst
+++ b/docs/changelog/1998.bugfix.rst
@@ -1,1 +1,2 @@
-Fix processing of the ``VIRTUALENV_PYTHON`` environment variable
+Fix processing of the ``VIRTUALENV_PYTHON`` environment variable and make it
+multi-value as well (separated by comma) - by :user:`pneff`.

--- a/docs/changelog/1998.bugfix.rst
+++ b/docs/changelog/1998.bugfix.rst
@@ -1,0 +1,1 @@
+Fix processing of the ``VIRTUALENV_PYTHON`` environment variable

--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -72,8 +72,11 @@ variable ``VIRTUALENV_PYTHON`` like:
    env VIRTUALENV_PYTHON=/opt/python-3.8/bin/python virtualenv
 
 Where the option accepts multiple values, for example for :option:`python` or
-:option:`extra-search-dir`, the values can be separated either by comma or a
-literal newline:
+:option:`extra-search-dir`, the values can be separated either by literal
+newlines or commas. Newlines and commas can not be mixed and if both are
+present only the newline is used for separating values. Examples for multiple
+values:
+
 
 .. code-block:: console
 

--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -71,21 +71,18 @@ variable ``VIRTUALENV_PYTHON`` like:
 
    env VIRTUALENV_PYTHON=/opt/python-3.8/bin/python virtualenv
 
-Multiple values can be provided separated with a comma:
+Where the option accepts multiple values, for example for :option:`python` or
+:option:`extra-search-dir`, the values can be separated either by comma or a
+literal newline:
 
 .. code-block:: console
 
    env VIRTUALENV_PYTHON=/opt/python-3.8/bin/python,python3.8 virtualenv
+   env VIRTUALENV_EXTRA_SEARCH_DIR=/path/to/dists\n/path/to/other/dists virtualenv
 
-This also works for appending command line options, like :option:`extra-search-dir`, where a literal newline
-is used to separate the values:
-
-.. code-block:: console
-
-  env VIRTUALENV_EXTRA_SEARCH_DIR=/path/to/dists\n/path/to/other/dists virtualenv
-
-The equivalent CLI-flags based invocation, for the above example, would be:
+The equivalent CLI-flags based invocation for the above examples would be:
 
 .. code-block:: console
 
+   virtualenv --python=/opt/python-3.8/bin/python --python=python3.8
    virtualenv --extra-search-dir=/path/to/dists --extra-search-dir=/path/to/other/dists

--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -71,6 +71,12 @@ variable ``VIRTUALENV_PYTHON`` like:
 
    env VIRTUALENV_PYTHON=/opt/python-3.8/bin/python virtualenv
 
+Multiple values can be provided separated with a comma:
+
+.. code-block:: console
+
+   env VIRTUALENV_PYTHON=/opt/python-3.8/bin/python,python3.8 virtualenv
+
 This also works for appending command line options, like :option:`extra-search-dir`, where a literal newline
 is used to separate the values:
 

--- a/src/virtualenv/config/convert.py
+++ b/src/virtualenv/config/convert.py
@@ -57,19 +57,21 @@ class ListType(TypeData):
     def split_values(self, value):
         """Split the provided value into a list.
 
-        For strings this is a comma-separated. For more complex types (`Path`
-        for example) this is newline-separated.
+        First this is done by newlines. If there were no newlines in the text,
+        then we next try to split by comma.
         """
         if isinstance(value, (str, bytes)):
-            if self.as_type is str:
-                # Simple split
-                value = value.split(",")
-            else:
-                value = value.splitlines()
+            # Use `splitlines` rather than a custom check for whether there is
+            # more than one line. This ensures that the full `splitlines()`
+            # logic is supported here.
+            values = value.splitlines()
+            if len(values) <= 1:
+                values = value.split(",")
+            values = filter(None, [x.strip() for x in values])
+        else:
+            values = list(value)
 
-            value = filter(None, [x.strip() for x in value])
-
-        return list(value)
+        return values
 
 
 def convert(value, as_type, source):

--- a/src/virtualenv/config/convert.py
+++ b/src/virtualenv/config/convert.py
@@ -46,15 +46,30 @@ class ListType(TypeData):
         """"""
 
     def convert(self, value, flatten=True):
-        if isinstance(value, (str, bytes)):
-            value = filter(None, [x.strip() for x in value.splitlines()])
-        values = list(value)
+        values = self.split_values(value)
         result = []
         for value in values:
             sub_values = value.split(os.pathsep)
             result.extend(sub_values)
         converted = [self.as_type(i) for i in result]
         return converted
+
+    def split_values(self, value):
+        """Split the provided value into a list.
+
+        For strings this is a comma-separated. For more complex types (`Path`
+        for example) this is newline-separated.
+        """
+        if isinstance(value, (str, bytes)):
+            if self.as_type is str:
+                # Simple split
+                value = value.split(",")
+            else:
+                value = value.splitlines()
+
+            value = filter(None, [x.strip() for x in value])
+
+        return list(value)
 
 
 def convert(value, as_type, source):

--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -25,6 +25,7 @@ class Builtin(Discover):
             "--python",
             dest="python",
             metavar="py",
+            type=str,
             action="append",
             default=[],
             help="interpreter based on what to create environment (path/identifier) "

--- a/tests/unit/config/test_env_var.py
+++ b/tests/unit/config/test_env_var.py
@@ -46,6 +46,20 @@ def test_python_multi_value_via_env_var(monkeypatch):
     assert options.python == ["python3", "python2"]
 
 
+def test_python_multi_value_newline_via_env_var(monkeypatch):
+    options = VirtualEnvOptions()
+    monkeypatch.setenv(str("VIRTUALENV_PYTHON"), str("python3\npython2"))
+    session_via_cli(["venv"], options=options)
+    assert options.python == ["python3", "python2"]
+
+
+def test_python_multi_value_prefer_newline_via_env_var(monkeypatch):
+    options = VirtualEnvOptions()
+    monkeypatch.setenv(str("VIRTUALENV_PYTHON"), str("python3\npython2,python27"))
+    session_via_cli(["venv"], options=options)
+    assert options.python == ["python3", "python2,python27"]
+
+
 def test_extra_search_dir_via_env_var(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     value = "a{}0{}b{}c".format(os.linesep, os.linesep, os.pathsep)

--- a/tests/unit/config/test_env_var.py
+++ b/tests/unit/config/test_env_var.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+from virtualenv.config.cli.parser import VirtualEnvOptions
 from virtualenv.config.ini import IniConfig
 from virtualenv.run import session_via_cli
 from virtualenv.util.path import Path
@@ -29,6 +30,13 @@ def test_value_bad(monkeypatch, caplog, empty_conf):
     assert len(caplog.messages) == 1
     assert "env var VIRTUALENV_VERBOSE failed to convert" in caplog.messages[0]
     assert "invalid literal" in caplog.messages[0]
+
+
+def test_python_via_env_var(monkeypatch):
+    options = VirtualEnvOptions()
+    monkeypatch.setenv(str("VIRTUALENV_PYTHON"), str("python3"))
+    session_via_cli(["venv"], options=options)
+    assert options.python == ["python3"]
 
 
 def test_extra_search_dir_via_env_var(tmp_path, monkeypatch):

--- a/tests/unit/config/test_env_var.py
+++ b/tests/unit/config/test_env_var.py
@@ -39,6 +39,13 @@ def test_python_via_env_var(monkeypatch):
     assert options.python == ["python3"]
 
 
+def test_python_multi_value_via_env_var(monkeypatch):
+    options = VirtualEnvOptions()
+    monkeypatch.setenv(str("VIRTUALENV_PYTHON"), str("python3,python2"))
+    session_via_cli(["venv"], options=options)
+    assert options.python == ["python3", "python2"]
+
+
 def test_extra_search_dir_via_env_var(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     value = "a{}0{}b{}c".format(os.linesep, os.linesep, os.pathsep)


### PR DESCRIPTION
The previous change which introduced the fallback discovery (#1995) broke this behaviour.

I originally thought to change the `ListType` class which uses `self.as_type` to cast the individual list values into the target value. At the moment the default for that type is a `list` which means the default behaviour for the class is to return a list of lists. But that became a bigger change than I'm comfortable doing on this code base, so I came up with this simpler change.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation
