### PR TITLE
Fix test_py_info to work on Python 3.11 too

### DIFF
--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -346,7 +346,8 @@ def test_custom_venv_install_scheme_is_prefered(mocker):
         "venv": venv_scheme,
     }
     if getattr(sysconfig, "get_preferred_scheme", None):
-        sysconfig_install_schemes[sysconfig.get_preferred_scheme("prefix")] = default_scheme
+        # define the prefix as sysconfig.get_preferred_scheme did before 3.11
+        sysconfig_install_schemes["nt" if os.name == "nt" else "posix_prefix"] = default_scheme
 
     if sys.version_info[0] == 2:
         sysconfig_install_schemes = _stringify_schemes_dict(sysconfig_install_schemes)


### PR DESCRIPTION
The test failure is a result of BPO 45413.

Fixes #2344

cc @hroncok who added this test and made the [cpython change](https://github.com/python/cpython/pull/31034/files#diff-d593bd299ba58e440ba411ffa0640ccd9d20d518b0cf2644ed4bdb75a82a3e70) for [BPO 45413](https://bugs.python.org/issue45413).