### PR TITLE
Optionally skip creation of .gitignore in virtualenv directory

### DIFF
--- a/docs/changelog/2003.feature.rst
+++ b/docs/changelog/2003.feature.rst
@@ -1,0 +1,3 @@
+Optionally skip generation of ``.gitignore`` with * directive in virtualenv
+directory, using command line option :option:`no-gitignore`.
+Default behavior is to generate the file as before.

--- a/docs/changelog/2003.feature.rst
+++ b/docs/changelog/2003.feature.rst
@@ -1,3 +1,1 @@
-Optionally skip VCS ignore directive for entire virtualenv
-directory, using command line option :option:`no-vcsignore`.
-Default behavior is to generate the file as before.
+Optionally skip VCS ignore directive for entire virtualenv directory, using option :option:`no-vcs-ignore`, by default ``False``.

--- a/docs/changelog/2003.feature.rst
+++ b/docs/changelog/2003.feature.rst
@@ -1,3 +1,3 @@
-Optionally skip generation of ``.gitignore`` with * directive in virtualenv
-directory, using command line option :option:`no-gitignore`.
+Optionally skip VCS ignore directive for entire virtualenv
+directory, using command line option :option:`no-vcsignore`.
 Default behavior is to generate the file as before.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -28,7 +28,7 @@ The tool works in two phases:
     *activate* the virtual environment from various shells).
   - create files that mark the virtual environment as to be ignored by version control systems (currently we support
     Git only, as Mercurial, Bazaar or SVN do not support ignore files in subdirectories). This step can be skipped
-    with the :option:`no-gitignore` command line option.
+    with the :option:`no-vcsignore` command line option.
 
 
 The python in your new virtualenv is effectively isolated from the python that was used to create it.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -27,7 +27,9 @@ The tool works in two phases:
   - install activation scripts into the binary directory of the virtual environment (these will allow end user to
     *activate* the virtual environment from various shells).
   - create files that mark the virtual environment as to be ignored by version control systems (currently we support
-    Git only, as Mercurial, Bazaar or SVN does not support ignore files in subdirectories).
+    Git only, as Mercurial, Bazaar or SVN do not support ignore files in subdirectories). This step can be skipped
+    with the :option:`no-gitignore` command line option.
+
 
 The python in your new virtualenv is effectively isolated from the python that was used to create it.
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -28,7 +28,7 @@ The tool works in two phases:
     *activate* the virtual environment from various shells).
   - create files that mark the virtual environment as to be ignored by version control systems (currently we support
     Git only, as Mercurial, Bazaar or SVN do not support ignore files in subdirectories). This step can be skipped
-    with the :option:`no-vcsignore` command line option.
+    with the :option:`no-vcs-ignore` option.
 
 
 The python in your new virtualenv is effectively isolated from the python that was used to create it.

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -44,7 +44,7 @@ class Creator(object):
         self._debug = None
         self.dest = Path(options.dest)
         self.clear = options.clear
-        self.vcs_ignore = options.vcs_ignore
+        self.no_vcs_ignore = options.no_vcs_ignore
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
         self.app_data = options.app_data
 
@@ -58,7 +58,7 @@ class Creator(object):
         return [
             ("dest", ensure_text(str(self.dest))),
             ("clear", self.clear),
-            ("vcs_ignore", self.vcs_ignore),
+            ("no_vcs_ignore", self.no_vcs_ignore),
         ]
 
     @classmethod
@@ -94,10 +94,10 @@ class Creator(object):
         )
         parser.add_argument(
             "--no-vcs-ignore",
-            dest="vcs_ignore",
-            action="store_false",
+            dest="no_vcs_ignore",
+            action="store_true",
             help="don't create VCS ignore directive in the destination directory",
-            default=True,
+            default=False,
         )
 
     @abstractmethod
@@ -169,7 +169,7 @@ class Creator(object):
             safe_delete(self.dest)
         self.create()
         self.set_pyenv_cfg()
