### PR TITLE
Fix site.getsitepackages() broken on python2 on debian

### DIFF
--- a/docs/changelog/2105.bugfix.rst
+++ b/docs/changelog/2105.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``site.getsitepackages()`` broken on python2 on debian - by :user:`freundTech`.

--- a/src/virtualenv/create/via_global_ref/builtin/python2/site.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/site.py
@@ -171,7 +171,8 @@ def rewrite_getsitepackages():
     def getsitepackages():
         sitepackages = orig_getsitepackages()
         for prefix in (sys.prefix, sys.exec_prefix):
-            path = os.path.join(prefix, "lib", "python" + sys.version[:3], "site-packages")
+            # os is not defined here, but will be in site.py, where we monkey-patch this function.
+            path = os.path.join(prefix, "lib", "python" + sys.version[:3], "site-packages")  # noqa: F821
             if path not in sitepackages:
                 sitepackages.insert(0, path)
 

--- a/src/virtualenv/create/via_global_ref/builtin/python2/site.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/site.py
@@ -9,6 +9,7 @@ import sys
 
 def main():
     """Patch what needed, and invoke the original site.py"""
+    here = __file__  # the distutils.install patterns will be injected relative to this site.py, save it here
     config = read_pyvenv()
     sys.real_prefix = sys.base_prefix = config["base-prefix"]
     sys.base_exec_prefix = config["base-exec-prefix"]
@@ -16,13 +17,13 @@ def main():
     global_site_package_enabled = config.get("include-system-site-packages", False) == "true"
     rewrite_standard_library_sys_path()
     disable_user_site_package()
-    load_host_site()
+    load_host_site(here)
     if global_site_package_enabled:
         add_global_site_package()
-    rewrite_getsitepackages()
+    rewrite_getsitepackages(here)
 
 
-def load_host_site():
+def load_host_site(here):
     """trigger reload of site.py - now it will use the standard library instance that will take care of init"""
     # we have a duality here, we generate the platform and pure library path based on what distutils.install specifies
     # because this is what pip will be using; the host site.py though may contain it's own pattern for where the
@@ -37,23 +38,26 @@ def load_host_site():
     # to facilitate when the two match, or not we first reload the site.py, now triggering the import of host site.py,
     # as this will ensure that initialization code within host site.py runs
 
-    here = __file__  # the distutils.install patterns will be injected relative to this site.py, save it here
-
     # ___RELOAD_CODE___
 
     # and then if the distutils site packages are not on the sys.path we add them via add_site_dir; note we must add
     # them by invoking add_site_dir to trigger the processing of pth files
+
+    add_site_dir = sys.modules["site"].addsitedir
+    for path in get_site_packages_dirs(here):
+        add_site_dir(path)
+
+
+def get_site_packages_dirs(here):
+    import json
     import os
 
     site_packages = r"""
     ___EXPECTED_SITE_PACKAGES___
     """
-    import json
 
-    add_site_dir = sys.modules["site"].addsitedir
     for path in json.loads(site_packages):
-        full_path = os.path.abspath(os.path.join(here, path.encode("utf-8")))
-        add_site_dir(full_path)
+        yield os.path.abspath(os.path.join(here, path.encode("utf-8")))
 
 
 sep = "\\" if sys.platform == "win32" else "/"  # no os module here yet - poor mans version
@@ -163,20 +167,15 @@ def add_global_site_package():
 
 
 # Debian and it's derivatives patch this function. We undo the damage
-def rewrite_getsitepackages():
-    # This mirrors the check in python's site.py
-    if sys.platform in ("os2emx", "riscos") or sep != "/":
-        return
-
+def rewrite_getsitepackages(here):
     site = sys.modules["site"]
 
+    site_package_dirs = get_site_packages_dirs(here)
     orig_getsitepackages = site.getsitepackages
 
     def getsitepackages():
         sitepackages = orig_getsitepackages()
-        for prefix in (sys.prefix, sys.exec_prefix):
-            # os is not defined here, but will be in site.py, where we monkey-patch this function.
-            path = os.path.join(prefix, "lib", "python" + sys.version[:3], "site-packages")  # noqa: F821
+        for path in site_package_dirs:
             if path not in sitepackages:
                 sitepackages.insert(0, path)
 

--- a/src/virtualenv/create/via_global_ref/builtin/python2/site.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/site.py
@@ -164,6 +164,10 @@ def add_global_site_package():
 
 # Debian and it's derivatives patch this function. We undo the damage
 def rewrite_getsitepackages():
+    # This mirrors the check in python's site.py
+    if sys.platform in ("os2emx", "riscos") or sep != "/":
+        return
+
     site = sys.modules["site"]
 
     orig_getsitepackages = site.getsitepackages

--- a/src/virtualenv/create/via_global_ref/builtin/python2/site.py
+++ b/src/virtualenv/create/via_global_ref/builtin/python2/site.py
@@ -175,6 +175,9 @@ def rewrite_getsitepackages(here):
 
     def getsitepackages():
         sitepackages = orig_getsitepackages()
+        if sys.prefix not in site.PREFIXES or sys.exec_prefix not in site.PREFIXES:
+            # Someone messed with the prefixes, so we stop patching
+            return sitepackages
         for path in site_package_dirs:
             if path not in sitepackages:
                 sitepackages.insert(0, path)

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -653,3 +653,16 @@ def test_getsitepackages_system_site(tmp_path):
 
     for system_site_package in system_site_packages:
         assert system_site_package in site_packages
+
+
+def test_getsitepackages(tmp_path):
+    session = cli_run([ensure_text(str(tmp_path))])
+    env_site_packages = [str(session.creator.purelib), str(session.creator.platlib)]
+    out = subprocess.check_output(
+        [str(session.creator.exe), "-c", r"import site; print(site.getsitepackages())"],
+        universal_newlines=True,
+    )
+    site_packages = ast.literal_eval(out)
+
+    for env_site_package in env_site_packages:
+        assert env_site_package in site_packages

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -655,7 +655,7 @@ def test_getsitepackages_system_site(tmp_path):
         assert system_site_package in site_packages
 
 
-def test_getsitepackages(tmp_path):
+def test_get_site_packages(tmp_path):
     session = cli_run([ensure_text(str(tmp_path))])
     env_site_packages = [str(session.creator.purelib), str(session.creator.platlib)]
     out = subprocess.check_output(

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -656,6 +656,7 @@ def test_getsitepackages_system_site(tmp_path):
 
 
 def test_get_site_packages(tmp_path):
+    case_sensitive = fs_is_case_sensitive()
     session = cli_run([ensure_text(str(tmp_path))])
     env_site_packages = [str(session.creator.purelib), str(session.creator.platlib)]
     out = subprocess.check_output(
@@ -663,6 +664,10 @@ def test_get_site_packages(tmp_path):
         universal_newlines=True,
     )
     site_packages = ast.literal_eval(out)
+
+    if not case_sensitive:
+        env_site_packages = [x.lower() for x in env_site_packages]
+        site_packages = [x.lower() for x in site_packages]
 
     for env_site_package in env_site_packages:
         assert env_site_package in site_packages


### PR DESCRIPTION
Fixes #2105.
This PR also adds a regression test. 
There might be a merge conflict between this PR and #2107, because they both add a test to the end of tests/unit/create/test_creator.py