### PR TITLE
fix building python3.10 virtualenvs on debian derivatives

### DIFF
--- a/docs/changelog/2350.bugfix.rst
+++ b/docs/changelog/2350.bugfix.rst
@@ -1,0 +1,1 @@
+Fix selected scheme on debian derivatives for python 3.10 when ``python3-distutils`` is not installed or the ``venv`` scheme is not avaiable - by :user:`asottile`.

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import itertools
 import json
 import logging
@@ -370,6 +371,76 @@ def test_custom_venv_install_scheme_is_prefered(mocker):
     # to define all install schemes.
     mocker.patch("distutils.command.install.INSTALL_SCHEMES", distutils_schemes)
     mocker.patch("sysconfig._INSTALL_SCHEMES", sysconfig_install_schemes)
+
+    pyinfo = PythonInfo()
+    pyver = f"{pyinfo.version_info.major}.{pyinfo.version_info.minor}"
+    assert pyinfo.install_path("scripts") == "bin"
+    assert pyinfo.install_path("purelib").replace(os.sep, "/") == f"lib/python{pyver}/site-packages"
+
+
+@pytest.mark.skipif(sys.version_info[:2] != (3, 10), reason="3.10 specific")
+def test_uses_posix_prefix_on_debian_3_10_without_venv(mocker):
+    # this is taken from ubuntu 22.04 /usr/lib/python3.10/sysconfig.py
+    sysconfig_install_schemes = {
+        "posix_prefix": {
+            "stdlib": "{installed_base}/{platlibdir}/python{py_version_short}",
+            "platstdlib": "{platbase}/{platlibdir}/python{py_version_short}",
+            "purelib": "{base}/lib/python{py_version_short}/site-packages",
+            "platlib": "{platbase}/{platlibdir}/python{py_version_short}/site-packages",
+            "include": "{installed_base}/include/python{py_version_short}{abiflags}",
+            "platinclude": "{installed_platbase}/include/python{py_version_short}{abiflags}",
+            "scripts": "{base}/bin",
+            "data": "{base}",
+        },
+        "posix_home": {
+            "stdlib": "{installed_base}/lib/python",
+            "platstdlib": "{base}/lib/python",
+            "purelib": "{base}/lib/python",
+            "platlib": "{base}/lib/python",
+            "include": "{installed_base}/include/python",
+            "platinclude": "{installed_base}/include/python",
+            "scripts": "{base}/bin",
+            "data": "{base}",
+        },
+        "nt": {
+            "stdlib": "{installed_base}/Lib",
+            "platstdlib": "{base}/Lib",
+            "purelib": "{base}/Lib/site-packages",
+            "platlib": "{base}/Lib/site-packages",
+            "include": "{installed_base}/Include",
+            "platinclude": "{installed_base}/Include",
+            "scripts": "{base}/Scripts",
+            "data": "{base}",
+        },
+        "deb_system": {
+            "stdlib": "{installed_base}/{platlibdir}/python{py_version_short}",
+            "platstdlib": "{platbase}/{platlibdir}/python{py_version_short}",
+            "purelib": "{base}/lib/python3/dist-packages",
+            "platlib": "{platbase}/{platlibdir}/python3/dist-packages",
+            "include": "{installed_base}/include/python{py_version_short}{abiflags}",
+            "platinclude": "{installed_platbase}/include/python{py_version_short}{abiflags}",
+            "scripts": "{base}/bin",
+            "data": "{base}",
+        },
+        "posix_local": {
+            "stdlib": "{installed_base}/{platlibdir}/python{py_version_short}",
+            "platstdlib": "{platbase}/{platlibdir}/python{py_version_short}",
+            "purelib": "{base}/local/lib/python{py_version_short}/dist-packages",
+            "platlib": "{platbase}/local/lib/python{py_version_short}/dist-packages",
+            "include": "{installed_base}/local/include/python{py_version_short}{abiflags}",
+            "platinclude": "{installed_platbase}/local/include/python{py_version_short}{abiflags}",
+            "scripts": "{base}/local/bin",
+            "data": "{base}",
+        },
+    }
+    # reset the default in case we're on a system which doesn't have this problem
+    sysconfig_get_path = functools.partial(sysconfig.get_path, scheme="posix_local")
+
+    # make it look like python3-distutils is not available
+    mocker.patch.dict(sys.modules, {"distutils.command": None})
+    mocker.patch("sysconfig._INSTALL_SCHEMES", sysconfig_install_schemes)
+    mocker.patch("sysconfig.get_path", sysconfig_get_path)
+    mocker.patch("sysconfig.get_default_scheme", return_value="posix_local")
 
     pyinfo = PythonInfo()
     pyver = f"{pyinfo.version_info.major}.{pyinfo.version_info.minor}"


### PR DESCRIPTION
this fixes building a virtualenv when python3-distutils is not installed (or when not using the deadsnakes fork)

I tried unsuccessfully to get debian and ubuntu to patch this and I'm sick of getting reports in pre-commit about this 😭 

resolves #2340
resolves #2350

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix)
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation (**N/A**)
