### PR TITLE
docs: fix simple typo, developent -> development

### DIFF
--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
@@ -43,7 +43,7 @@ class PyPy3Posix(PyPy3, PosixSupports):
         for src in super(PyPy3Posix, cls).sources(interpreter):
             yield src
         # PyPy >= 3.8 supports a standard prefix installation, where older
-        # versions always used a portable/developent style installation.
+        # versions always used a portable/development style installation.
         # If this is a standard prefix installation, skip the below:
         if interpreter.system_prefix == "/usr":
             return


### PR DESCRIPTION
There is a small typo in src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py.

Should read `development` rather than `developent`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md