### PR TITLE
Add --seed-packages.

### DIFF
--- a/src/virtualenv/seed/wheels/embed/__init__.py
+++ b/src/virtualenv/seed/wheels/embed/__init__.py
@@ -50,8 +50,10 @@ MAX = "3.10"
 
 
 def get_embed_wheel(distribution, for_py_version):
-    path = BUNDLE_FOLDER / (BUNDLE_SUPPORT.get(for_py_version, {}) or BUNDLE_SUPPORT[MAX]).get(distribution)
-    return Wheel.from_path(path)
+    wheel_name = (BUNDLE_SUPPORT.get(for_py_version, {}) or BUNDLE_SUPPORT[MAX]).get(distribution)
+    if wheel_name is None:
+        return None
+    return Wheel.from_path(BUNDLE_FOLDER / wheel_name)
 
 
 __all__ = (


### PR DESCRIPTION
Hello,

I added a `--seed-packages` option to the builtin seeders. This tells them to seed additional packages, with the intent being to provide a way to bootstrap any packages required to make `pip` work.

My use case is that my machine can only access the internet through a socks proxy (in fact I use [tails](https://tails.boum.org), which routes all internet traffic through tor). This causes problems for most virtualenvs, because `pip` requires [PySocks](https://pypi.org/project/PySocks) to download anything, so I have to bootstrap every virtualenv with a `.whl` file downloaded from a web browser.

This is fine for my own virtualenvs, but tools like `tox` and `pre-commit` create virtualenvs with little opportunity to customize bootstrapping. See pre-commit/pre-commit#1697 for some discussion.

I considered writing a custom seeder plugin, but I expect that virtualenv-creating tools would override my plugin with `--seeder`, based on considerations of *how* to seed, rather than *what* to seed. So I thought it was better to modify the builtin seeders.

For my case, I can do
```sh
export VIRTUALENV_SEED_PACKAGE=PySocks
export VIRTUALENV_EXTRA_SEARCH_DIR=/path/to/wheel
```
then, `pre-commit` and `tox` work normally everywhere.

I'm not sure if this is immediately useful for other cases, but I see a lot of try-import blocks in `pip`'s source code, so I expect it's useful to someone somewhere.

This PR is still WIP while I add tests, but I thought I should open it now for discussion purposes.