### PR TITLE
fix 20ms startup penalty added by virtualenv

### DIFF
--- a/docs/changelog/2317.bugfix.rst
+++ b/docs/changelog/2317.bugfix.rst
@@ -1,0 +1,1 @@
+Improve performance of python startup inside created virtualenvs - by :user:`asottile`.

--- a/docs/changelog/examples.rst
+++ b/docs/changelog/examples.rst
@@ -2,17 +2,17 @@
 
 file ``544.doc.rst``::
 
-    explain everything much better - by ``passionate_technicalwriter``
+    explain everything much better - by :user:`passionate_technicalwriter`.
 
 file ``544.feature.rst``::
 
-    ``tox --version`` now shows information about all registered plugins - by ``obestwalter``
+    ``tox --version`` now shows information about all registered plugins - by :user:`obestwalter`.
 
 
 file ``571.bugfix.rst``::
 
     ``skip_install`` overrides ``usedevelop`` (``usedevelop`` is an option to choose the
     installation type if the package is installed and ``skip_install`` determines if it should be
-    installed at all) - by ``ferdonline``
+    installed at all) - by :user:`ferdonline`.
 
 .. see pyproject.toml for all available categories

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -37,11 +37,8 @@ def patch_dist(dist):
 _DISTUTILS_PATCH = "distutils.dist", "setuptools.dist"
 if sys.version_info > (3, 4):
     # https://docs.python.org/3/library/importlib.html#setting-up-an-importer
-    from functools import partial
-    from importlib.abc import MetaPathFinder
-    from importlib.util import find_spec
 
-    class _Finder(MetaPathFinder):
+    class _Finder:
         """A meta path finder that allows patching the imported distutils modules"""
 
         fullname = None
@@ -64,6 +61,9 @@ if sys.version_info > (3, 4):
                     # - that every thread will use - into .lock[0].
                     # https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe
                     self.lock.append(lock)
+
+                from functools import partial
+                from importlib.util import find_spec
 
                 with self.lock[0]:
                     self.fullname = fullname


### PR DESCRIPTION
before:

```console
$ rm -rf vvv; virtualenv vvv -ppython3.10; time vvv/bin/python3 -c ''; time vvv/bin/python3 -c ''
created virtual environment CPython3.10.2.final.0-64 in 712ms
  creator CPython3Posix(dest=/tmp/virtualenv/vvv, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/asottile/.local/share/virtualenv)
    added seed packages: pip==22.0.4, setuptools==60.9.3, wheel==0.37.1
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

real	0m0.037s
user	0m0.037s
sys	0m0.000s

real	0m0.032s
user	0m0.031s
sys	0m0.000s
```

after:

```console
$ rm -rf vvv; virtualenv vvv -ppython3.10; time vvv/bin/python3 -c ''; time vvv/bin/python3 -c ''
created virtual environment CPython3.10.2.final.0-64 in 677ms
  creator CPython3Posix(dest=/tmp/virtualenv/vvv, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/asottile/.local/share/virtualenv)
    added seed packages: pip==22.0.4, setuptools==60.9.3, wheel==0.37.1
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

real	0m0.022s
user	0m0.022s
sys	0m0.000s

real	0m0.015s
user	0m0.015s
sys	0m0.000s
```

just to confirm the hack still works as well:

```console
$ vvv/bin/python3 -c 'import distutils.dist; print(distutils.dist.Distribution.parse_config_files.__module__)'
_virtualenv
```

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix  (**N/A**)
- [x] added news fragment in ``docs/changelog`` folder
- [x] updated/extended the documentation (**N/A**)
