### PR TITLE
replace remaining gitter links with discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI - Implementation](https://img.shields.io/pypi/implementation/virtualenv?style=flat-square)](https://pypi.org/project/virtualenv)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/virtualenv?style=flat-square)](https://pypi.org/project/virtualenv)
 [![Documentation](https://readthedocs.org/projects/virtualenv/badge/?version=latest&style=flat-square)](http://virtualenv.pypa.io)
-[![Gitter Chat](https://img.shields.io/gitter/room/pypa/virtualenv?color=FF004F&style=flat-square)](https://gitter.im/pypa/virtualenv)
+[![Discord](https://img.shields.io/discord/803025117553754132)](https://discord.gg/pypa)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/virtualenv?style=flat-square)](https://pypistats.org/packages/virtualenv)
 [![PyPI - License](https://img.shields.io/pypi/l/virtualenv?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Build Status](https://github.com/pypa/virtualenv/workflows/check/badge.svg?branch=main&event=push)](https://github.com/pypa/virtualenv/actions?query=workflow%3Acheck)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,9 +11,9 @@ Virtualenv
 .. image:: https://readthedocs.org/projects/virtualenv/badge/?version=latest&style=flat-square
   :target: https://virtualenv.pypa.io
   :alt: Documentation status
-.. image:: https://img.shields.io/gitter/room/pypa/virtualenv?color=FF004F&style=flat-square
-  :target: https://gitter.im/pypa/virtualenv
-  :alt: Gitter
+.. image:: https://img.shields.io/discord/803025117553754132
+  :target: https://discord.gg/pypa
+  :alt: Discord
 .. image:: https://img.shields.io/pypi/dm/virtualenv?style=flat-square
   :target: https://pypistats.org/packages/virtualenv
   :alt: PyPI - Downloads


### PR DESCRIPTION
resolves #2134 

I replaced the remaining gitter entries/badges with discord, using the shields.io badges for discord with the `server_id` included (shows how many people are online right now). It looks like the widget setting is already enabled on the discord server, so nothing to be done on this end.

- [X] ran the linter to address style issues (``tox -e fix_lint``)
- [X] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
