### PR TITLE
Allow unfunctioing pydoc to fail

### DIFF
--- a/docs/changelog/2049.bugfix.rst
+++ b/docs/changelog/2049.bugfix.rst
@@ -1,0 +1,4 @@
+Allow unfunctioning of pydoc to fail freely so that virtualenvs can be
+activated under Zsh with set -e (since otherwise ``unset -f`` and
+``unfunction`` exit with 1 if the function does not exist in Zsh) - by
+:user:`d125q`.

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -8,7 +8,7 @@ if [ "${BASH_SOURCE-}" = "$0" ]; then
 fi
 
 deactivate () {
-    unset -f pydoc >/dev/null 2>&1
+    unset -f pydoc >/dev/null 2>&1 || true
 
     # reset old environment variables
     # ! [ -z ${VAR+_} ] returns true if VAR is declared at all


### PR DESCRIPTION
Otherwise, one cannot activate a virtualenv under Zsh with set -e.

As an example,
```shell-session
$ zsh -c 'set -ex; source /path/to/virtualenv/bin/activate; echo activated'
+zsh:1> source /path/to/virtualenvbin/activate
+/path/to/virtualenvbin/activate:5> [ '' '=' /path/to/virtualenvbin/activate ']'
+/path/to/virtualenvbin/activate:47> deactivate nondestructive
+deactivate:1> unset -f pydoc
```
fails with exit code 1 because there is nothing to unset.  (The relevant version are: zsh 5.8.0.2-dev (x86_64-pc-linux-gnu), Python 3.9.1, and virtualenv 20.3.0.)
