### PR TITLE
Fail early instead of creating non-working env

### DIFF
--- a/docs/changelog/2189.misc.rst
+++ b/docs/changelog/2189.misc.rst
@@ -1,0 +1,1 @@
+Fail early instead of creating a non-working env for Python 2 on Apple Silicon (M1) Macs.

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 from six import add_metaclass
 
 from virtualenv.create.via_global_ref.builtin.ref import ExePathRefToDest, PathRefToDest, RefMust
+from virtualenv.info import IS_MAC_ARM64
 from virtualenv.util.path import Path
 from virtualenv.util.six import ensure_text
 
@@ -101,6 +102,13 @@ class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
             ),
         )
         return result
+
+    @classmethod
+    def can_create(cls, interpreter):
+        if IS_MAC_ARM64:
+            return False
+        else:
+            return super(CPythonmacOsFramework, cls).can_create(interpreter)
 
 
 class CPython3macOsFramework(CPythonmacOsFramework, CPython3, CPythonPosix):

--- a/src/virtualenv/info.py
+++ b/src/virtualenv/info.py
@@ -12,6 +12,7 @@ IS_CPYTHON = IMPLEMENTATION == "CPython"
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
 IS_WIN = sys.platform == "win32"
+IS_MAC_ARM64 = sys.platform == "darwin" and platform.machine() == "arm64"
 ROOT = os.path.realpath(os.path.join(os.path.abspath(__file__), os.path.pardir, os.path.pardir))
 IS_ZIPAPP = os.path.isfile(ROOT)
 WIN_CPYTHON_2 = IS_CPYTHON and IS_WIN and PY2


### PR DESCRIPTION
for Python 2 on Apple Silicon (M1) Macs.

Related to pypa#2024.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
