### PR TITLE
fix: AttributeError on macOS creating a Python 2.x virtualenv

### DIFF
--- a/docs/changelog/bugfix.2269.rst
+++ b/docs/changelog/bugfix.2269.rst
@@ -1,0 +1,2 @@
+Fix ``AttributeError: 'bool' object has no attribute 'error'`` when creating a
+Python 2.x virtualenv on macOS - by ``moreati``

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -70,7 +70,9 @@ class CPythonmacOsFramework(CPython):
 class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
     def can_create(cls, interpreter):
-        return not IS_MAC_ARM64 and super(CPython2macOsFramework, cls).can_describe(interpreter)
+        if not IS_MAC_ARM64 and super(CPython2macOsFramework, cls).can_describe(interpreter):
+            return super(CPython2macOsFramework, cls).can_create(interpreter)
+        return False
 
     @classmethod
     def image_ref(cls, interpreter):
@@ -111,7 +113,9 @@ class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
 class CPython2macOsArmFramework(CPython2macOsFramework, CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
     def can_create(cls, interpreter):
-        return IS_MAC_ARM64 and super(CPythonmacOsFramework, cls).can_describe(interpreter)
+        if IS_MAC_ARM64 and super(CPythonmacOsFramework, cls).can_describe(interpreter):
+            return super(CPythonmacOsFramework, cls).can_create(interpreter)
+        return False
 
     def create(self):
         super(CPython2macOsFramework, self).create()


### PR DESCRIPTION
Fixes #2269

> AttributeError: 'bool' object has no attribute 'error'

when creating a Python 2.x environment on macOS with virtualenv 20.12.0.

Refs #2233

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder