### PR TITLE
PyPy: glob for required dlls, check they exist

### DIFF
--- a/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
@@ -43,11 +43,9 @@ class PyPy(ViaGlobalRefVirtualenvBuiltin):
     def _add_shared_libs(cls, interpreter):
         # https://bitbucket.org/pypy/pypy/issue/1922/future-proofing-virtualenv
         python_dir = Path(interpreter.system_executable).resolve().parent
-        for libname in cls._shared_libs():
-            # Windows needs two dlls
-            for src in python_dir.glob(libname):
-                yield src
+        for src in cls._shared_libs(python_dir):
+            yield src
 
     @classmethod
-    def _shared_libs(cls):
+    def _shared_libs(cls, python_dir):
         raise NotImplementedError

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
@@ -45,12 +45,8 @@ class PyPy(ViaGlobalRefVirtualenvBuiltin):
         python_dir = Path(interpreter.system_executable).resolve().parent
         for libname in cls._shared_libs():
             # Windows needs two dlls
-            found = False
             for src in python_dir.glob(libname):
-                found = True
                 yield src
-            if not found:
-                raise RuntimeError(f"could not find {python_dir / libname}, aborting")
 
     @classmethod
     def _shared_libs(cls):

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
@@ -44,9 +44,13 @@ class PyPy(ViaGlobalRefVirtualenvBuiltin):
         # https://bitbucket.org/pypy/pypy/issue/1922/future-proofing-virtualenv
         python_dir = Path(interpreter.system_executable).resolve().parent
         for libname in cls._shared_libs():
-            src = python_dir / libname
-            if src.exists():
+            # Windows needs two dlls
+            found = False
+            for src in python_dir.glob(libname):
+                found = True
                 yield src
+            if not found:
+                raise RuntimeError(f"could not find {python_dir / libname}, aborting")
 
     @classmethod
     def _shared_libs(cls):

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
@@ -87,9 +87,8 @@ class PyPy2Posix(PyPy2, PosixSupports):
         return super(PyPy2Posix, cls).modules() + ["posixpath"]
 
     @classmethod
-    def _shared_libs(cls):
-        # glob for libpypy-c.so, libpypy-c.dylib, ...
-        return ["libpypy*.*"]
+    def _shared_libs(cls, python_dir):
+        return  python_dir.glob("libpypy*.*")
 
     @property
     def lib(self):
@@ -112,9 +111,12 @@ class Pypy2Windows(PyPy2, WindowsSupports):
         return super(Pypy2Windows, cls).modules() + ["ntpath"]
 
     @classmethod
-    def _shared_libs(cls):
-        # glob for libpypy*.dll and libffi*.dll
-        return ["libpypy*.dll", "libffi*.dll"]
+    def _shared_libs(cls, python_dir):
+        # No glob in python2 PathLib
+        for candidate in ["libpypy-c.dll", "libffi-7.dll", "libffi-8.dll"]:
+            dll = python_dir / candidate
+            if dll.exists():
+                yield dll
 
     @classmethod
     def sources(cls, interpreter):

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
@@ -88,7 +88,7 @@ class PyPy2Posix(PyPy2, PosixSupports):
 
     @classmethod
     def _shared_libs(cls, python_dir):
-        return  python_dir.glob("libpypy*.*")
+        return python_dir.glob("libpypy*.*")
 
     @property
     def lib(self):

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy2.py
@@ -88,7 +88,8 @@ class PyPy2Posix(PyPy2, PosixSupports):
 
     @classmethod
     def _shared_libs(cls):
-        return ["libpypy-c.so", "libpypy-c.dylib"]
+        # glob for libpypy-c.so, libpypy-c.dylib, ...
+        return ["libpypy*.*"]
 
     @property
     def lib(self):
@@ -112,7 +113,8 @@ class Pypy2Windows(PyPy2, WindowsSupports):
 
     @classmethod
     def _shared_libs(cls):
-        return ["libpypy-c.dll", "libffi-7.dll", "libffi-8.dll"]
+        # glob for libpypy*.dll and libffi*.dll
+        return ["libpypy*.dll", "libffi*.dll"]
 
     @classmethod
     def sources(cls, interpreter):

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
@@ -23,7 +23,7 @@ class PyPy3(PyPy, Python3Supports):
 
 
 class PyPy3Posix(PyPy3, PosixSupports):
-    """PyPy 2 on POSIX"""
+    """PyPy 3 on POSIX"""
 
     @property
     def stdlib(self):
