### PR TITLE
feature: store version update source in embed JSON file

### DIFF
--- a/docs/changelog/2265.bugfix.rst
+++ b/docs/changelog/2265.bugfix.rst
@@ -1,0 +1,3 @@
+Try using previous updates of ``pip``, ``setuptools`` & ``wheel``
+when inside an update grace period rather than always falling back
+to embedded wheels - by :user:`mayeut`.

--- a/docs/changelog/2266.bugfix.rst
+++ b/docs/changelog/2266.bugfix.rst
@@ -1,0 +1,2 @@
+New patch versions of ``pip``, ``setuptools`` & ``wheel`` are now
+returned in the expected timeframe. - by :user:`mayeut`.

--- a/docs/changelog/2267.bugfix.rst
+++ b/docs/changelog/2267.bugfix.rst
@@ -1,0 +1,2 @@
+Manual upgrades of ``pip``, ``setuptools`` & ``wheel`` are
+not discarded by a periodic update - by :user:`mayeut`.

--- a/src/virtualenv/app_data/via_disk_folder.py
+++ b/src/virtualenv/app_data/via_disk_folder.py
@@ -14,7 +14,7 @@ virtualenv-app-data
 │       │           └── <install class> -> CopyPipInstall / SymlinkPipInstall
 │       │               └── <wheel name> -> pip-20.1.1-py2.py3-none-any
 │       └── embed
-│           └── 1
+│           └── 2 -> json format versioning
 │               └── *.json -> for every distribution contains data about newer embed versions and releases
 └─── unzip <in zip app we cannot refer to some internal files, so first extract them>
      └── <virtualenv version>
@@ -101,7 +101,7 @@ class AppDataDiskFolder(AppData):
                             filename.unlink()
 
     def embed_update_log(self, distribution, for_py_version):
-        return EmbedDistributionUpdateStoreDisk(self.lock / "wheel" / for_py_version / "embed" / "1", distribution)
+        return EmbedDistributionUpdateStoreDisk(self.lock / "wheel" / for_py_version / "embed" / "2", distribution)
 
     @property
     def house(self):

--- a/tests/unit/seed/wheels/test_bundle.py
+++ b/tests/unit/seed/wheels/test_bundle.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+from datetime import datetime
 
 import pytest
 
 from virtualenv.app_data import AppDataDiskFolder
 from virtualenv.seed.wheels.bundle import from_bundle
 from virtualenv.seed.wheels.embed import get_embed_wheel
+from virtualenv.seed.wheels.periodic_update import dump_datetime
 from virtualenv.seed.wheels.util import Version, Wheel
 from virtualenv.util.path import Path
 
@@ -23,17 +25,19 @@ def next_pip_wheel(for_py_version):
 @pytest.fixture(scope="module")
 def app_data(tmp_path_factory, for_py_version, next_pip_wheel):
     temp_folder = tmp_path_factory.mktemp("module-app-data")
