### PR TITLE
Allow empty string as version for `find_compatible_in_house`

### DIFF
--- a/docs/changelog/2429.bugfix.rst
+++ b/docs/changelog/2429.bugfix.rst
@@ -1,0 +1,1 @@
+Fix fallback handling of downloading wheels for bundled packages - by :user:`schaap`.

--- a/src/virtualenv/seed/wheels/acquire.py
+++ b/src/virtualenv/seed/wheels/acquire.py
@@ -83,7 +83,7 @@ def _find_downloaded_wheel(distribution, version_spec, for_py_version, to_folder
 def find_compatible_in_house(distribution, version_spec, for_py_version, in_folder):
     wheels = discover_wheels(in_folder, distribution, None, for_py_version)
     start, end = 0, len(wheels)
-    if version_spec is not None:
+    if version_spec is not None and version_spec != "":
         if version_spec.startswith("<"):
             from_pos, op = 1, lt
         elif version_spec.startswith("=="):

--- a/tests/unit/seed/wheels/test_acquire_find_wheel.py
+++ b/tests/unit/seed/wheels/test_acquire_find_wheel.py
@@ -4,8 +4,14 @@ from virtualenv.seed.wheels.acquire import find_compatible_in_house
 from virtualenv.seed.wheels.embed import BUNDLE_FOLDER, MAX, get_embed_wheel
 
 
-def test_find_latest(for_py_version):
+def test_find_latest_none(for_py_version):
     result = find_compatible_in_house("setuptools", None, for_py_version, BUNDLE_FOLDER)
+    expected = get_embed_wheel("setuptools", for_py_version)
+    assert result.path == expected.path
+
+
+def test_find_latest_string(for_py_version):
+    result = find_compatible_in_house("setuptools", "", for_py_version, BUNDLE_FOLDER)
     expected = get_embed_wheel("setuptools", for_py_version)
     assert result.path == expected.path
 


### PR DESCRIPTION
The empty string is used in several locations to indicate the newest version. Interpret it as such instead of rejecting it as invalid.

This resolves the problem as reported in issue [#2429](https://github.com/pypa/virtualenv/issues/2429), allowing virtualenv to correctly fall back on retrieving the newest wheel for bundled package that needed to be downloaded when the output of pip did not contain the package's location. See the issue for more details.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