@@ -32,7 +32,8 @@ class PyPy3Posix(PyPy3, PosixSupports):
 
     @classmethod
     def _shared_libs(cls):
-        return ["libpypy3-c.so", "libpypy3-c.dylib"]
+        # glob for libpypy3-c.so, libpypy3-c.dylib, libpypy3.9-c.so ...
+        return ["libpypy3*.*"]
 
     def to_lib(self, src):
         return self.dest / "lib" / src.name
@@ -72,4 +73,5 @@ class Pypy3Windows(PyPy3, WindowsSupports):
 
     @classmethod
     def _shared_libs(cls):
-        return ["libpypy3-c.dll", "libffi-7.dll", "libffi-8.dll"]
+        # glob for libpypy*.dll and libffi*.dll
+        return ["libpypy*.dll", "libffi*.dll"]

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
@@ -31,9 +31,9 @@ class PyPy3Posix(PyPy3, PosixSupports):
         return self.dest / "lib" / "pypy{}".format(self.interpreter.version_release_str) / "site-packages"
 
     @classmethod
-    def _shared_libs(cls):
+    def _shared_libs(cls, python_dir):
         # glob for libpypy3-c.so, libpypy3-c.dylib, libpypy3.9-c.so ...
-        return ["libpypy3*.*"]
+        return python_dir.glob("libpypy3*.*")
 
     def to_lib(self, src):
         return self.dest / "lib" / src.name
@@ -72,6 +72,9 @@ class Pypy3Windows(PyPy3, WindowsSupports):
         return self.dest / "Scripts"
 
     @classmethod
-    def _shared_libs(cls):
+    def _shared_libs(cls, python_dir):
         # glob for libpypy*.dll and libffi*.dll
-        return ["libpypy*.dll", "libffi*.dll"]
+        for pattern in ["libpypy*.dll", "libffi*.dll"]:
+            srcs = python_dir.glob(pattern)
+            for src in srcs:
+                yield src


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation

PyPy3.9 will change the name of the shared object.

Rather than specify a list of needed dlls/sos/dylibs for PyPy, use a glob. Also check that the glob succeeds, raising a RuntimeError if the glob fails.

BTW, `tox -e fix_lint` tries to use python3.10. Even after installing it from deadsnakes (on Ubuntu), I get an error.

<details><summary>error log</summary>

```
$ tox -e fix_lint
fix_lint create: /home/matti/oss/virtualenv/.tox/fix_lint
fix_lint installdeps: pre-commit>=2
ERROR: invocation failed (exit code 1), logfile: /home/matti/oss/virtualenv/.tox/fix_lint/log/fix_lint-1.log
============================================== log start ==============================================
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/__main__.py", line 29, in <module>
    from pip._internal.cli.main import main as _main
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/cli/main.py", line 9, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/cli/autocompletion.py", line 10, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/cli/main_parser.py", line 8, in <module>
    from pip._internal.cli import cmdoptions
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/cli/cmdoptions.py", line 23, in <module>
    from pip._internal.cli.parser import ConfigOptionParser
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/cli/parser.py", line 12, in <module>
    from pip._internal.configuration import Configuration, ConfigurationError
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/configuration.py", line 26, in <module>
    from pip._internal.utils.logging import getLogger
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/utils/logging.py", line 13, in <module>
    from pip._internal.utils.misc import ensure_dir
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/utils/misc.py", line 40, in <module>
    from pip._internal.locations import get_major_minor_version, site_packages, user_site
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/locations/__init__.py", line 14, in <module>
    from . import _distutils, _sysconfig
  File "/home/matti/oss/virtualenv/.tox/fix_lint/lib/python3.10/site-packages/pip/_internal/locations/_distutils.py", line 9, in <module>
    from distutils.cmd import Command as DistutilsCommand
ModuleNotFoundError: No module named 'distutils.cmd'

=============================================== log end ===============================================
ERROR: could not install deps [pre-commit>=2]; v = InvocationError("/home/matti/oss/virtualenv/.tox/fix_lint/bin/python -m pip install 'pre-commit>=2' --disable-pip-version-check", 1)
_______________________________________________ summary _______________________________________________
ERROR:   fix_lint: could not install deps [pre-commit>=2]; v = InvocationError("/home/matti/oss/virtualenv/.tox/fix_lint/bin/python -m pip install 'pre-commit>=2' --disable-pip-version-check", 1)
```

</details>

I tested the change on the upcoming PyPy3.9
