### PR TITLE
During seeding properly uninstall present versions of the wheels

### DIFF
--- a/docs/changelog/2185.bugfix.rst
+++ b/docs/changelog/2185.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug where while creating a venv on top of an existing one, without cleaning, when seeded
+wheel version mismatch occurred, multiple ``.dist-info`` directories may be present, confounding entrypoint
+discovery - by :user:`arcivanov`

--- a/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
@@ -189,7 +189,7 @@ class PipInstall(object):
                                 break
                         if not pkg_found:
                             file_to_remove = self._creator.purelib / r[: r.index(",")]
-                            files_to_remove.append(file_to_remove.resolve())
+                            files_to_remove.append(file_to_remove)
 
             # Remove dist-info itself
             files_to_remove.append(existing_dist)

--- a/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
@@ -31,6 +31,16 @@ class PipInstall(object):
 
     def install(self, version_info):
         self._extracted = True
+        # cleanup existing version's .dist-info if exists
+        # TODO: This still could leave extra packages hanging around but those should be inert
+        dist_name = self._dist_info.stem[: self._dist_info.stem.index("-")]
+        for filename in self._creator.purelib.iterdir():
+            if filename.name.startswith(dist_name) and filename.suffix == ".dist-info" and filename.is_dir():
+                logging.debug(
+                    "removing %s of the present version of %s from %s", filename.name, dist_name, self._creator.purelib
+                )
+                safe_delete(filename)
+                break
         # sync image
         for filename in self._image_dir.iterdir():
             into = self._creator.purelib / filename.name

--- a/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
+++ b/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
@@ -52,7 +52,7 @@ def test_seed_link_via_app_data(tmp_path, coverage_env, current_fastest, copies)
     pip = site_package / "pip"
     setuptools = site_package / "setuptools"
 
-    files_post_first_create = list(site_package.iterdir())
+    files_post_first_create = set(site_package.iterdir())
     assert pip in files_post_first_create
     assert setuptools in files_post_first_create
     for pip_exe in [
@@ -82,15 +82,29 @@ def test_seed_link_via_app_data(tmp_path, coverage_env, current_fastest, copies)
     assert not process.returncode
     assert site_package.exists()
 
-    files_post_first_uninstall = list(site_package.iterdir())
+    files_post_first_uninstall = set(site_package.iterdir())
     assert pip in files_post_first_uninstall
     assert setuptools not in files_post_first_uninstall
+
+    install_cmd = [
+        str(result.creator.script("pip")),
+        "--verbose",
+        "--disable-pip-version-check",
+        "install",
+        "setuptools<" + bundle_ver["setuptools"].split("-")[1],
+    ]
+    process = Popen(install_cmd)
+    _, __ = process.communicate()
+    assert not process.returncode
+    assert site_package.exists()
+    files_post_downgrade = set(site_package.iterdir())
+    assert setuptools in files_post_downgrade
 
     # check we can run it again and will work - checks both overwrite and reuse cache
     result = cli_run(create_cmd)
     coverage_env()
     assert result
-    files_post_second_create = list(site_package.iterdir())
+    files_post_second_create = set(site_package.iterdir())
     assert files_post_first_create == files_post_second_create
 
     # Windows does not allow removing a executable while running it, so when uninstalling pip we need to do it via

--- a/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
+++ b/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
@@ -86,15 +86,11 @@ def test_seed_link_via_app_data(tmp_path, coverage_env, current_fastest, copies)
     assert pip in files_post_first_uninstall
     assert setuptools not in files_post_first_uninstall
 
-    install_cmd = [
-        str(result.creator.script("pip")),
-        "--verbose",
-        "--disable-pip-version-check",
-        "install",
-        "setuptools<" + bundle_ver["setuptools"].split("-")[1],
-    ]
+    # install a different setuptools to test that virtualenv removes this before installing new
+    version = "setuptools<{}".format(bundle_ver["setuptools"].split("-")[1])
+    install_cmd = [str(result.creator.script("pip")), "--verbose", "--disable-pip-version-check", "install", version]
     process = Popen(install_cmd)
-    _, __ = process.communicate()
+    process.communicate()
     assert not process.returncode
     assert site_package.exists()
     files_post_downgrade = set(site_package.iterdir())


### PR DESCRIPTION
An existing dist-info may contain entrypoints that may interfere with
normal functioning of the redeployed seeded wheel if there is a version
mismatch

fixes #2185

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [X] ran the linter to address style issues (``tox -e fix_lint``)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