-        if self.vcs_ignore:
+        if not self.no_vcs_ignore:
             self.setup_ignore_vcs()
 
     def set_pyenv_cfg(self):

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -44,7 +44,7 @@ class Creator(object):
         self._debug = None
         self.dest = Path(options.dest)
         self.clear = options.clear
-        self.vcsignore = options.vcsignore
+        self.vcs_ignore = options.vcs_ignore
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
         self.app_data = options.app_data
 
@@ -58,7 +58,7 @@ class Creator(object):
         return [
             ("dest", ensure_text(str(self.dest))),
             ("clear", self.clear),
-            ("vcsignore", self.vcsignore),
+            ("vcs_ignore", self.vcs_ignore),
         ]
 
     @classmethod
@@ -93,10 +93,10 @@ class Creator(object):
             default=False,
         )
         parser.add_argument(
-            "--no-vcsignore",
-            dest="vcsignore",
+            "--no-vcs-ignore",
+            dest="vcs_ignore",
             action="store_false",
-            help="skip creation of coverall VCS ignore directive in destination directory",
+            help="don't create VCS ignore directive in the destination directory",
             default=True,
         )
 
@@ -169,7 +169,7 @@ class Creator(object):
             safe_delete(self.dest)
         self.create()
         self.set_pyenv_cfg()
-        if self.vcsignore:
+        if self.vcs_ignore:
             self.setup_ignore_vcs()
 
     def set_pyenv_cfg(self):

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -44,7 +44,7 @@ class Creator(object):
         self._debug = None
         self.dest = Path(options.dest)
         self.clear = options.clear
-        self.gitignore = options.gitignore
+        self.vcsignore = options.vcsignore
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
         self.app_data = options.app_data
 
@@ -58,7 +58,7 @@ class Creator(object):
         return [
             ("dest", ensure_text(str(self.dest))),
             ("clear", self.clear),
-            ("gitignore", self.gitignore),
+            ("vcsignore", self.vcsignore),
         ]
 
     @classmethod
@@ -93,10 +93,10 @@ class Creator(object):
             default=False,
         )
         parser.add_argument(
-            "--no-gitignore",
-            dest="gitignore",
+            "--no-vcsignore",
+            dest="vcsignore",
             action="store_false",
-            help="skip creation of coverall .gitignore in destination directory",
+            help="skip creation of coverall VCS ignore directive in destination directory",
             default=True,
         )
 
@@ -169,7 +169,7 @@ class Creator(object):
             safe_delete(self.dest)
         self.create()
         self.set_pyenv_cfg()
-        if self.gitignore:
+        if self.vcsignore:
             self.setup_ignore_vcs()
 
     def set_pyenv_cfg(self):

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -44,6 +44,7 @@ class Creator(object):
         self._debug = None
         self.dest = Path(options.dest)
         self.clear = options.clear
+        self.gitignore = options.gitignore
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
         self.app_data = options.app_data
 
@@ -57,6 +58,7 @@ class Creator(object):
         return [
             ("dest", ensure_text(str(self.dest))),
             ("clear", self.clear),
+            ("gitignore", self.gitignore),
         ]
 
     @classmethod
@@ -89,6 +91,13 @@ class Creator(object):
             action="store_true",
             help="remove the destination directory if exist before starting (will overwrite files otherwise)",
             default=False,
+        )
+        parser.add_argument(
+            "--no-gitignore",
+            dest="gitignore",
+            action="store_false",
+            help="skip creation of coverall .gitignore in destination directory",
+            default=True,
         )
 
     @abstractmethod
@@ -160,7 +169,8 @@ class Creator(object):
             safe_delete(self.dest)
         self.create()
         self.set_pyenv_cfg()
-        self.setup_ignore_vcs()
+        if self.gitignore:
+            self.setup_ignore_vcs()
 
     def set_pyenv_cfg(self):
         self.pyenv_cfg.content = OrderedDict()

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -242,23 +242,23 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
     assert git_ignore.splitlines() == ["# created by virtualenv automatically", "*"]
 
 
