### PR TITLE
fix: `--download` option

### DIFF
--- a/docs/changelog/2120.bugfix.rst
+++ b/docs/changelog/2120.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--download`` option - by :user:`mayeut`.

--- a/src/virtualenv/seed/wheels/acquire.py
+++ b/src/virtualenv/seed/wheels/acquire.py
@@ -18,11 +18,14 @@ def get_wheel(distribution, version, for_py_version, search_dirs, download, app_
     Get a wheel with the given distribution-version-for_py_version trio, by using the extra search dir + download
     """
     # not all wheels are compatible with all python versions, so we need to py version qualify it
-    # 1. acquire from bundle
-    wheel = from_bundle(distribution, version, for_py_version, search_dirs, app_data, do_periodic_update, env)
+    wheel = None
 
-    # 2. download from the internet
-    if version not in Version.non_version and download:
+    if not download or version != Version.bundle:
+        # 1. acquire from bundle
+        wheel = from_bundle(distribution, version, for_py_version, search_dirs, app_data, do_periodic_update, env)
+
+    if download and wheel is None and version != Version.embed:
+        # 2. download from the internet
         wheel = download_wheel(
             distribution=distribution,
             version_spec=Version.as_version_spec(version),
@@ -32,6 +35,7 @@ def get_wheel(distribution, version, for_py_version, search_dirs, download, app_
             to_folder=app_data.house,
             env=env,
         )
+
     return wheel
 
 


### PR DESCRIPTION
Fixes #2120

Without those changes, downloads were only attempted for pinned versions.
When the `--download` option is used:
- Always trigger a download when using `bundle`, don't even look at what is embedded / updated wheels.
- Never trigger a download when using `embed`, only use the embedded version.
- When a pinned version is used, start by looking if it matches embedded / updated wheels and fallback to to trigger a download if not found.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
