### PR TITLE
Remove xdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,6 @@ testing =
     pytest-mock>=2
     pytest-randomly>=1
     pytest-timeout>=1
-    pytest-xdist>=1.31.0
     packaging>=20.0;python_version>"3.4"
     xonsh>=0.9.16;python_version > '3.4' and python_version != '3.9'
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,14 +31,13 @@ setenv =
     PYTHONIOENCODING = utf-8
     _COVERAGE_SRC = {envsitepackagesdir}/virtualenv
     {py34,py27,pypy2, upgrade}: PYTHONWARNINGS = ignore:DEPRECATION::pip._internal.cli.base_command
-    {py34,pypy2,py27}: PYTEST_XDIST = 0
 extras =
     testing
 commands =
     python -m coverage erase
     python -m coverage run -m pytest \
       --junitxml {toxworkdir}/junit.{envname}.xml \
-      {posargs:tests --int --timeout 600 -n {env:PYTEST_XDIST:auto}}
+      {posargs:tests --int --timeout 600}
     python -m coverage combine
     python -m coverage report --skip-covered --show-missing
     python -m coverage xml -o {toxworkdir}/coverage.{envname}.xml


### PR DESCRIPTION
Because the workers keep crashing.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
