### PR TITLE
Restore unintentionally-modified pre-``2186`` cleanup behaviors

### DIFF
--- a/docs/changelog/2198.bugfix.rst
+++ b/docs/changelog/2198.bugfix.rst
@@ -1,0 +1,1 @@
+Restore unintentionally-modified pre-``2186`` cleanup behaviors - by :user:`arcivanov`


### PR DESCRIPTION
1. Do not disturb platdir
2. Do delete a target directory on install if it is present and
wasn't a part of the distro that could've been uninstalled

fixes #2198

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