-def test_create_gitignore_exists(tmp_path):
+def test_create_vcsignore_exists(tmp_path):
     git_ignore = tmp_path / ".gitignore"
     git_ignore.write_text("magic")
     cli_run([str(tmp_path), "--without-pip", "--activators", ""])
     assert git_ignore.read_text() == "magic"
 
 
-def test_create_gitignore_override(tmp_path):
+def test_create_vcsignore_override(tmp_path):
     git_ignore = tmp_path / ".gitignore"
-    cli_run([str(tmp_path), "--without-pip", "--no-gitignore", "--activators", ""])
+    cli_run([str(tmp_path), "--without-pip", "--no-vcsignore", "--activators", ""])
     assert not git_ignore.exists()
 
 
-def test_create_gitignore_exists_override(tmp_path):
+def test_create_vcsignore_exists_override(tmp_path):
     git_ignore = tmp_path / ".gitignore"
     git_ignore.write_text("magic")
-    cli_run([str(tmp_path), "--without-pip", "--no-gitignore", "--activators", ""])
+    cli_run([str(tmp_path), "--without-pip", "--no-vcsignore", "--activators", ""])
     assert git_ignore.read_text() == "magic"
 
 

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -249,6 +249,19 @@ def test_create_gitignore_exists(tmp_path):
     assert git_ignore.read_text() == "magic"
 
 
+def test_create_gitignore_override(tmp_path):
+    git_ignore = tmp_path / ".gitignore"
+    cli_run([str(tmp_path), "--without-pip", "--no-gitignore", "--activators", ""])
+    assert not git_ignore.exists()
+
+
+def test_create_gitignore_exists_override(tmp_path):
+    git_ignore = tmp_path / ".gitignore"
+    git_ignore.write_text("magic")
+    cli_run([str(tmp_path), "--without-pip", "--no-gitignore", "--activators", ""])
+    assert git_ignore.read_text() == "magic"
+
+
 @pytest.mark.skipif(not CURRENT.has_venv, reason="requires interpreter with venv")
 def test_venv_fails_not_inline(tmp_path, capsys, mocker):
     if hasattr(os, "geteuid"):

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -242,23 +242,23 @@ def test_create_no_seed(python, creator, isolated, system, coverage_env, special
     assert git_ignore.splitlines() == ["# created by virtualenv automatically", "*"]
 
 
-def test_create_vcsignore_exists(tmp_path):
+def test_create_vcs_ignore_exists(tmp_path):
     git_ignore = tmp_path / ".gitignore"
     git_ignore.write_text("magic")
     cli_run([str(tmp_path), "--without-pip", "--activators", ""])
     assert git_ignore.read_text() == "magic"
 
 
-def test_create_vcsignore_override(tmp_path):
+def test_create_vcs_ignore_override(tmp_path):
     git_ignore = tmp_path / ".gitignore"
-    cli_run([str(tmp_path), "--without-pip", "--no-vcsignore", "--activators", ""])
+    cli_run([str(tmp_path), "--without-pip", "--no-vcs-ignore", "--activators", ""])
     assert not git_ignore.exists()
 
 
-def test_create_vcsignore_exists_override(tmp_path):
+def test_create_vcs_ignore_exists_override(tmp_path):
     git_ignore = tmp_path / ".gitignore"
     git_ignore.write_text("magic")
-    cli_run([str(tmp_path), "--without-pip", "--no-vcsignore", "--activators", ""])
+    cli_run([str(tmp_path), "--without-pip", "--no-vcs-ignore", "--activators", ""])
     assert git_ignore.read_text() == "magic"
 
 


### PR DESCRIPTION
Addresses #2003.  Creation of `.gitignore` with non-overridable * directive in the environment directory interferes with possibly more specific ignore directives in higher directories.  When the environment directory is a subdirectory of a repo and we need tracking of a subset of its files, allow to skip creation of this `.gitignore` with a command line option to `virtualenv`.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation