### PR TITLE
Remove universal wheel, python 2 is unsupported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,9 +107,6 @@ virtualenv.seed.wheels.embed = *.whl
 [sdist]
 formats = gztar
 
-[bdist_wheel]
-universal = true
-
 [tool:pytest]
 markers =
     slow


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
