### PR TITLE
use importlib_metadata instead of importlib.metadata for python<3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     filelock>=3.2,<4
     platformdirs>=2,<3
     six>=1.9.0,<2   # keep it >=1.9.0 as it may cause problems on LTS platforms
-    importlib-metadata>=0.12;python_version<"3.8"
+    importlib-metadata>=0.12;python_version<"3.10"
     importlib-resources>=1.0;python_version<"3.7"
     pathlib2>=2.3.3,<3;python_version < '3.4' and sys.platform != 'win32'
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*

--- a/src/virtualenv/run/plugin/base.py
+++ b/src/virtualenv/run/plugin/base.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import sys
 from collections import OrderedDict
 
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
 
     importlib_metadata_version = ()

--- a/tasks/__main__zipapp.py
+++ b/tasks/__main__zipapp.py
@@ -92,7 +92,7 @@ _VER_DISTRIBUTION_CLASS = None
 def versioned_distribution_class():
     global _VER_DISTRIBUTION_CLASS
     if _VER_DISTRIBUTION_CLASS is None:
-        if sys.version_info >= (3, 8):
+        if sys.version_info >= (3, 10):
             # noinspection PyCompatibility
             from importlib.metadata import Distribution
         else:


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

This PR is pretty minimal and is meant to address https://github.com/pypa/virtualenv/issues/2303
`importlib.metadata` does not provide unique results for `entry_points` when duplicate packages are found until python >= 3.10. To allow local installation of virtualenv to superseed global installations, we need to use `importlib_metadata` instead. 


- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
