### PR TITLE
Remove unnecessary special cases for bash/zsh

### DIFF
--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -23,12 +23,10 @@ deactivate () {
         unset _OLD_VIRTUAL_PYTHONHOME
     fi
 
-    # This should detect bash and zsh, which have a hash command that must
-    # be called to get it to forget past commands.  Without forgetting
-    # past commands the $PATH changes we made may not be respected
-    if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
-        hash -r 2>/dev/null
-    fi
+    # The hash command must be called to get it to forget past
+    # commands. Without forgetting past commands the $PATH changes 
+    # we made may not be respected
+    hash -r 2>/dev/null
 
     if ! [ -z "${_OLD_VIRTUAL_PS1+_}" ] ; then
         PS1="$_OLD_VIRTUAL_PS1"
@@ -79,9 +77,7 @@ pydoc () {
     python -m pydoc "$@"
 }
 
-# This should detect bash and zsh, which have a hash command that must
-# be called to get it to forget past commands.  Without forgetting
-# past commands the $PATH changes we made may not be respected
-if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
-    hash -r 2>/dev/null
-fi
+# The hash command must be called to get it to forget past
+# commands. Without forgetting past commands the $PATH changes 
+# we made may not be respected
+hash -r 2>/dev/null

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -24,7 +24,7 @@ deactivate () {
     fi
 
     # The hash command must be called to get it to forget past
-    # commands. Without forgetting past commands the $PATH changes 
+    # commands. Without forgetting past commands the $PATH changes
     # we made may not be respected
     hash -r 2>/dev/null
 
@@ -78,6 +78,6 @@ pydoc () {
 }
 
 # The hash command must be called to get it to forget past
-# commands. Without forgetting past commands the $PATH changes 
+# commands. Without forgetting past commands the $PATH changes
 # we made may not be respected
 hash -r 2>/dev/null


### PR DESCRIPTION
The internal shell utility hash is standard posix. There is no need to special-case it only for bash and zsh.
In fact, this check can break the script on shells such as the built-in sh on BSD systems, ksh, ash or 
busybox sh which are otherwise perfectly capable of running it. The script is a valid posix shell script, as
verified by shellcheck. The one feature that depends on bash (checking that the script is sourced rather 
than executed) will work only on bash, but it is only a safety check.

 https://pubs.opengroup.org/onlinepubs/9699919799/utilities/hash.html

