### PR TITLE
Built in discovery class is always preferred over plugin supplied classes

### DIFF
--- a/docs/changelog/2087.bugfix.rst
+++ b/docs/changelog/2087.bugfix.rst
@@ -1,0 +1,1 @@
+Built in discovery class is always preferred over plugin supplied classes.

--- a/src/virtualenv/run/plugin/discovery.py
+++ b/src/virtualenv/run/plugin/discovery.py
@@ -13,10 +13,13 @@ def get_discover(parser, args):
         title="discovery",
         description="discover and provide a target interpreter",
     )
+    choices = _get_default_discovery(discover_types)
+    # prefer the builtin if present, otherwise fallback to first defined type
+    choices = sorted(choices, key=lambda a: 0 if a == "builtin" else 1)
     discovery_parser.add_argument(
         "--discovery",
-        choices=_get_default_discovery(discover_types),
-        default=next(i for i in discover_types.keys()),
+        choices=choices,
+        default=next(iter(choices)),
         required=False,
         help="interpreter discovery method",
     )

--- a/tests/unit/config/cli/test_parser.py
+++ b/tests/unit/config/cli/test_parser.py
@@ -44,3 +44,14 @@ def test_reset_app_data_does_not_conflict_clear():
     session_via_cli(["--clear", "venv"], options=options)
     assert options.clear is True
     assert options.reset_app_data is False
+
+
+def test_builtin_discovery_class_preferred(mocker):
+    mocker.patch(
+        "virtualenv.run.plugin.discovery._get_default_discovery",
+        return_value=["pluginA", "pluginX", "builtin", "Aplugin", "Xplugin"],
+    )
+
+    options = VirtualEnvOptions()
+    session_via_cli(["venv"], options=options)
+    assert options.discovery == "builtin"


### PR DESCRIPTION
- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

This ensures that the builtin Discovery class is always chosen over any discovery class provided by plugins, as discussed in #2087

Closes #2087 