### PR TITLE
Add 3.9 to doc list of cpython versions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -85,7 +85,7 @@ Python and OS Compatibility
 
 virtualenv works with the following Python interpreter implementations:
 
-- `CPython <https://www.python.org/>`_ versions 2.7, 3.4, 3.5, 3.6, 3.7, 3.8
+- `CPython <https://www.python.org/>`_ versions 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9
 - `PyPy <https://pypy.org/>`_ 2.7 and 3.4+.
 
 This means virtualenv works on the latest patch version of each of these minor versions. Previous patch versions are


### PR DESCRIPTION
virtualenv has the 3.9 classifier and therefore advertises itself as compatible with cpython 3.9. Add it to the list of supported cpython versions in the install doc.