### PR TITLE
When setting prefixes to empty strings, check the key names in addition to value

### DIFF
--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -136,7 +136,10 @@ class PythonInfo(object):
         if result is None:  # use sysconfig if sysconfig_scheme is set or distutils is unavailable
             # set prefixes to empty => result is relative from cwd
             prefixes = self.prefix, self.exec_prefix, self.base_prefix, self.base_exec_prefix
-            config_var = {k: "" if v in prefixes else v for k, v in self.sysconfig_vars.items()}
+            # Fedora-based distributions mangle the default value of some of those to /usr/local
+            # so we are extra careful here: we set them to empty based on value and key
+            prefix_vars = "prefix", "exec_prefix", "installed_base", "base", "installed_platbase", "platbase"
+            config_var = {k: "" if v in prefixes or k in prefix_vars else v for k, v in self.sysconfig_vars.items()}
             result = self.sysconfig_path(key, config_var=config_var).lstrip(os.sep)
         return result
 


### PR DESCRIPTION
In Fedora, we are currently trying to come up with a safe approach that
will make `sudo pip` and similar install to /usr/local rather than /usr.

After years of only patching distutils for this,
we need to adapt our change to use sysconfig.

In the past, we've tried to use a custom installation scheme,
but that has yielded many unexpected side effects for our users.

Now we try to set the defaults of {base} and {platbase} to /usr/local instead.
However, such value is not in the prefixes listed in this check in virtualenv.

Here, I adapted the code to be more robust for such changes:

 - if the value is listed in prefixes, we still set to empty
 - if the key is listed in prefix_vars, we now also set to empty

Let me know if this is acceptable to virtualenv. An alternative would be something like:

```python
if hasattr(sysconfig, 'extra_prefixes'):
    prefixes = prefixes + tuple(sysconfig.extra_prefixes)
```
Or:

```python
if hasattr(sys, 'insatllation_prefix'):
    prefixes = prefixes + (sys.insatllation_prefix,)
```

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

I plan to work on tests and docs after we agree on the best approach to fix this.