+    now = dump_datetime(datetime.now())
     app_data_ = AppDataDiskFolder(str(temp_folder))
     app_data_.embed_update_log("pip", for_py_version).write(
         {
-            "completed": "2000-01-01T00:00:00.000000Z",
+            "completed": now,
             "periodic": True,
-            "started": "2000-01-01T00:00:00.000000Z",
+            "started": now,
             "versions": [
                 {
                     "filename": next_pip_wheel.name,
                     "found_date": "2000-01-01T00:00:00.000000Z",
                     "release_date": "2000-01-01T00:00:00.000000Z",
+                    "source": "periodic",
                 }
             ],
         }

--- a/tests/unit/seed/wheels/test_periodic_update.py
+++ b/tests/unit/seed/wheels/test_periodic_update.py
@@ -42,7 +42,7 @@ def clear_pypi_info_cache():
 
 def test_manual_upgrade(session_app_data, caplog, mocker, for_py_version):
     wheel = get_embed_wheel("pip", for_py_version)
-    new_version = NewVersion(wheel.path, datetime.now(), datetime.now() - timedelta(days=20))
+    new_version = NewVersion(wheel.path, datetime.now(), datetime.now() - timedelta(days=20), "manual")
 
     def _do_update(distribution, for_py_version, embed_filename, app_data, search_dirs, periodic):  # noqa
         if distribution == "pip":
@@ -73,7 +73,7 @@ def test_pick_periodic_update(tmp_path, session_app_data, mocker, for_py_version
     u_log = UpdateLog(
         started=datetime.now() - timedelta(days=30),
         completed=completed,
-        versions=[NewVersion(filename=current.path, found_date=completed, release_date=completed)],
+        versions=[NewVersion(filename=current.path, found_date=completed, release_date=completed, source="periodic")],
         periodic=True,
     )
     read_dict = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
@@ -93,9 +93,9 @@ def test_periodic_update_stops_at_current(mocker, session_app_data, for_py_versi
         started=completed,
         completed=completed,
         versions=[
-            NewVersion(wheel_path(current, (1,)), completed, now - timedelta(days=1)),
-            NewVersion(filename=current.path, found_date=completed, release_date=now - timedelta(days=2)),
-            NewVersion(wheel_path(current, (-1,)), completed, now - timedelta(days=30)),
+            NewVersion(wheel_path(current, (1,)), completed, now - timedelta(days=1), "periodic"),
+            NewVersion(current.path, completed, now - timedelta(days=2), "periodic"),
+            NewVersion(wheel_path(current, (-1,)), completed, now - timedelta(days=30), "periodic"),
         ],
         periodic=True,
     )
@@ -107,21 +107,67 @@ def test_periodic_update_stops_at_current(mocker, session_app_data, for_py_versi
 
 def test_periodic_update_latest_per_patch(mocker, session_app_data, for_py_version):
     current = get_embed_wheel("setuptools", for_py_version)
-    now, completed = datetime.now(), datetime.now() - timedelta(days=29)
+    expected_path = wheel_path(current, (0, 1, 2))
+    now = datetime.now()
+    completed = now - timedelta(hours=2)
     u_log = UpdateLog(
         started=completed,
         completed=completed,
-        versions=[
-            NewVersion(wheel_path(current, (0, 1, 2)), completed, now - timedelta(days=1)),
-            NewVersion(wheel_path(current, (0, 1, 1)), completed, now - timedelta(days=30)),
-            NewVersion(filename=str(current.path), found_date=completed, release_date=now - timedelta(days=2)),
-        ],
         periodic=True,
+        versions=[
+            NewVersion(expected_path, completed, now - timedelta(days=1), "periodic"),
+            NewVersion(wheel_path(current, (0, 1, 1)), completed, now - timedelta(days=30), "periodic"),
+            NewVersion(str(current.path), completed, now - timedelta(days=31), "periodic"),
+        ],
     )
     mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
 
     result = periodic_update("setuptools", None, for_py_version, current, [], session_app_data, False, os.environ)
-    assert result.path == current.path
+    assert str(result.path) == expected_path
+
+
+def test_periodic_update_latest_per_patch_prev_is_manual(mocker, session_app_data, for_py_version):
+    current = get_embed_wheel("setuptools", for_py_version)
+    expected_path = wheel_path(current, (0, 1, 2))
+    now = datetime.now()
+    completed = now - timedelta(hours=2)
+    u_log = UpdateLog(
+        started=completed,
+        completed=completed,
+        periodic=True,
+        versions=[
+            NewVersion(expected_path, completed, completed, "periodic"),
+            NewVersion(wheel_path(current, (0, 1, 1)), completed, now - timedelta(days=10), "manual"),
+            NewVersion(wheel_path(current, (0, 1, 0)), completed, now - timedelta(days=11), "periodic"),
+            NewVersion(str(current.path), completed, now - timedelta(days=12), "manual"),
+        ],
+    )
+    mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
+
+    result = periodic_update("setuptools", None, for_py_version, current, [], session_app_data, False, os.environ)
+    assert str(result.path) == expected_path
+
+
+def test_manual_update_honored(mocker, session_app_data, for_py_version):
+    current = get_embed_wheel("setuptools", for_py_version)
+    expected_path = wheel_path(current, (0, 1, 1))
+    now = datetime.now()
+    completed = now
+    u_log = UpdateLog(
+        started=completed,
+        completed=completed,
+        periodic=True,
+        versions=[
+            NewVersion(wheel_path(current, (0, 1, 2)), completed, completed, "periodic"),
+            NewVersion(expected_path, completed, now - timedelta(days=10), "manual"),
+            NewVersion(wheel_path(current, (0, 1, 0)), completed, now - timedelta(days=11), "periodic"),
+            NewVersion(str(current.path), completed, now - timedelta(days=12), "manual"),
+        ],
+    )
+    mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
+
+    result = periodic_update("setuptools", None, for_py_version, current, [], session_app_data, False, os.environ)
+    assert str(result.path) == expected_path
 
 
 def wheel_path(wheel, of):
@@ -338,7 +384,7 @@ def test_do_update_first(tmp_path, mocker, freezer):
     assert copy.call_count == 1
 
     expected = [
-        NewVersion(Path(wheel).name, _UP_NOW, None if release is None else release.replace(microsecond=0))
+        NewVersion(Path(wheel).name, _UP_NOW, None if release is None else release.replace(microsecond=0), "periodic")
         for wheel, release in pip_version_remote
     ]
     assert versions == expected
@@ -371,7 +417,7 @@ def test_do_update_skip_already_done(tmp_path, mocker, freezer):
     u_log = UpdateLog(
         started=_UP_NOW - timedelta(days=31),
         completed=released,
-        versions=[NewVersion(filename=wheel.path.name, found_date=released, release_date=released)],
+        versions=[NewVersion(filename=wheel.path.name, found_date=released, release_date=released, source="periodic")],
         periodic=True,
     )
     read_dict = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
@@ -395,21 +441,20 @@ def test_do_update_skip_already_done(tmp_path, mocker, freezer):
                 "filename": wheel.path.name,
                 "release_date": dump_datetime(released),
                 "found_date": dump_datetime(released),
+                "source": "manual",  # changed from "periodic" to "manual"
             },
         ],
     }
 
 
 def test_new_version_eq():
