### PR TITLE
Support Python 2.7 framework-style distributions on macOS 12

### DIFF
--- a/docs/changelog/2284.feature.rst
+++ b/docs/changelog/2284.feature.rst
@@ -1,0 +1,1 @@
+Support for creating a virtual environment from a Python 2.7 framework on macOS 12 - by :user:`nickhutchinson`.


### PR DESCRIPTION
virtualenv's trick of adding a symlink to the base Python dylib (`/Library/Frameworks/Python.framework/Versions/2.7/Python`) in the virtualenv root, and rewriting the dependent dylib list of the `<virtualenv>/bin/python` binary with the path of this symlink, no longer works in macOS 12.

As of macOS 12, when <https://github.com/python/cpython/blob/v2.7.18/Modules/getpath.c> computes `sys.prefix`, it ends up resolving the symlink. The result is that `sys.prefix` points to the Python framework, e.g.  `/path/to/Python.framework/Versions/2.7` instead of at the virtualenv root.

To mitigate this, add a _copy_ of the Python dylib into the virtualenv instead of a symlink. To placate code signing (at least on Intel machines), add a symlink to the `Resources` dir so the `Info.plist` file is accessible.

Note that Apple's Python 2.7 distribution -- removed in macOS 12.3 but previously located at /System/Library/Frameworks/Python.framework -- behaved differently to the python.org builds. It appears to have incorporated custom patches to getpath.c to support virtualenv. See: <https://github.com/apple-oss-distributions/python/blob/python-170.80.2/2.7/fix/getpath.c.ed>.

Tested on macOS 12.3 on an Intel and M1 mac.

Fixes: #2284

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
