### PR TITLE
Fix test_csh when running with the original csh

### DIFF
--- a/docs/changelog/2418.bugfix.rst
+++ b/docs/changelog/2418.bugfix.rst
@@ -1,0 +1,1 @@
+Allow the test suite to pass even with the original C shell (rather than ``tcsh``) - by :user:`kulikjak`.

--- a/tests/unit/activation/test_csh.py
+++ b/tests/unit/activation/test_csh.py
@@ -7,6 +7,8 @@ def test_csh(activation_tester_class, activation_tester):
             super().__init__(CShellActivator, session, "csh", "activate.csh", "csh")
 
         def print_prompt(self):
-            return "echo 'source \"$VIRTUAL_ENV/bin/activate.csh\"; echo $prompt' | csh -i"
+            # Original csh doesn't print the last newline,
+            # breaking the test; hence the trailing echo.
+            return "echo 'source \"$VIRTUAL_ENV/bin/activate.csh\"; echo $prompt' | csh -i ; echo"
 
     activation_tester(Csh)


### PR DESCRIPTION
This fixes the issue with **test_csh** when running with the original `csh` rather than today widely used `tcsh`.

`tcsh` on Linux (`csh` is just a symlink to `tcsh`) or Solaris:
```shell
$ echo "echo 'test'" | tcsh -i
[me@mymachine ~]$ test
[me@mymachine ~]$ exit
$
```
and `csh` on Solaris:
```shell
$ echo "echo 'test'" | csh -i
mymachine-i386-25280% test
mymachine-i386-25280% $
```
By adding a forced newline to the prompt, we can be sure that at least one will be there, and thus the prompt won't 'leak' to the next line.

I am wondering whether it makes sense to add a similar **test_tcsh** test that would explicitly run `tcsh`. On Linux, it would do the same thing, but on platforms where both versions of the shell are available, it would test both.

Closes #2409 

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