-    value = NewVersion("a", datetime.now(), datetime.now())
+    value = NewVersion("a", datetime.now(), datetime.now(), "periodic")
     assert value == value
 
 
 def test_new_version_ne():
-    assert NewVersion("a", datetime.now(), datetime.now()) != NewVersion(
-        "a",
-        datetime.now(),
-        datetime.now() + timedelta(hours=1),
+    assert NewVersion("a", datetime.now(), datetime.now(), "periodic") != NewVersion(
+        "a", datetime.now(), datetime.now() + timedelta(hours=1), "manual"
     )
 
 
@@ -469,6 +514,96 @@ def test_download_stop_with_embed(tmp_path, mocker, freezer):
 
     assert download_wheel.call_count == 3
     assert url_o.call_count == 2
+
+    assert read_dict.call_count == 1
+    assert write.call_count == 1
+
+
+def test_download_periodic_stop_at_first_usable(tmp_path, mocker, freezer):
+    freezer.move_to(_UP_NOW)
+    wheel = get_embed_wheel("pip", "3.9")
+    app_data_outer = AppDataDiskFolder(str(tmp_path / "app"))
+    pip_version_remote = [wheel_path(wheel, (0, 1, 1)), wheel_path(wheel, (0, 1, 0))]
+    rel_date_remote = [_UP_NOW - timedelta(days=1), _UP_NOW - timedelta(days=30)]
+    at = {"download": 0, "release_date": 0}
+
+    def download():
+        while True:
+            path = pip_version_remote[at["download"]]
+            at["download"] += 1
+            yield Wheel(Path(path))
+
+    download_gen = download()
+    download_wheel = mocker.patch(
+        "virtualenv.seed.wheels.acquire.download_wheel", side_effect=lambda *a, **k: next(download_gen)
+    )
+
+    def rel_date():
+        while True:
+            value = rel_date_remote[at["release_date"]]
+            at["release_date"] += 1
+            yield value
+
+    rel_date_gen = rel_date()
+    release_date = mocker.patch(
+        "virtualenv.seed.wheels.periodic_update.release_date_for_wheel_path",
+        side_effect=lambda *a, **k: next(rel_date_gen),
+    )
+
+    last_update = _UP_NOW - timedelta(days=14)
+    u_log = UpdateLog(started=last_update, completed=last_update, versions=[], periodic=True)
+    read_dict = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
+    write = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.write")
+
+    do_update("pip", "3.9", str(wheel.path), str(app_data_outer), [], True)
+
+    assert download_wheel.call_count == 2
+    assert release_date.call_count == 2
+
+    assert read_dict.call_count == 1
+    assert write.call_count == 1
+
+
+def test_download_manual_stop_at_first_usable(tmp_path, mocker, freezer):
+    freezer.move_to(_UP_NOW)
+    wheel = get_embed_wheel("pip", "3.9")
+    app_data_outer = AppDataDiskFolder(str(tmp_path / "app"))
+    pip_version_remote = [wheel_path(wheel, (0, 1, 1))]
+    rel_date_remote = [_UP_NOW + timedelta(hours=1)]
+    at = {"download": 0, "release_date": 0}
+
+    def download():
+        while True:
+            path = pip_version_remote[at["download"]]
+            at["download"] += 1
+            yield Wheel(Path(path))
+
+    download_gen = download()
+    download_wheel = mocker.patch(
+        "virtualenv.seed.wheels.acquire.download_wheel", side_effect=lambda *a, **k: next(download_gen)
+    )
+
+    def rel_date():
+        while True:
+            value = rel_date_remote[at["release_date"]]
+            at["release_date"] += 1
+            yield value
+
+    rel_date_gen = rel_date()
+    release_date = mocker.patch(
+        "virtualenv.seed.wheels.periodic_update.release_date_for_wheel_path",
+        side_effect=lambda *a, **k: next(rel_date_gen),
+    )
+
+    last_update = _UP_NOW - timedelta(days=14)
+    u_log = UpdateLog(started=last_update, completed=last_update, versions=[], periodic=True)
+    read_dict = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.read", return_value=u_log.to_dict())
+    write = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.write")
+
+    do_update("pip", "3.9", str(wheel.path), str(app_data_outer), [], False)
+
+    assert download_wheel.call_count == 1
+    assert release_date.call_count == 1
 
     assert read_dict.call_count == 1
     assert write.call_count == 1


### PR DESCRIPTION
Store version update source in embed JSON file.
For now, the source can take the value `periodic` or `manual` (not enforced to allow future sources).
Only `periodic` & `manual` sources are allowed to provide an update path for a `bundle` version.
Running a manual update marks all versions source as `manual`.
Running a periodic update marks all versions source as `periodic` if the source value is not `manual`.


The following issues are fixed:
- fixes #2265
- fixes #2266
- fixes #2267

This will also allow to implement #2268 with a new source (e.g. `download`).


 
### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
