### PR TITLE
Omit backports.entry_points_selectable for Python >=3.10

### DIFF
--- a/docs/changelog/2238.feature.rst
+++ b/docs/changelog/2238.feature.rst
@@ -1,0 +1,1 @@
+Omit backports.entry_points_selectable for Python >=3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,11 +40,11 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    backports.entry-points-selectable>=1.0.4
     distlib>=0.3.1,<1
     filelock>=3.2,<4
     platformdirs>=2,<3
     six>=1.9.0,<2   # keep it >=1.9.0 as it may cause problems on LTS platforms
+    backports.entry-points-selectable>=1.0.4;python_version<"3.10"
     importlib-metadata>=0.12;python_version<"3.8"
     importlib-resources>=1.0;python_version<"3.7"
     pathlib2>=2.3.3,<3;python_version < '3.4' and sys.platform != 'win32'

--- a/src/virtualenv/run/plugin/base.py
+++ b/src/virtualenv/run/plugin/base.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import sys
 from collections import OrderedDict
 
-from backports.entry_points_selectable import entry_points
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
+else:
+    from backports.entry_points_selectable import entry_points
 
 
 class PluginLoader(object):


### PR DESCRIPTION
If I understood backports.entry_points_selectable documentation correctly, this is equivalent.
Change is proposed to update above 20.4.7 on Void Linux, which is on python 3.10 already, without fuss of adding the backport module to repository.

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
