### PR TITLE
Update Nushell activation scripts to 0.60

### DIFF
--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -1,41 +1,93 @@
-# Setting all environment variables for the venv
-let path-name = (if ((sys).host.name == "Windows") { "Path" } { "PATH" })
-let virtual-env = "__VIRTUAL_ENV__"
-let bin = "__BIN_NAME__"
-let path-sep = "__PATH_SEP__"
+# This command prepares the required environment variables
+def-env activate-virtualenv [] {
+    def is-string [x] {
+        ($x | describe) == "string"
+    }
 
-let old-path = ($nu.path | str collect ($path-sep))
+    def has-env [name: string] {
+        $name in (env).name
+    }
 
-let venv-path = ([$virtual-env $bin] | path join)
-let new-path = ($nu.path | prepend $venv-path | str collect ($path-sep))
+    let is-windows = ((sys).host.name | str downcase) == "windows"
+    let virtual-env = "__VIRTUAL_ENV__"
+    let bin = "__BIN_NAME__"
+    let path-sep = "__PATH_SEP__"
+    let path-name = if $is-windows {
+        "Path"
+    } else {
+        "PATH"
+    }
 
-# environment variables that will be batched loaded to the virtual env
-let new-env = ([
-    [name, value];
-    [$path-name $new-path]
-    [_OLD_VIRTUAL_PATH $old-path]
-    [VIRTUAL_ENV $virtual-env]
-])
+    let old-path = (
+        if $is-windows {
+            $env.Path
+        } else {
+            $env.PATH
+        } | if (is-string $in) {
+            # if Path/PATH is a string, make it a list
+            $in | split row $path-sep | path expand
+        } else {
+            $in
+        }
+    )
 
-load-env $new-env
+    let venv-path = ([$virtual-env $bin] | path join)
+    let new-path = ($old-path | prepend $venv-path)
 
-# Creating the new prompt for the session
-let virtual_prompt = (if ("__VIRTUAL_PROMPT__" != "") {
-    "(__VIRTUAL_PROMPT__) "
-} {
-    (build-string '(' ($virtual-env | path basename) ') ')
+    # Creating the new prompt for the session
+    let virtual-prompt = (
+        if ("__VIRTUAL_PROMPT__" == "") {
+            $"(char lparen)($virtual-env | path basename)(char rparen)"
+        } else {
+            "(__VIRTUAL_PROMPT__) "
+        }
+    )
+
+    # Back up the old prompt builder
+    let old-prompt-command = if (has-env "VIRTUAL_ENV") {
+        $env._OLD_PROMPT_COMMAND
+    } else {
+        if (has-env "PROMPT_COMMAND") {
+            $env.PROMPT_COMMAND
+        } else {
+            ""
+        }
+    }
+
+    # If there is no default prompt, then only the env is printed in the prompt
+    let new-prompt = if (has-env "PROMPT_COMMAND") {
+        ($"build-string '($virtual-prompt)' (config get prompt | str find-replace "build-string" "")")
+        #TODO: Check for block vs string!
+        if ($env.PROMPT_COMMAND | describe) == "block" {
+            { $"($virtual-prompt)(do $env.PROMPT_COMMAND)" }
+        } else {
+            { $"($virtual-prompt)($env.PROMPT_COMMAND)" }
+        }
+    } else {
+        { $"($virtual-prompt)" }
+    }
+
+    # Environment variables that will be batched loaded to the virtual env
+    let new-env = {
+        $path-name          : $new-path
+        _OLD_VIRTUAL_PATH   : $old-path
+        VIRTUAL_ENV         : $virtual-env
+        _OLD_PROMPT_COMMAND : $old-prompt-command
+        PROMPT_COMMAND      : $new-prompt
+        VIRTUAL_PROMPT      : $virtual-prompt
+    }
+
+    # Activate the environment variables
+    load-env $new-env
 }
-)
 
-# If there is no default prompt, then only the env is printed in the prompt
-let new_prompt = (if ( config | select prompt | empty? ) {
-    ($"build-string '($virtual_prompt)'")
-} {
-    ($"build-string '($virtual_prompt)' (config get prompt | str find-replace "build-string" "")")
-})
-let-env PROMPT_COMMAND = $new_prompt
+def pydoc [] {
+    python -m pydoc
+}
 
-# We are using alias as the function definitions because only aliases can be
-# removed from the scope
-alias pydoc = python -m pydoc
-alias deactivate = source "__DEACTIVATE_PATH__"
+def-env deactivate [] {
+    source "__DEACTIVATE_PATH__"
+}
+
+# Activate the virtualenv
+activate-virtualenv

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -20,7 +20,11 @@ def-env activate-virtualenv [] {
 
     let old-path = (
         if $is-windows {
-            $env.Path
+            if (has-env "Path") {
+                $env.Path
+            } else {
+                $env.PATH
+            }
         } else {
             $env.PATH
         } | if (is-string $in) {
@@ -68,7 +72,7 @@ def-env activate-virtualenv [] {
     # Environment variables that will be batched loaded to the virtual env
     let new-env = {
         $path-name          : $new-path
-        _OLD_VIRTUAL_PATH   : $old-path
+        _OLD_VIRTUAL_PATH   : ($old-path | str collect $path-sep)
         VIRTUAL_ENV         : $virtual-env
         _OLD_PROMPT_COMMAND : $old-prompt-command
         PROMPT_COMMAND      : $new-prompt

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -43,16 +43,14 @@ def-env activate-virtualenv [] {
     let new-path = ($old-path | prepend $venv-path | str collect $path-sep)
 
     # Creating the new prompt for the session
-    let virtual-prompt = (
-        if ("__VIRTUAL_PROMPT__" == "") {
-            $"(char lparen)($virtual-env | path basename)(char rparen) "
-        } else {
-            "(__VIRTUAL_PROMPT__) "
-        }
-    )
+    let virtual-prompt = if ("__VIRTUAL_PROMPT__" == "") {
+        $"(char lparen)($virtual-env | path basename)(char rparen) "
+    } else {
+        "(__VIRTUAL_PROMPT__) "
+    }
 
     # Back up the old prompt builder
-    let old-prompt-command = if (has-env "VIRTUAL_ENV") {
+    let old-prompt-command = if (has-env "VIRTUAL_ENV") && (has-env "_OLD_PROMPT_COMMAND") {
         $env._OLD_PROMPT_COMMAND
     } else {
         if (has-env "PROMPT_COMMAND") {
@@ -64,10 +62,10 @@ def-env activate-virtualenv [] {
 
     # If there is no default prompt, then only the env is printed in the prompt
     let new-prompt = if (has-env "PROMPT_COMMAND") {
-        if ($env._OLD_PROMPT_COMMAND | describe) == "block" {
-            { $"($virtual-prompt)(do $env._OLD_PROMPT_COMMAND)" }
+        if ($old-prompt-command | describe) == "block" {
+            { $"($virtual-prompt)(do $old-prompt-command)" }
         } else {
-            { $"($virtual-prompt)($env._OLD_PROMPT_COMMAND)" }
+            { $"($virtual-prompt)($old-prompt-command)" }
         }
     } else {
         { $"($virtual-prompt)" }
@@ -76,8 +74,8 @@ def-env activate-virtualenv [] {
     # Environment variables that will be batched loaded to the virtual env
     let new-env = {
         $path-name          : $new-path
-        _OLD_VIRTUAL_PATH   : ($old-path | str collect $path-sep)
         VIRTUAL_ENV         : $virtual-env
+        _OLD_VIRTUAL_PATH   : ($old-path | str collect $path-sep)
         _OLD_PROMPT_COMMAND : $old-prompt-command
         PROMPT_COMMAND      : $new-prompt
         VIRTUAL_PROMPT      : $virtual-prompt

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -56,7 +56,6 @@ def-env activate-virtualenv [] {
 
     # If there is no default prompt, then only the env is printed in the prompt
     let new-prompt = if (has-env "PROMPT_COMMAND") {
-        #TODO: Check for block vs string!
         if ($env.PROMPT_COMMAND | describe) == "block" {
             { $"($virtual-prompt)(do $env.PROMPT_COMMAND)" }
         } else {

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -1,30 +1,30 @@
 # This command prepares the required environment variables
 def-env activate-virtualenv [] {
     def is-string [x] {
-        ($x | describe) == "string"
+        ($x | describe) == 'string'
     }
 
     def has-env [name: string] {
         $name in (env).name
     }
 
-    let is-windows = ((sys).host.name | str downcase) == "windows"
-    let virtual-env = "__VIRTUAL_ENV__"
-    let bin = "__BIN_NAME__"
-    let path-sep = "__PATH_SEP__"
+    let is-windows = ((sys).host.name | str downcase) == 'windows'
+    let virtual-env = '__VIRTUAL_ENV__'
+    let bin = '__BIN_NAME__'
+    let path-sep = '__PATH_SEP__'
     let path-name = if $is-windows {
-        if (has-env "Path") {
-            "Path"
+        if (has-env 'Path') {
+            'Path'
         } else {
-            "PATH"
+            'PATH'
         }
     } else {
-        "PATH"
+        'PATH'
     }
 
     let old-path = (
         if $is-windows {
-            if (has-env "Path") {
+            if (has-env 'Path') {
                 $env.Path
             } else {
                 $env.PATH
@@ -43,32 +43,32 @@ def-env activate-virtualenv [] {
     let new-path = ($old-path | prepend $venv-path | str collect $path-sep)
 
     # Creating the new prompt for the session
-    let virtual-prompt = if ("__VIRTUAL_PROMPT__" == "") {
-        $"(char lparen)($virtual-env | path basename)(char rparen) "
+    let virtual-prompt = if ('__VIRTUAL_PROMPT__' == '') {
+        $'(char lparen)($virtual-env | path basename)(char rparen) '
     } else {
-        "(__VIRTUAL_PROMPT__) "
+        '(__VIRTUAL_PROMPT__) '
     }
 
     # Back up the old prompt builder
-    let old-prompt-command = if (has-env "VIRTUAL_ENV") && (has-env "_OLD_PROMPT_COMMAND") {
+    let old-prompt-command = if (has-env 'VIRTUAL_ENV') && (has-env '_OLD_PROMPT_COMMAND') {
         $env._OLD_PROMPT_COMMAND
     } else {
-        if (has-env "PROMPT_COMMAND") {
+        if (has-env 'PROMPT_COMMAND') {
             $env.PROMPT_COMMAND
         } else {
-            ""
+            ''
         }
     }
 
     # If there is no default prompt, then only the env is printed in the prompt
-    let new-prompt = if (has-env "PROMPT_COMMAND") {
-        if ($old-prompt-command | describe) == "block" {
-            { $"($virtual-prompt)(do $old-prompt-command)" }
+    let new-prompt = if (has-env 'PROMPT_COMMAND') {
+        if ($old-prompt-command | describe) == 'block' {
+            { $'($virtual-prompt)(do $old-prompt-command)' }
         } else {
-            { $"($virtual-prompt)($old-prompt-command)" }
+            { $'($virtual-prompt)($old-prompt-command)' }
         }
     } else {
-        { $"($virtual-prompt)" }
+        { $'($virtual-prompt)' }
     }
 
     # Environment variables that will be batched loaded to the virtual env
@@ -89,4 +89,4 @@ def-env activate-virtualenv [] {
 activate-virtualenv
 
 alias pydoc = python -m pydoc
-alias deactivate = source "__DEACTIVATE_PATH__"
+alias deactivate = source '__DEACTIVATE_PATH__'

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -32,7 +32,7 @@ def-env activate-virtualenv [] {
     )
 
     let venv-path = ([$virtual-env $bin] | path join)
-    let new-path = ($old-path | prepend $venv-path)
+    let new-path = ($old-path | prepend $venv-path | str collect $path-sep)
 
     # Creating the new prompt for the session
     let virtual-prompt = (
@@ -57,9 +57,9 @@ def-env activate-virtualenv [] {
     # If there is no default prompt, then only the env is printed in the prompt
     let new-prompt = if (has-env "PROMPT_COMMAND") {
         if ($env.PROMPT_COMMAND | describe) == "block" {
-            { $"($virtual-prompt)(do $env.PROMPT_COMMAND)" }
+            { $"($virtual-prompt)(do $env._OLD_PROMPT_COMMAND)" }
         } else {
-            { $"($virtual-prompt)($env.PROMPT_COMMAND)" }
+            { $"($virtual-prompt)($env._OLD_PROMPT_COMMAND)" }
         }
     } else {
         { $"($virtual-prompt)" }

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -13,7 +13,11 @@ def-env activate-virtualenv [] {
     let bin = "__BIN_NAME__"
     let path-sep = "__PATH_SEP__"
     let path-name = if $is-windows {
-        "Path"
+        if (has-env "Path") {
+            "Path"
+        } else {
+            "PATH"
+        }
     } else {
         "PATH"
     }

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -37,7 +37,7 @@ def-env activate-virtualenv [] {
     # Creating the new prompt for the session
     let virtual-prompt = (
         if ("__VIRTUAL_PROMPT__" == "") {
-            $"(char lparen)($virtual-env | path basename)(char rparen)"
+            $"(char lparen)($virtual-env | path basename)(char rparen) "
         } else {
             "(__VIRTUAL_PROMPT__) "
         }
@@ -56,7 +56,7 @@ def-env activate-virtualenv [] {
 
     # If there is no default prompt, then only the env is printed in the prompt
     let new-prompt = if (has-env "PROMPT_COMMAND") {
-        if ($env.PROMPT_COMMAND | describe) == "block" {
+        if ($env._OLD_PROMPT_COMMAND | describe) == "block" {
             { $"($virtual-prompt)(do $env._OLD_PROMPT_COMMAND)" }
         } else {
             { $"($virtual-prompt)($env._OLD_PROMPT_COMMAND)" }

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -56,7 +56,6 @@ def-env activate-virtualenv [] {
 
     # If there is no default prompt, then only the env is printed in the prompt
     let new-prompt = if (has-env "PROMPT_COMMAND") {
-        ($"build-string '($virtual-prompt)' (config get prompt | str find-replace "build-string" "")")
         #TODO: Check for block vs string!
         if ($env.PROMPT_COMMAND | describe) == "block" {
             { $"($virtual-prompt)(do $env.PROMPT_COMMAND)" }

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -85,15 +85,8 @@ def-env activate-virtualenv [] {
     load-env $new-env
 }
 
-# def pydoc [] {
-#     python -m pydoc
-# }
-
 alias pydoc = python -m pydoc
-
-def-env deactivate [] {
-    source "__DEACTIVATE_PATH__"
-}
+alias deactivate = (source "__DEACTIVATE_PATH__")
 
 # Activate the virtualenv
 activate-virtualenv

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -81,9 +81,11 @@ def-env activate-virtualenv [] {
     load-env $new-env
 }
 
-def pydoc [] {
-    python -m pydoc
-}
+# def pydoc [] {
+#     python -m pydoc
+# }
+
+alias pydoc = python -m pydoc
 
 def-env deactivate [] {
     source "__DEACTIVATE_PATH__"

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -85,8 +85,8 @@ def-env activate-virtualenv [] {
     load-env $new-env
 }
 
-alias pydoc = python -m pydoc
-alias deactivate = (source "__DEACTIVATE_PATH__")
-
 # Activate the virtualenv
 activate-virtualenv
+
+alias pydoc = python -m pydoc
+alias deactivate = source "__DEACTIVATE_PATH__"

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -1,11 +1,22 @@
-# Setting the old path
-let path-name = (if ((sys).host.name == "Windows") { "Path" } { "PATH" })
-let-env $path-name = $nu.env._OLD_VIRTUAL_PATH
+def-env deactivate-virtualenv [] {
+    let is-windows = ((sys).host.name | str downcase) == "windows"
 
-# Unleting the environment variables that were created when activating the env
-unlet-env VIRTUAL_ENV
-unlet-env _OLD_VIRTUAL_PATH
-unlet-env PROMPT_COMMAND
+    let path-name = if $is-windows {
+        "Path"
+    } else {
+        "PATH"
+    }
 
-unalias pydoc
-unalias deactivate
+    load-env { $path-name : $env._OLD_VIRTUAL_PATH }
+
+    # Hiding the environment variables that were created when activating the env
+    hide _OLD_VIRTUAL_PATH
+    hide VIRTUAL_ENV
+    hide PROMPT_COMMAND
+    hide VIRTUAL_PROMPT
+}
+
+deactivate-virtualenv
+
+hide pydoc
+hide deactivate

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -27,5 +27,5 @@ def-env deactivate-virtualenv [] {
 
 deactivate-virtualenv
 
-# hide pydoc
+hide pydoc
 hide deactivate

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -1,8 +1,16 @@
 def-env deactivate-virtualenv [] {
+    def has-env [name: string] {
+        $name in (env).name
+    }
+
     let is-windows = ((sys).host.name | str downcase) == "windows"
 
     let path-name = if $is-windows {
-        "Path"
+        if (has-env "Path") {
+            "Path"
+        } else {
+            "PATH"
+        }
     } else {
         "PATH"
     }

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -28,5 +28,5 @@ def-env deactivate-virtualenv [] {
 
 deactivate-virtualenv
 
-hide pydoc
+# hide pydoc
 hide deactivate

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -28,5 +28,5 @@ def-env deactivate-virtualenv [] {
 
 deactivate-virtualenv
 
-# hide pydoc
+hide pydoc
 hide deactivate

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -17,11 +17,12 @@ def-env deactivate-virtualenv [] {
 
     load-env { $path-name : $env._OLD_VIRTUAL_PATH }
 
+    let-env PROMPT_COMMAND = $env._OLD_PROMPT_COMMAND
+
     # Hiding the environment variables that were created when activating the env
     hide _OLD_VIRTUAL_PATH
     hide _OLD_PROMPT_COMMAND
     hide VIRTUAL_ENV
-    hide PROMPT_COMMAND
     hide VIRTUAL_PROMPT
 }
 

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -18,5 +18,5 @@ def-env deactivate-virtualenv [] {
 
 deactivate-virtualenv
 
-hide pydoc
+# hide pydoc
 hide deactivate

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -3,16 +3,16 @@ def-env deactivate-virtualenv [] {
         $name in (env).name
     }
 
-    let is-windows = ((sys).host.name | str downcase) == "windows"
+    let is-windows = ((sys).host.name | str downcase) == 'windows'
 
     let path-name = if $is-windows {
-        if (has-env "Path") {
-            "Path"
+        if (has-env 'Path') {
+            'Path'
         } else {
-            "PATH"
+            'PATH'
         }
     } else {
-        "PATH"
+        'PATH'
     }
 
     load-env { $path-name : $env._OLD_VIRTUAL_PATH }

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -19,6 +19,7 @@ def-env deactivate-virtualenv [] {
 
     # Hiding the environment variables that were created when activating the env
     hide _OLD_VIRTUAL_PATH
+    hide _OLD_PROMPT_COMMAND
     hide VIRTUAL_ENV
     hide PROMPT_COMMAND
     hide VIRTUAL_PROMPT

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -24,6 +24,6 @@ def test_nushell(activation_tester_class, activation_tester):
             self.unix_line_ending = not IS_WIN
 
         def print_prompt(self):
-            return r"$'($env.VIRTUAL_PROMPT)(char nl)'"
+            return r"$env.VIRTUAL_PROMPT"
 
     activation_tester(Nushell)

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -24,6 +24,6 @@ def test_nushell(activation_tester_class, activation_tester):
             self.unix_line_ending = not IS_WIN
 
         def print_prompt(self):
-            return r"$'($env.VIRTUAL_PROMPT)(char space)'"
+            return r"$env.VIRTUAL_PROMPT"
 
     activation_tester(Nushell)

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -24,6 +24,6 @@ def test_nushell(activation_tester_class, activation_tester):
             self.unix_line_ending = not IS_WIN
 
         def print_prompt(self):
-            return r"echo $virtual_prompt; printf '\n'"
+            return r"$env.VIRTUAL_PROMPT; printf '\n'"
 
     activation_tester(Nushell)

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -24,6 +24,6 @@ def test_nushell(activation_tester_class, activation_tester):
             self.unix_line_ending = not IS_WIN
 
         def print_prompt(self):
-            return r"$env.VIRTUAL_PROMPT; printf '\n'"
+            return r"$'($env.VIRTUAL_PROMPT)(char nl)'"
 
     activation_tester(Nushell)

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -24,6 +24,6 @@ def test_nushell(activation_tester_class, activation_tester):
             self.unix_line_ending = not IS_WIN
 
         def print_prompt(self):
-            return r"$env.VIRTUAL_PROMPT"
+            return r"$'($env.VIRTUAL_PROMPT)(char space)'"
 
     activation_tester(Nushell)


### PR DESCRIPTION
New Nushell version was [just released](https://www.nushell.sh/blog/2022-03-22-nushell_0_60.html) with breaking changes.
This PR updates the activation scripts to the new version 0.60.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
