### PR TITLE
Prefer an explicit list of Python versions

### DIFF
--- a/tasks/make_zipapp.py
+++ b/tasks/make_zipapp.py
@@ -20,7 +20,7 @@ from packaging.requirements import Requirement
 
 HERE = Path(__file__).parent.absolute()
 
-VERSIONS = [f"3.{i}" for i in range(10, 5, -1)]
+VERSIONS = ["3.11", "3.10", "3.9", "3.8", "3.7", "3.6"]
 
 
 def main():


### PR DESCRIPTION
Replacing the list comprehension with an
explicit enumeration of versions is easier to read.
It also helps ensure that all versions are listed
as the [f"3.{i}" for i in range(10, 5, -1)] was missing
version 3.11.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
