### PR TITLE
Sign the python2 exe on Darwin arm64

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -630,7 +630,7 @@ Bugfixes - 20.0.8
 - Having `distutils configuration <https://docs.python.org/3/install/index.html#distutils-configuration-files>`_
   files that set ``prefix`` and ``install_scripts`` cause installation of packages in the wrong location -
   by :user:`gaborbernat`. (`#1663 <https://github.com/pypa/virtualenv/issues/1663>`_)
-- Fix ``PYTHONPATH`` being overridden on Python 2 — by :user:`jd`. (`#1673 <https://github.com/pypa/virtualenv/issues/1673>`_)
+- Fix ``PYTHONPATH`` being overridden on Python 2 — by :user:`jd`. (`#1673 <https://github.com/pypa/virtualenv/issues/1673>`_)
 - Fix list configuration value parsing from config file or environment variable - by :user:`gaborbernat`. (`#1674 <https://github.com/pypa/virtualenv/issues/1674>`_)
 - Fix Batch activation script shell prompt to display environment name by default - by :user:`spetafree`. (`#1679 <https://github.com/pypa/virtualenv/issues/1679>`_)
 - Fix startup on Python 2 is slower for virtualenv - this was due to setuptools calculating it's working set distribution

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ virtualenv.create =
     cpython3-win = virtualenv.create.via_global_ref.builtin.cpython.cpython3:CPython3Windows
     cpython2-posix = virtualenv.create.via_global_ref.builtin.cpython.cpython2:CPython2Posix
     cpython2-mac-framework = virtualenv.create.via_global_ref.builtin.cpython.mac_os:CPython2macOsFramework
+    cpython2-mac-arm-framework  = virtualenv.create.via_global_ref.builtin.cpython.mac_os:CPython2macOsArmFramework
     cpython3-mac-framework = virtualenv.create.via_global_ref.builtin.cpython.mac_os:CPython3macOsFramework
     cpython2-win = virtualenv.create.via_global_ref.builtin.cpython.cpython2:CPython2Windows
     pypy2-posix = virtualenv.create.via_global_ref.builtin.pypy.pypy2:PyPy2Posix

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -69,6 +69,10 @@ class CPythonmacOsFramework(CPython):
 
 class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
+    def can_create(cls, interpreter):
+        return not IS_MAC_ARM64 and super(CPython2macOsFramework, cls).can_describe(interpreter)
+
+    @classmethod
     def image_ref(cls, interpreter):
         return Path(interpreter.prefix) / "Python"
 
@@ -106,37 +110,32 @@ class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
 
 class CPython2macOsArmFramework(CPython2macOsFramework, CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
-    def can_describe(cls, interpreter):
+    def can_create(cls, interpreter):
         return IS_MAC_ARM64 and super(CPythonmacOsFramework, cls).can_describe(interpreter)
 
     def create(self):
         super(CPython2macOsFramework, self).create()
-        # re-sign the newly copied/modified python binary
-        python_exe = os.path.join(str(self.dest), "bin", "python")
-        self.fix_signature(python_exe)
+        self.fix_signature()
 
-    def fix_signature(self, exe):
+    def fix_signature(self):
         """
-        On Apple M1 machines (arm64 chips),  rewriting the python executable invalidates it's signature.
+        On Apple M1 machines (arm64 chips),  rewriting the python executable invalidates its signature.
         In python2 this results in a unusable python exe which just dies.
-        As a temporary workaround we can codesign the python exe during the createion process.
+        As a temporary workaround we can codesign the python exe during the creation process.
         """
+        exe = self.exe
         try:
             logging.debug("Changing signature of copied python exe %s", exe)
-            bak_dir = os.path.join(os.path.dirname(exe), "bk")
-            bk_python = os.path.join(bak_dir, os.path.basename(exe))
-
-            # hack to reset the signing on Darwin since the exe has been modified.
-            # codesign fails on the original exe, it needs to be copied and moved back.
-            os.makedirs(bak_dir)
+            bak_dir = exe.parent / "bk"
+            # Reset the signing on Darwin since the exe has been modified.
+            # Note codesign fails on the original exe, it needs to be copied and moved back.
+            bak_dir.mkdir(parents=True, exist_ok=True)
             subprocess.check_call(["cp", exe, bak_dir])
-            subprocess.check_call(["mv", bk_python, exe])
-            os.rmdir(bak_dir)
-
+            subprocess.check_call(["mv", bak_dir / exe.name, exe])
+            bak_dir.unlink()
             cmd = ["codesign", "-s", "-", "--preserve-metadata=identifier,entitlements,flags,runtime", "-f", exe]
             logging.debug("Changing Signature: %s", cmd)
             subprocess.check_call(cmd)
-
         except Exception:
             logging.fatal("Could not change MacOS code signing on copied python exe at %s", exe)
             raise

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -48,8 +48,6 @@ class CPythonmacOsFramework(CPython):
                         exes.extend(self.bin_dir / a for a in src.aliases)
                     for exe in exes:
                         fix_mach_o(str(exe), current, target, self.interpreter.max_size)
-                        if IS_MAC_ARM64:
-                            fix_signature(str(exe))
 
     @classmethod
     def _executables(cls, interpreter):
@@ -105,9 +103,17 @@ class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
         )
         return result
 
+
+class CPython2macOsArmFramework(CPython2macOsFramework, CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
-    def can_create(cls, interpreter):
-        return super(CPythonmacOsFramework, cls).can_create(interpreter)
+    def can_describe(cls, interpreter):
+        return IS_MAC_ARM64 and super(CPythonmacOsFramework, cls).can_describe(interpreter)
+
+    def create(self):
+        super(CPython2macOsFramework, self).create()
+        # re-sign the newly copied/modified python binary
+        python_exe = os.path.join(str(self.dest), "bin", "python")
+        fix_signature(python_exe)
 
 
 class CPython3macOsFramework(CPythonmacOsFramework, CPython3, CPythonPosix):


### PR DESCRIPTION
As part of https://github.com/pypa/virtualenv/issues/2024 , the latest version of virtualenv will not run on Darwin Arm64 (Apple M1).
The original issue was that the python exe would be killed due to the exe not being properly signed.  There is a workaround for the issue which is to sign the python exe that has been moved/modified in the virtualenv.   Up until 20.8.1 running the codesign process after virtualenv was ran would allow for a usable environment.
This PR is to propose that we just add the workaround of adhoc signing the exe into the virtualenv process.

With the latest version of virtualenv this only affect python2 on Darwin ARM64.

This PR adds a fix_signature function to perform the codesign if on MAC_ARM64 and removes the change to can_create to return false if MAC_ARM64.

Tested on an M1 machine using python2.7 and python3.7 without any issues.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [X] ran the linter to address style issues (``tox -e fix_lint``)
- [X ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
