### PR TITLE
Remove outdated PyPy stdlib overrides

### DIFF
--- a/docs/changelog/2426.feature.rst
+++ b/docs/changelog/2426.feature.rst
@@ -1,1 +1,1 @@
-Drop support for PyPy3.6, PyPy3.7 which are no longer supported upstream.
+Drop unneeded shims for PyPy3 directory structure

--- a/docs/changelog/2426.feature.rst
+++ b/docs/changelog/2426.feature.rst
@@ -1,0 +1,1 @@
+Drop support for PyPy3.6, PyPy3.7 which are no longer supported upstream.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -89,7 +89,7 @@ Python and OS Compatibility
 virtualenv works with the following Python interpreter implementations:
 
 - `CPython <https://www.python.org/>`_ versions 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10
-- `PyPy <https://pypy.org/>`_ 2.7 and 3.5+.
+- `PyPy <https://pypy.org/>`_ 2.7, 3.6, 3.7, 3.8, 3.9
 
 This means virtualenv works on the latest patch version of each of these minor versions. Previous patch versions are
 supported on a best effort approach.

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
@@ -20,11 +20,6 @@ class PyPy3(PyPy, Python3Supports, metaclass=abc.ABCMeta):
 class PyPy3Posix(PyPy3, PosixSupports):
     """PyPy 3 on POSIX"""
 
-    @property
-    def stdlib(self):
-        """PyPy3 respects sysconfig only for the host python, virtual envs is instead lib/pythonx.y/site-packages"""
-        return self.dest / "lib" / f"pypy{self.interpreter.version_release_str}" / "site-packages"
-
     @classmethod
     def _shared_libs(cls, python_dir):
         # glob for libpypy3-c.so, libpypy3-c.dylib, libpypy3.9-c.so ...
@@ -63,18 +58,6 @@ class Pypy3Windows(PyPy3, WindowsSupports):
     @property
     def less_v37(self):
         return self.interpreter.version_info.minor < 7
-
-    @property
-    def stdlib(self):
-        """PyPy3 respects sysconfig only for the host python, virtual envs is instead Lib/site-packages"""
-        if self.less_v37:
-            return self.dest / "site-packages"
-        return self.dest / "Lib" / "site-packages"
-
-    @property
-    def bin_dir(self):
-        """PyPy3 needs to fallback to pypy definition"""
-        return self.dest / "Scripts"
 
     @classmethod
     def _shared_libs(cls, python_dir):


### PR DESCRIPTION
PyPy changed its layout in the 7.3.6 release (Oct 17, 2021) for pypy3.8+. Since PyPy3.7 and earlier are no longer supported upstream, remove the shims put into place to override sysconfig stdlib_path with a different layout.

Maybe too early for this PR if virtualenv wants to continue to support pypy3.6, pypy3.7?

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
