### PR TITLE
feature: cache downloaded wheel information

### DIFF
--- a/docs/changelog/2268.feature.rst
+++ b/docs/changelog/2268.feature.rst
@@ -1,0 +1,2 @@
+Add downloaded wheel information in the relevant JSON embed file to
+prevent additional downloads of the same wheel. - by :user:`mayeut`.

--- a/src/virtualenv/app_data/via_disk_folder.py
+++ b/src/virtualenv/app_data/via_disk_folder.py
@@ -14,7 +14,7 @@ virtualenv-app-data
 │       │           └── <install class> -> CopyPipInstall / SymlinkPipInstall
 │       │               └── <wheel name> -> pip-20.1.1-py2.py3-none-any
 │       └── embed
-│           └── 2 -> json format versioning
+│           └── 3 -> json format versioning
 │               └── *.json -> for every distribution contains data about newer embed versions and releases
 └─── unzip <in zip app we cannot refer to some internal files, so first extract them>
      └── <virtualenv version>
@@ -101,7 +101,7 @@ class AppDataDiskFolder(AppData):
                             filename.unlink()
 
     def embed_update_log(self, distribution, for_py_version):
-        return EmbedDistributionUpdateStoreDisk(self.lock / "wheel" / for_py_version / "embed" / "2", distribution)
+        return EmbedDistributionUpdateStoreDisk(self.lock / "wheel" / for_py_version / "embed" / "3", distribution)
 
     @property
     def house(self):

--- a/src/virtualenv/seed/wheels/acquire.py
+++ b/src/virtualenv/seed/wheels/acquire.py
@@ -10,6 +10,7 @@ from virtualenv.util.six import ensure_str
 from virtualenv.util.subprocess import Popen, subprocess
 
 from .bundle import from_bundle
+from .periodic_update import add_wheel_to_update_log
 from .util import Version, Wheel, discover_wheels
 
 
@@ -35,6 +36,8 @@ def get_wheel(distribution, version, for_py_version, search_dirs, download, app_
             to_folder=app_data.house,
             env=env,
         )
+        if wheel is not None and app_data.can_update:
+            add_wheel_to_update_log(wheel, for_py_version, app_data)
 
     return wheel
 

--- a/tests/unit/seed/wheels/test_acquire.py
+++ b/tests/unit/seed/wheels/test_acquire.py
@@ -2,14 +2,23 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import sys
+from datetime import datetime
 from subprocess import CalledProcessError
 
 import pytest
 
+from virtualenv.app_data import AppDataDiskFolder
+from virtualenv.info import IS_PYPY, PY2
 from virtualenv.seed.wheels.acquire import download_wheel, get_wheel, pip_wheel_env_run
 from virtualenv.seed.wheels.embed import BUNDLE_FOLDER, get_embed_wheel
+from virtualenv.seed.wheels.periodic_update import dump_datetime
 from virtualenv.seed.wheels.util import Wheel, discover_wheels
 from virtualenv.util.path import Path
+
+
+@pytest.fixture(autouse=True)
+def fake_release_date(mocker):
+    mocker.patch("virtualenv.seed.wheels.periodic_update.release_date_for_wheel_path", return_value=None)
 
 
 def test_pip_wheel_env_run_could_not_find(session_app_data, mocker):
@@ -74,24 +83,64 @@ def test_download_fails(mocker, for_py_version, session_app_data):
 @pytest.fixture
 def downloaded_wheel(mocker):
     wheel = Wheel.from_path(Path("setuptools-0.0.0-py2.py3-none-any.whl"))
-    mocker.patch("virtualenv.seed.wheels.acquire.download_wheel", return_value=wheel)
-    yield wheel
+    yield wheel, mocker.patch("virtualenv.seed.wheels.acquire.download_wheel", return_value=wheel)
 
 
 @pytest.mark.parametrize("version", ["bundle", "0.0.0"])
-def test_get_wheel_download_called(for_py_version, session_app_data, downloaded_wheel, version):
+def test_get_wheel_download_called(mocker, for_py_version, session_app_data, downloaded_wheel, version):
     distribution = "setuptools"
+    write = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.write")
     wheel = get_wheel(distribution, version, for_py_version, [], True, session_app_data, False, os.environ)
     assert wheel is not None
-    assert wheel.name == downloaded_wheel.name
+    assert wheel.name == downloaded_wheel[0].name
+    assert downloaded_wheel[1].call_count == 1
+    assert write.call_count == 1
 
 
 @pytest.mark.parametrize("version", ["embed", "pinned"])
-def test_get_wheel_download_not_called(for_py_version, session_app_data, downloaded_wheel, version):
+def test_get_wheel_download_not_called(mocker, for_py_version, session_app_data, downloaded_wheel, version):
     distribution = "setuptools"
     expected = get_embed_wheel(distribution, for_py_version)
     if version == "pinned":
         version = expected.version
+    write = mocker.patch("virtualenv.app_data.via_disk_folder.JSONStoreDisk.write")
     wheel = get_wheel(distribution, version, for_py_version, [], True, session_app_data, False, os.environ)
     assert wheel is not None
     assert wheel.name == expected.name
+    assert downloaded_wheel[1].call_count == 0
+    assert write.call_count == 0
+
+
+@pytest.mark.skipif(IS_PYPY and PY2, reason="mocker.spy failing on PyPy 2.x")
+def test_get_wheel_download_cached(tmp_path, freezer, mocker, for_py_version, downloaded_wheel):
+    from virtualenv.app_data.via_disk_folder import JSONStoreDisk
+
+    app_data = AppDataDiskFolder(folder=str(tmp_path))
+    expected = downloaded_wheel[0]
+    write = mocker.spy(JSONStoreDisk, "write")
+    # 1st call, not cached, download is called
+    wheel = get_wheel(expected.distribution, expected.version, for_py_version, [], True, app_data, False, os.environ)
+    assert wheel is not None
+    assert wheel.name == expected.name
+    assert downloaded_wheel[1].call_count == 1
+    assert write.call_count == 1
+    # 2nd call, cached, download is not called
+    wheel = get_wheel(expected.distribution, expected.version, for_py_version, [], True, app_data, False, os.environ)
+    assert wheel is not None
+    assert wheel.name == expected.name
+    assert downloaded_wheel[1].call_count == 1
+    assert write.call_count == 1
+    wrote_json = write.call_args[0][1]
+    assert wrote_json == {
+        "completed": None,
+        "periodic": None,
+        "started": None,
+        "versions": [
+            {
+                "filename": expected.name,
+                "release_date": None,
+                "found_date": dump_datetime(datetime.now()),
+                "source": "download",
+            },
+        ],
+    }

--- a/tests/unit/seed/wheels/test_periodic_update.py
+++ b/tests/unit/seed/wheels/test_periodic_update.py
@@ -606,7 +606,7 @@ def test_download_periodic_stop_at_first_usable(tmp_path, mocker, freezer):
     assert write.call_count == 1
 
 
-def test_download_periodic_stop_at_first_usable2(tmp_path, mocker, freezer):
+def test_download_periodic_stop_at_first_usable_with_previous_minor(tmp_path, mocker, freezer):
     freezer.move_to(_UP_NOW)
     wheel = get_embed_wheel("pip", "3.9")
     app_data_outer = AppDataDiskFolder(str(tmp_path / "app"))


### PR DESCRIPTION
Add downloaded wheel information in the relevant JSON embed file to prevent additional downloads of the same wheel.

This requires to bump the JSON embed file version once again as I was lacking some tests cases in #2273.

I will add some inline comments for some choices that I made.

Fixes #2268

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
