### PR TITLE
Favor the "venv" sysconfig install scheme over the default and distutils scheme

### DIFF
--- a/docs/changelog/2208.feature.rst
+++ b/docs/changelog/2208.feature.rst
@@ -1,0 +1,4 @@
+If a ``"venv"`` install scheme exists in ``sysconfig``, virtualenv now uses it to create new virtual environments.
+This allows Python distributors, such as Fedora, to patch/replace the default install scheme without affecting
+the paths in new virtual environments.
+A similar technique `was proposed to Python, for the venv module <https://bugs.python.org/issue45413>`_ - by ``hroncok``


### PR DESCRIPTION
Python is preparing to allow re-distributors to set custom sysconfig install schemes in 3.11+:

https://bugs.python.org/issue43976

Fedora is already adapting the default installation scheme to their needs:

https://lists.fedoraproject.org/archives/list/python-devel@lists.fedoraproject.org/thread/AAGUFQZ4RZDU7KUN4HA43KQJCMSFR3GW/

With either of the above, the distributors need to signalize the paths used in virtual environments somehow. When they set the "venv" install scheme in sysconfig, it is now favored over the default sysconfig scheme as well as over distutils.

Fixes https://github.com/pypa/virtualenv/issues/2208

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

I'll work on the docs next. Opening earlier to validate the test works on Widnows.