### PR TITLE
Fix broken Nushell installation in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,10 +48,10 @@ jobs:
             echo "try $i" && \
             ${{ runner.os == 'Linux' && 'sudo apt-get update -y && sudo apt-get install snapd fish csh -y' || true }} && \
             ${{ runner.os == 'Linux' && 'sudo apt-get install curl wget -y' || true }} && \
-            ${{ runner.os == 'Linux' && 'nushell_url=$(curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep "browser_" | cut -d\" -f4 | grep .tar.gz)' || true }} && \
+            ${{ runner.os == 'Linux' && 'nushell_url=$(curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep "browser_" | grep "x86_64" | grep "linux" | grep "gnu" | cut -d\" -f4 )' || true }} && \
             ${{ runner.os == 'Linux' && 'wget -O nushell.tar.gz $nushell_url' || true }} && \
-            ${{ runner.os == 'Linux' && 'tar -zxf nushell.tar.gz --one-top-level=nushell --strip-components=2' || true }} && \
-            ${{ runner.os == 'Linux' && 'sudo cp nushell/nu /usr/bin' || true }} && \
+            ${{ runner.os == 'Linux' && 'tar -zxf nushell.tar.gz' || true }} && \
+            ${{ runner.os == 'Linux' && 'sudo cp nu /usr/bin' || true }} && \
             ${{ runner.os == 'Windows' && 'choco install nushell' || true }} && \
             ${{ runner.os == 'macOS' && 'brew update && brew install fish tcsh nushell' || true }} && \
             exit 0 || true;


### PR DESCRIPTION
Recently, we added a few more Linux build targets so the install script got confused.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
