### PR TITLE
Fix pip_cert pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,14 +153,15 @@ def pip_cert(tmp_path_factory):
     # workaround for https://github.com/pypa/pip/issues/8984 - if the certificate is explicitly set no error can happen
     key = ensure_str("PIP_CERT")
     if key in os.environ:
-        return
-    cert = tmp_path_factory.mktemp("folder") / "cert"
-    import pkgutil
-
-    cert_data = pkgutil.get_data("pip._vendor.certifi", "cacert.pem")
-    cert.write_bytes(cert_data)
-    with change_os_environ(key, str(cert)):
         yield
+    else:
+        cert = tmp_path_factory.mktemp("folder") / "cert"
+        import pkgutil
+
+        cert_data = pkgutil.get_data("pip._vendor.certifi", "cacert.pem")
+        cert.write_bytes(cert_data)
+        with change_os_environ(key, str(cert)):
+            yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
pip_cert is recognized as a generator so it should not use
return if PIP_CERT is in os.environ.

Fixes: https://github.com/pypa/virtualenv/issues/2048

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

I'm not sure this is testable easily given the fact that a CA cert bundle might be in various locations. Is a change in tests worth mentioning in the changelog?

Before this change:
```
$ PIP_CERT=/etc/ssl/certs/ca-bundle.crt tox -e py39 -- -x
…
ValueError: pip_cert did not yield a value
```

after this change:
```
$ PIP_CERT=/etc/ssl/certs/ca-bundle.crt tox -e py39 -- -x
…
  py39: commands succeeded
  congratulations :)
```