### PR TITLE
CI: Update actions and OSes, weekly cron job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
       - uses: pre-commit/action@v2.0.3
 
   test:
@@ -59,23 +59,23 @@ jobs:
           exit 1
         shell: bash
       - name: Setup python for tox
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.10"
       - name: Install tox
         run: python -m pip install tox
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Use local virtualenv for tox
         run: python -m pip install .
       - name: Install Python 2 for cross test
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "2.7"
       - name: Setup python for test ${{ matrix.py }}
         if: "!( startsWith(matrix.py,'brew@py') || endsWith(matrix.py, '-dev') )"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.py }}
       - name: Setup brew python for test ${{ matrix.py }}
@@ -108,7 +108,7 @@ jobs:
         run: import os; import sys; os.rename(".tox/.coverage.{}".format(os.environ['TOXENV']), ".tox/.coverage.{}-{}".format(os.environ['TOXENV'], sys.platform))
         shell: python
       - name: Upload coverage data
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-data
           path: ".tox/.coverage.*"
@@ -118,10 +118,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
       - name: Install tox
@@ -133,14 +133,14 @@ jobs:
       - name: Build package
         run: pyproject-build --wheel .
       - name: Download coverage data
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: coverage-data
           path: .tox
       - name: Combine and report coverage
         run: tox -e coverage
       - name: Upload HTML report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: html-report
           path: .tox/htmlcov
@@ -164,11 +164,11 @@ jobs:
           - { os: windows-2022, tox_env: readme }
           - { os: windows-2022, tox_env: docs }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Python "3.10"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.10"
       - name: Install tox
@@ -184,12 +184,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Setup python to build package
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.10"
       - name: Install https://pypi.org/project/build
         run: python -m pip install build
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Build sdist and wheel

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,11 +36,11 @@ jobs:
           - "2.7"
           - pypy-2.7
         os:
-          - ubuntu-20.04
-          - macos-10.15
-          - windows-2022
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         include:
-          - { os: macos-10.15, py: brew@py3 }
+          - { os: macos-latest, py: brew@py3 }
     steps:
       - name: Install OS dependencies
         run: |
@@ -152,8 +152,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
-          - windows-2022
+          - ubuntu-latest
+          - windows-latest
         tox_env:
           - dev
           - docs
@@ -161,8 +161,8 @@ jobs:
           - upgrade
           - zipapp
         exclude:
-          - { os: windows-2022, tox_env: readme }
-          - { os: windows-2022, tox_env: docs }
+          - { os: windows-latest, tox_env: readme }
+          - { os: windows-latest, tox_env: docs }
     steps:
       - uses: actions/checkout@v3
         with:
@@ -181,7 +181,7 @@ jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: [check, coverage, lint]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup python to build package
         uses: actions/setup-python@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 8 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
A bit of maintenance on the CI. This PR consists of 3 commits:

- _Update used actions to v3_
   Update the checkout, setup-python and upload-/download-artifact actions to v3

 - _Use the latest stable version of each OS_
   Use the latest stable version of Ubuntu, macOS and Windows. Currently those are Ubuntu 20.04, macOS 11 and Windows Server 2022, which means macOS is directly updated from 10.15 to 11, and all OS will be kept up to date.

   The scheduled cron job will catch any breaking changes due to changing environments (which aren't likely).
 - _Run cron job weekly (instead of daily)_
   Once a week is enough to catch changes in dependencies or the environment. Running this extensive CI daily is quite power intensive and thus has a large costs and environmental impact.