### PR TITLE
Fix site.getsitepackages() ignoring --system-site-packages on python2

### DIFF
--- a/docs/changelog/2106.bugfix.rst
+++ b/docs/changelog/2106.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``site.getsitepackages()`` ignoring ``--system-site-packages`` on python2 - by :user:`freundTech`.

--- a/src/virtualenv/create/via_global_ref/builtin/python2/site.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/site.py
@@ -158,7 +158,7 @@ def add_global_site_package():
         site.PREFIXES = [sys.base_prefix, sys.base_exec_prefix]
         site.main()
     finally:
-        site.PREFIXES = orig_prefixes
+        site.PREFIXES = orig_prefixes + site.PREFIXES
 
 
 main()

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import ast
 import difflib
 import gc
 import json
@@ -621,3 +622,33 @@ def test_pth_in_site_vs_PYTHONPATH(tmp_path):
         env=env,
     )
     assert out == "ok\n"
+
+
+def test_getsitepackages_system_site(tmp_path):
+    import site
+    old_prefixes = site.PREFIXES
+    site.PREFIXES = [sys.base_prefix, sys.base_exec_prefix]
+    system_site_packages = site.getsitepackages()
+    site.PREFIXES = old_prefixes
+
+    # Test without --system-site-packages
+    session = cli_run([ensure_text(str(tmp_path))])
+    out = subprocess.check_output(
+        [str(session.creator.exe), "-c", r"import site; print(site.getsitepackages())"],
+        universal_newlines=True,
+    )
+    site_packages = ast.literal_eval(out)
+
+    for system_site_package in system_site_packages:
+        assert system_site_package not in site_packages
+
+    # Test with --system-site-packages
+    session = cli_run([ensure_text(str(tmp_path)), "--system-site-packages"])
+    out = subprocess.check_output(
+        [str(session.creator.exe), "-c", r"import site; print(site.getsitepackages())"],
+        universal_newlines=True,
+    )
+    site_packages = ast.literal_eval(out)
+
+    for system_site_package in system_site_packages:
+        assert system_site_package in site_packages

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -626,6 +626,7 @@ def test_pth_in_site_vs_PYTHONPATH(tmp_path):
 
 def test_getsitepackages_system_site(tmp_path):
     import site
+
     old_prefixes = site.PREFIXES
     site.PREFIXES = [sys.base_prefix, sys.base_exec_prefix]
     system_site_packages = site.getsitepackages()


### PR DESCRIPTION
Fixes #2106.
This PR also adds a regression test.
There might be a merge conflict between this PR and #2108, because they both add a test to the end of tests/unit/create/test_creator.py