### PR TITLE
fish: PATH variables should not be quoted when being set

### DIFF
--- a/src/virtualenv/activation/fish/activate.fish
+++ b/src/virtualenv/activation/fish/activate.fish
@@ -21,7 +21,7 @@ function deactivate -d 'Exit virtualenv mode and return to the normal environmen
         if test (echo $FISH_VERSION | head -c 1) -lt 3
             set -gx PATH (_fishify_path "$_OLD_VIRTUAL_PATH")
         else
-            set -gx PATH "$_OLD_VIRTUAL_PATH"
+            set -gx PATH $_OLD_VIRTUAL_PATH
         end
         set -e _OLD_VIRTUAL_PATH
     end
@@ -63,7 +63,7 @@ set -gx VIRTUAL_ENV '__VIRTUAL_ENV__'
 if test (echo $FISH_VERSION | head -c 1) -lt 3
    set -gx _OLD_VIRTUAL_PATH (_bashify_path $PATH)
 else
-    set -gx _OLD_VIRTUAL_PATH "$PATH"
+    set -gx _OLD_VIRTUAL_PATH $PATH
 end
 set -gx PATH "$VIRTUAL_ENV"'/__BIN_NAME__' $PATH
 


### PR DESCRIPTION
Before this change, deactivation fails with the following error because the old PATH value is not expanded into a list.

```
(venv) [03:14:38] ~/code/d3dave/gprofiler
david> deactivate
set: Warning: $PATH entry "/Users/david/.sdkman/candidates/scala/current/bin:/Users/david/.sdkman/candidates/sbt/current/bin:/Users/david/.sdkman/candidates/maven/current/bin:/Users/david/.sdkman/candidates/java/current/bin:/Users/david/.sdkman/candidates/gradle/current/bin:/Users/david/Library/Python/3.9/bin:/Users/david/.cargo/bin:/Users/david/Library/Python/2.7/bin:/usr/local/Cellar/ruby/3.0.1/bin:/Users/david/.yarn/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/Applications/VMware Fusion.app/Contents/Public:/Applications/Wireshark.app/Contents/MacOS" is not valid (No such file or directory)
set: Did you mean 'set PATH $PATH /Users/david/.sdkman/candidates/sbt/current/bin:/Users/david/.sdkman/candidates/maven/current/bin:/Users/david/.sdkman/candidates/java/current/bin:/Users/david/.sdkman/candidates/gradle/current/bin:/Users/david/Library/Python/3.9/bin:/Users/david/.cargo/bin:/Users/david/Library/Python/2.7/bin:/usr/local/Cellar/ruby/3.0.1/bin:/Users/david/.yarn/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/Applications/VMware Fusion.app/Contents/Public:/Applications/Wireshark.app/Contents/MacOS'?
```

I don't know about the CI, but at least when running the fish tests locally they fail with this exact same error 🙁 
I am running on Mac OS with fish 3.2.2.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation
