### PR TITLE
fix: Correctly remove bk dir when re-signing macOS Python 2.x executable

### DIFF
--- a/docs/changelog/bugfix.2269.rst
+++ b/docs/changelog/bugfix.2269.rst
@@ -1,0 +1,2 @@
+Fix ``AttributeError: 'bool' object has no attribute 'error'`` when creating a
+Python 2.x virtualenv on macOS - by ``moreati``

--- a/docs/changelog/bugfix.2271.rst
+++ b/docs/changelog/bugfix.2271.rst
@@ -1,0 +1,2 @@
+Fix ``PermissionError: [Errno 1] Operation not permitted`` when creating a
+Python 2.x virtualenv on macOS/arm64 - by ``moreati``

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -70,7 +70,9 @@ class CPythonmacOsFramework(CPython):
 class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
     def can_create(cls, interpreter):
-        return not IS_MAC_ARM64 and super(CPython2macOsFramework, cls).can_describe(interpreter)
+        if not IS_MAC_ARM64 and super(CPython2macOsFramework, cls).can_describe(interpreter):
+            return super(CPython2macOsFramework, cls).can_create(interpreter)
+        return False
 
     @classmethod
     def image_ref(cls, interpreter):
@@ -111,7 +113,9 @@ class CPython2macOsFramework(CPythonmacOsFramework, CPython2PosixBase):
 class CPython2macOsArmFramework(CPython2macOsFramework, CPythonmacOsFramework, CPython2PosixBase):
     @classmethod
     def can_create(cls, interpreter):
-        return IS_MAC_ARM64 and super(CPythonmacOsFramework, cls).can_describe(interpreter)
+        if IS_MAC_ARM64 and super(CPythonmacOsFramework, cls).can_describe(interpreter):
+            return super(CPythonmacOsFramework, cls).can_create(interpreter)
+        return False
 
     def create(self):
         super(CPython2macOsFramework, self).create()

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -136,7 +136,7 @@ class CPython2macOsArmFramework(CPython2macOsFramework, CPythonmacOsFramework, C
             bak_dir.mkdir(parents=True, exist_ok=True)
             subprocess.check_call(["cp", exe, bak_dir])
             subprocess.check_call(["mv", bak_dir / exe.name, exe])
-            bak_dir.unlink()
+            bak_dir.rmdir()
             cmd = ["codesign", "-s", "-", "--preserve-metadata=identifier,entitlements,flags,runtime", "-f", exe]
             logging.debug("Changing Signature: %s", cmd)
             subprocess.check_call(cmd)


### PR DESCRIPTION
**This should not be merged before #2270**

Fixes #2271

> PermissionError: [Errno 1] Operation not permitted:
'/Users/alex/src/virtualenv/v27/bin/bk'

Requires #2270
Refs #2233

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
