### PR TITLE
Bugfix: PR #2034 - Fix Segfault 11 on OS X:ksh93

### DIFF
--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -7,7 +7,7 @@ if [ "${BASH_SOURCE-}" = "$0" ]; then
     exit 33
 fi
 
-deactivate () {
+_deactivate () {
     unset -f pydoc >/dev/null 2>&1
 
     # reset old environment variables
@@ -37,14 +37,11 @@ deactivate () {
     fi
 
     unset VIRTUAL_ENV
-    if [ ! "${1-}" = "nondestructive" ] ; then
-    # Self destruct!
-        unset -f deactivate
-    fi
 }
+alias deactivate="\_deactivate; unset -f _deactivate; unalias deactivate"
 
 # unset irrelevant variables
-deactivate nondestructive
+_deactivate
 
 VIRTUAL_ENV='__VIRTUAL_ENV__'
 if ([ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]) && $(command -v cygpath &> /dev/null) ; then


### PR DESCRIPTION
With the embedded `unset -f deactivate` call, the deactivate function
segfaulted on Mac OS X ksh93. This patch removes the `unset -f` call
from the function which fixes the segfault. It restores the
functionality by hiding the function behind an underscore, `deactivate`
-> `_deactivate` and then uses an alias to get rid of both the function
and the alias.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
