### PR TITLE
Replace appdirs with platformdirs in docs

### DIFF
--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -33,7 +33,7 @@ Configuration file
 ^^^^^^^^^^^^^^^^^^
 
 virtualenv looks for a standard ini configuration file. The exact location depends on the operating system you're using,
-as determined by :pypi:`appdirs` application configuration definition. The configuration file location is printed as at
+as determined by :pypi:`platformdirs` application configuration definition. The configuration file location is printed as at
 the end of the output when ``--help`` is passed.
 
 The keys of the settings are derived from the command line option (left strip the ``-`` characters, and replace ``-``


### PR DESCRIPTION
- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation

This PR is a small change to docs, so I ignored most of the things mentioned above. 😳
Please, let me know, if they are still necessary. 

### Description
`virtualenv` uses [platformdirs](https://pypi.org/project/platformdirs/) instead of [appdirs](https://pypi.org/project/appdirs/) since https://github.com/pypa/virtualenv/pull/2142, but in the docs `appdirs` was [still mentioned](https://virtualenv.pypa.io/en/20.8.1/cli_interface.html#defaults). 😊
I did not find any other mentions of `appdirs` in docs.