### PR TITLE
Use shlex.quote instead of deprecated pipes.quote

### DIFF
--- a/docs/changelog/2351.bugfix.rst
+++ b/docs/changelog/2351.bugfix.rst
@@ -1,0 +1,1 @@
+Use ``shlex.quote`` instead of deprecated ``pipes.quote`` in Python 3. - by :user:`frenzymadness`.

--- a/src/virtualenv/discovery/cached_py_info.py
+++ b/src/virtualenv/discovery/cached_py_info.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
-import pipes
 import sys
 from collections import OrderedDict
 
@@ -18,6 +17,11 @@ from virtualenv.info import PY2
 from virtualenv.util.path import Path
 from virtualenv.util.six import ensure_text
 from virtualenv.util.subprocess import Popen, subprocess
+
+if PY2:
+    from pipes import quote
+else:
+    from shlex import quote
 
 _CACHE = OrderedDict()
 _CACHE[Path(sys.executable)] = PythonInfo()
@@ -126,7 +130,7 @@ class LogCmd(object):
         def e(v):
             return v.decode("utf-8") if isinstance(v, bytes) else v
 
-        cmd_repr = e(" ").join(pipes.quote(e(c)) for c in self.cmd)
+        cmd_repr = e(" ").join(quote(e(c)) for c in self.cmd)
         if self.env is not None:
             cmd_repr += e(" env of {!r}").format(self.env)
         if PY2:

--- a/tasks/make_zipapp.py
+++ b/tasks/make_zipapp.py
@@ -3,7 +3,6 @@ import argparse
 import io
 import json
 import os
-import pipes
 import shutil
 import subprocess
 import sys
@@ -17,6 +16,11 @@ from tempfile import TemporaryDirectory
 
 from packaging.markers import Marker
 from packaging.requirements import Requirement
+
+if sys.version_info[0] == 2:
+    from pipes import quote
+else:
+    from shlex import quote
 
 HERE = Path(__file__).parent.absolute()
 
@@ -227,7 +231,7 @@ def run_suppress_output(cmd, stop_print_on_fail=False):
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     out, err = process.communicate()
     if stop_print_on_fail and process.returncode != 0:
-        print("exit with {} of {}".format(process.returncode, " ".join(pipes.quote(i) for i in cmd)), file=sys.stdout)
+        print("exit with {} of {}".format(process.returncode, " ".join(quote(i) for i in cmd)), file=sys.stdout)
         if out:
             print(out, file=sys.stdout)
         if err:

--- a/tests/unit/activation/conftest.py
+++ b/tests/unit/activation/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import pipes
 import re
 import shutil
 import subprocess
@@ -11,11 +10,16 @@ from os.path import dirname, normcase
 import pytest
 import six
 
-from virtualenv.info import IS_PYPY, WIN_CPYTHON_2
+from virtualenv.info import IS_PYPY, PY2, WIN_CPYTHON_2
 from virtualenv.run import cli_run
 from virtualenv.util.path import Path
 from virtualenv.util.six import ensure_str, ensure_text
 from virtualenv.util.subprocess import Popen
+
+if PY2:
+    from pipes import quote
+else:
+    from shlex import quote
 
 
 class ActivationTester(object):
@@ -157,7 +161,7 @@ class ActivationTester(object):
         assert out[-1] == "None", raw
 
     def quote(self, s):
-        return pipes.quote(s)
+        return quote(s)
 
     def python_cmd(self, cmd):
         return "{} -c {}".format(os.path.basename(sys.executable), self.quote(cmd))

--- a/tests/unit/activation/test_batch.py
+++ b/tests/unit/activation/test_batch.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
-import pipes
-
 from virtualenv.activation import BatchActivator
+from virtualenv.info import PY2
+
+if PY2:
+    from pipes import quote
+else:
+    from shlex import quote
 
 
 def test_batch(activation_tester_class, activation_tester, tmp_path, activation_python):
@@ -25,7 +29,7 @@ def test_batch(activation_tester_class, activation_tester, tmp_path, activation_
 
         def quote(self, s):
             """double quotes needs to be single, and single need to be double"""
-            return "".join(("'" if c == '"' else ('"' if c == "'" else c)) for c in pipes.quote(s))
+            return "".join(("'" if c == '"' else ('"' if c == "'" else c)) for c in quote(s))
 
         def print_prompt(self):
             return "echo %PROMPT%"

--- a/tests/unit/activation/test_powershell.py
+++ b/tests/unit/activation/test_powershell.py
@@ -1,11 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
-import pipes
 import sys
 
 import pytest
 
 from virtualenv.activation import PowerShellActivator
+from virtualenv.info import PY2
+
+if PY2:
+    from pipes import quote
+else:
+    from shlex import quote
 
 
 @pytest.mark.slow
@@ -23,7 +28,7 @@ def test_powershell(activation_tester_class, activation_tester, monkeypatch):
 
         def quote(self, s):
             """powershell double double quote needed for quotes within single quotes"""
-            return pipes.quote(s).replace('"', '""')
+            return quote(s).replace('"', '""')
 
         def _get_test_lines(self, activate_script):
             # for BATCH utf-8 support need change the character code page to 650001


### PR DESCRIPTION
pipes module is deprecated in Py 3.11 and will be removed in 3.13.
https://docs.python.org/3.11/whatsnew/3.11.html

This is an implementation detail so I believe that it does not need a changelog entry.

- [x] ran the linter to address style issues (``tox -e fix_lint``)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
