### PR TITLE
Improve prompt nushell

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          #- ubuntu-latest
           - windows-latest
-          - macos-latest
+          #- macos-latest
         py:
           - 3.10.0-rc.1
           - 3.9

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          #- ubuntu-latest
+          - ubuntu-latest
           - windows-latest
-          #- macos-latest
+          - macos-latest
         py:
           - 3.10.0-rc.1
           - 3.9

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -1,4 +1,5 @@
 # Setting all environment variables for the venv
+let path-name = (if ((sys).host.name == "Windows") { "Path" } { "PATH" })
 let virtual-env = "__VIRTUAL_ENV__"
 let bin = "__BIN_NAME__"
 let path-sep = "__PATH_SEP__"
@@ -11,7 +12,7 @@ let new-path = ($nu.path | prepend $venv-path | str collect ($path-sep))
 # environment variables that will be batched loaded to the virtual env
 let new-env = ([
     [name, value];
-    [PATH $new-path]
+    [$path-name $new-path]
     [_OLD_VIRTUAL_PATH $old-path]
     [VIRTUAL_ENV $virtual-env]
 ])
@@ -22,15 +23,15 @@ load-env $new-env
 let virtual_prompt = (if ("__VIRTUAL_PROMPT__" != "") {
     "__VIRTUAL_PROMPT__"
 } {
-    $virtual-env | path basename
+    (build-string '(' ($virtual-env | path basename) ') ')
 }
 )
 
 # If there is no default prompt, then only the env is printed in the prompt
 let new_prompt = (if ( config | select prompt | empty? ) {
-    ($"build-string '(char lparen)' '($virtual_prompt)' '(char rparen) ' ")
+    ($"build-string '($virtual_prompt)'")
 } {
-    ($"build-string '(char lparen)' '($virtual_prompt)' '(char rparen) ' (config get prompt | str find-replace "build-string" "")")
+    ($"build-string '($virtual_prompt)' (config get prompt | str find-replace "build-string" "")")
 })
 let-env PROMPT_COMMAND = $new_prompt
 

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -21,17 +21,17 @@ load-env $new-env
 
 # Creating the new prompt for the session
 let virtual_prompt = (if ("__VIRTUAL_PROMPT__" != "") {
-    "__VIRTUAL_PROMPT__" | str find-replace -a "[\(\)]" "" | str trim
+    "__VIRTUAL_PROMPT__"
 } {
-    $virtual-env | path basename
+    (build-string '(' ($virtual-env | path basename) ') ')
 }
 )
 
 # If there is no default prompt, then only the env is printed in the prompt
 let new_prompt = (if ( config | select prompt | empty? ) {
-    ($"build-string '(char lparen)' '($virtual_prompt)' '(char rparen) ' ")
+    ($"build-string '($virtual_prompt)'")
 } {
-    ($"build-string '(char lparen)' '($virtual_prompt)' '(char rparen) ' (config get prompt | str find-replace "build-string" "")")
+    ($"build-string '($virtual_prompt)' (config get prompt | str find-replace "build-string" "")")
 })
 let-env PROMPT_COMMAND = $new_prompt
 

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -1,4 +1,5 @@
 # Setting all environment variables for the venv
+let path-name = (if ((sys).host.name == "Windows") { "Path" } { "PATH" })
 let virtual-env = "__VIRTUAL_ENV__"
 let bin = "__BIN_NAME__"
 let path-sep = "__PATH_SEP__"
@@ -11,7 +12,7 @@ let new-path = ($nu.path | prepend $venv-path | str collect ($path-sep))
 # environment variables that will be batched loaded to the virtual env
 let new-env = ([
     [name, value];
-    [PATH $new-path]
+    [$path-name $new-path]
     [_OLD_VIRTUAL_PATH $old-path]
     [VIRTUAL_ENV $virtual-env]
 ])
@@ -20,7 +21,7 @@ load-env $new-env
 
 # Creating the new prompt for the session
 let virtual_prompt = (if ("__VIRTUAL_PROMPT__" != "") {
-    "__VIRTUAL_PROMPT__"
+    "__VIRTUAL_PROMPT__" | str find-replace -a "[\(\)]" "" | str trim
 } {
     $virtual-env | path basename
 }

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -1,5 +1,4 @@
 # Setting all environment variables for the venv
-let path-name = (if ((sys).host.name == "Windows") { "PATH" } { "PATH" })
 let virtual-env = "__VIRTUAL_ENV__"
 let bin = "__BIN_NAME__"
 let path-sep = "__PATH_SEP__"
@@ -12,7 +11,7 @@ let new-path = ($nu.path | prepend $venv-path | str collect ($path-sep))
 # environment variables that will be batched loaded to the virtual env
 let new-env = ([
     [name, value];
-    [$path-name $new-path]
+    [PATH $new-path]
     [_OLD_VIRTUAL_PATH $old-path]
     [VIRTUAL_ENV $virtual-env]
 ])
@@ -23,15 +22,15 @@ load-env $new-env
 let virtual_prompt = (if ("__VIRTUAL_PROMPT__" != "") {
     "__VIRTUAL_PROMPT__"
 } {
-    (build-string '(' ($virtual-env | path basename) ') ')
+    $virtual-env | path basename
 }
 )
 
 # If there is no default prompt, then only the env is printed in the prompt
 let new_prompt = (if ( config | select prompt | empty? ) {
-    ($"build-string '($virtual_prompt)'")
+    ($"build-string '(char lparen)' '($virtual_prompt)' '(char rparen) ' ")
 } {
-    ($"build-string '($virtual_prompt)' (config get prompt | str find-replace "build-string" "")")
+    ($"build-string '(char lparen)' '($virtual_prompt)' '(char rparen) ' (config get prompt | str find-replace "build-string" "")")
 })
 let-env PROMPT_COMMAND = $new_prompt
 

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -1,5 +1,5 @@
 # Setting all environment variables for the venv
-let path-name = (if ((sys).host.name == "Windows") { "Path" } { "PATH" })
+let path-name = (if ((sys).host.name == "Windows") { "PATH" } { "PATH" })
 let virtual-env = "__VIRTUAL_ENV__"
 let bin = "__BIN_NAME__"
 let path-sep = "__PATH_SEP__"


### PR DESCRIPTION
The prompt constructor was printing double bracket when the prompt was given (e.g. pipenv).
This PR corrects that and prints the correct prompt