### PR TITLE
Ensures activate.bat can handle Unicode contents

### DIFF
--- a/docs/changelog/2416.feature.rst
+++ b/docs/changelog/2416.feature.rst
@@ -1,0 +1,1 @@
+Ensures activate.bat can handle Unicode contents - by :user:`OmerFI`.

--- a/src/virtualenv/activation/batch/activate.bat
+++ b/src/virtualenv/activation/batch/activate.bat
@@ -1,3 +1,11 @@
+@REM This file is UTF-8 encoded, so we need to update the current code page while executing it
+@for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do @(
+    @set _OLD_CODEPAGE=%%a
+)
+@if defined _OLD_CODEPAGE (
+    "%SystemRoot%\System32\chcp.com" 65001 > nul
+)
+
 @set "VIRTUAL_ENV=__VIRTUAL_ENV__"
 
 @if defined _OLD_VIRTUAL_PROMPT (
@@ -35,3 +43,8 @@
 :ENDIFVPATH2
 
 @set "PATH=%VIRTUAL_ENV%\__BIN_NAME__;%PATH%"
+
+@if defined _OLD_CODEPAGE (
+    "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
+    @set _OLD_CODEPAGE=
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from virtualenv.app_data import AppDataDiskFolder
 from virtualenv.discovery.builtin import get_interpreter
 from virtualenv.discovery.py_info import PythonInfo
-from virtualenv.info import IS_WIN, fs_supports_symlink
+from virtualenv.info import fs_supports_symlink
 from virtualenv.report import LOGGER
 
 
@@ -294,7 +294,7 @@ def is_inside_ci():
 def special_char_name():
     base = "e-$ èрт🚒♞中片-j"
     # workaround for pypy3 https://bitbucket.org/pypy/pypy/issues/3147/venv-non-ascii-support-windows
-    encoding = "ascii" if IS_WIN else sys.getfilesystemencoding()
+    encoding = sys.getfilesystemencoding()
     # let's not include characters that the file system cannot encode)
     result = ""
     for char in base:

--- a/tests/unit/activation/test_batch.py
+++ b/tests/unit/activation/test_batch.py
@@ -21,8 +21,7 @@ def test_batch(activation_tester_class, activation_tester, tmp_path):
             self.unix_line_ending = False
 
         def _get_test_lines(self, activate_script):
-            # for BATCH utf-8 support need change the character code page to 650001
-            return ["@echo off", "", "chcp 65001 1>NUL"] + super()._get_test_lines(activate_script)
+            return ["@echo off", ""] + super()._get_test_lines(activate_script)
 
         def quote(self, s):
             """double quotes needs to be single, and single need to be double"""

--- a/tests/unit/activation/test_batch.py
+++ b/tests/unit/activation/test_batch.py
@@ -20,8 +20,31 @@ def test_batch(activation_tester_class, activation_tester, tmp_path):
             self.pydoc_call = f"call {self.pydoc_call}"
             self.unix_line_ending = False
 
+        def set_code_page_utf8(self):
+            return """
+            for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\\System32\\chcp.com"') do (
+                set _OLD_CODEPAGE=%%a
+            )
+            if defined _OLD_CODEPAGE (
+                "%SystemRoot%\\System32\\chcp.com" 65001 > nul
+            )
+            """.strip().splitlines()
+
+        def unset_code_page_utf8(self):
+            return """
+            if defined _OLD_CODEPAGE (
+                "%SystemRoot%\\System32\\chcp.com" %_OLD_CODEPAGE% > nul
+                set _OLD_CODEPAGE=
+            )
+            """.strip().splitlines()
+
         def _get_test_lines(self, activate_script):
-            return ["@echo off", ""] + super()._get_test_lines(activate_script)
+            return (
+                ["@echo off", ""]
+                + self.set_code_page_utf8()
+                + super()._get_test_lines(activate_script)
+                + self.unset_code_page_utf8()
+            )
 
         def quote(self, s):
             """double quotes needs to be single, and single need to be double"""


### PR DESCRIPTION
### activate.bat is UTF-8 encoded but uses current console codepage.

This issue was encountered first in [venv](https://docs.python.org/3/library/venv.html).
You can see the issue created for the venv module on: https://github.com/python/cpython/issues/76590
And the original pull request for the venv module: https://github.com/python/cpython/pull/5757

I just added some code that applies the [original PR](https://github.com/python/cpython/pull/5757) that is made for the venv module to solve this issue. The code I added is almost the same as the [original commit](https://github.com/python/cpython/pull/5757/files#diff-7c85d7383e780aa67d394c766ca77aa0e0b4988a1b042f56232fcd35ee0a7a91) except added `@` signs.

Closes #2414 