### PR TITLE
Change activation call to be a list of commands

### DIFF
--- a/docs/changelog/2424.feature.rst
+++ b/docs/changelog/2424.feature.rst
@@ -1,0 +1,1 @@
+Change shell test activation command to be a list of commands.

--- a/tests/unit/activation/conftest.py
+++ b/tests/unit/activation/conftest.py
@@ -161,7 +161,7 @@ class ActivationTester:
         return NotImplemented
 
     def activate_call(self, script):
-        cmd = " ".join([str(cmd) for cmd in self.activate_cmd])
+        cmd = " ".join([self.quote(str(cmd)) for cmd in self.activate_cmd])
         scr = self.quote(str(script))
         return f"{cmd} {scr}".strip()
 

--- a/tests/unit/activation/conftest.py
+++ b/tests/unit/activation/conftest.py
@@ -20,7 +20,7 @@ class ActivationTester:
         self._invoke_script = [cmd]
         self.activate_script = activate_script
         self.extension = extension
-        self.activate_cmd = "source"
+        self.activate_cmd = ["source"]
         self.deactivate = "deactivate"
         self.pydoc_call = "pydoc -w pydoc_test"
         self.script_encoding = "utf-8"
@@ -161,7 +161,7 @@ class ActivationTester:
         return NotImplemented
 
     def activate_call(self, script):
-        cmd = self.quote(str(self.activate_cmd))
+        cmd = " ".join([str(cmd) for cmd in self.activate_cmd])
         scr = self.quote(str(script))
         return f"{cmd} {scr}".strip()
 

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -18,4 +18,9 @@ def test_nushell(activation_tester_class, activation_tester):
         def print_prompt(self):
             return r"$env.VIRTUAL_PROMPT"
 
+        def activate_call(self, script):
+            cmd = " ".join([str(cmd) for cmd in self.activate_cmd])
+            scr = self.quote(str(script))
+            return f"{cmd} {scr}".strip()
+
     activation_tester(Nushell)


### PR DESCRIPTION
ActivationTester will use a list of strings as the command instead of just a string.

Required to proceed with https://github.com/pypa/virtualenv/pull/2422

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
