### PR TITLE
Redirected gitter link to new location on Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@
 blank_issues_enabled: true  # default
 contact_links:
 - name: '💬 pypa/virtualenv @ Discord'
-  url: https://discord.gg/uufxTxAMCX
+  url: https://discord.gg/tox
   about: Chat with the devs
 - name: 🤷💻🤦 Discourse
   url: https://discuss.python.org/c/packaging

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,9 @@
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: true  # default
 contact_links:
-- name: '💬 pypa/virtualenv @ Gitter'
-  url: https://gitter.im/pypa/virtualenv
-  about: Chat with devs
+- name: '💬 pypa/virtualenv @ Discord'
+  url: https://discord.gg/uufxTxAMCX
+  about: Chat with the devs
 - name: 🤷💻🤦 Discourse
   url: https://discuss.python.org/c/packaging
   about: |

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@
 blank_issues_enabled: true  # default
 contact_links:
 - name: '💬 pypa/virtualenv @ Discord'
-  url: https://discord.gg/tox
+  url: https://discord.gg/pypa
   about: Chat with the devs
 - name: 🤷💻🤦 Discourse
   url: https://discuss.python.org/c/packaging


### PR DESCRIPTION
- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

The conversations on gitter are being redirected to the new location on Discord. Therefore this change makes the issue page point directly to the Discord link instead of users needing to go through gitter first.