### PR TITLE
refactor to not do too much in ReentrantFileLock.__del__

### DIFF
--- a/src/virtualenv/util/lock.py
+++ b/src/virtualenv/util/lock.py
@@ -90,8 +90,8 @@ class ReentrantFileLock(PathLockBase):
 
     @staticmethod
     def _del_lock(lock):
-        with _store_lock:
-            if lock is not None:
+        if lock is not None:
+            with _store_lock:
                 with lock.thread_safe:
                     if lock.count == 0:
                         _lock_store.pop(lock.lock_file, None)
@@ -105,6 +105,8 @@ class ReentrantFileLock(PathLockBase):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._release(self._lock)
+        self._del_lock(self._lock)
+        self._lock = None
 
     def _lock_file(self, lock, no_block=False):
         # multiple processes might be trying to get a first lock... so we cannot check if this directory exist without
@@ -138,6 +140,7 @@ class ReentrantFileLock(PathLockBase):
                 self._release(lock)
         finally:
             self._del_lock(lock)
+            lock = None
 
     @contextmanager
     def non_reentrant_lock_for_key(self, name):


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

Internal refactor of `ReentrantFileLock.__del__` to avoid the `_store_lock` context if not needed. Also make sure the lock is deleted and set to None in the `__exit__` call, so that `__del__` now will be a no-op on the happy path.

This came up in #2206 when looking at PyPy failures. Since PyPy uses a non-refcount garbage collector, `__del__` can be called much later than on CPython, leaving unneeded locks hanging around.