### PR TITLE
use the workflow as part of the concurrency group

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 8 * * *"
 
 concurrency:
-  group: check-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
apparently this fixes the set of `[cancelled]` statuses from the primary branch run when a release PR is opened
