### PR TITLE
Fix pull request template formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-### Thanks for contributing, make sure you address all the checklists (for details on how see
-
-[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!
+### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!
 
 - [ ] ran the linter to address style issues (`tox -e fix_lint`)
 - [ ] wrote descriptive pull request text


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

When making a PR to virtualenv, I personally found the default template formatting a bit confusing. This PR brings the development documentation link to the same line with the rest of the sentence which should make it more discoverable.
