### PR TITLE
Skip directories when symlinking libraries for PyPy3

### DIFF
--- a/docs/changelog/2182.bugfix.txt
+++ b/docs/changelog/2182.bugfix.txt
@@ -1,0 +1,2 @@
+Fixed path collision that could lead to a PermissionError or writing to system
+directories when using PyPy3.8 - by :user:`mgorny`.

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
@@ -44,6 +44,8 @@ class PyPy3Posix(PyPy3, PosixSupports):
         host_lib = Path(interpreter.system_prefix) / "lib"
         if host_lib.exists() and host_lib.is_dir():
             for path in host_lib.iterdir():
+                if path.is_dir():
+                    continue
                 yield PathRefToDest(path, dest=cls.to_lib)
 
 


### PR DESCRIPTION
The PyPy3 logic creates symlinks for all files from the library
directory existing alongside the PyPy executable.  This is meant
to ensure that the bundled libraries to which PyPy is linked can also
be found from inside the virtualenv.  However, this logic also symlinks
all directories which is unnecessary and causes library directory
collisions with the new install layout.  Change to logic to symlink
non-directories only.

A similar fix has been applied to the internal venv module in PyPy3.8:
https://foss.heptapod.net/pypy/pypy/-/commit/713b2af9abd2b9453e12c60143e17431a1aefb33

Fixes #2182

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix (n/a?)
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation (n/a)
