### PR TITLE
Replace six in tests/unit/test_run.py

### DIFF
--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-import six
 
 from virtualenv import __version__
 from virtualenv.run import cli_run, session_via_cli
@@ -22,10 +21,8 @@ def test_version(capsys):
         cli_run(args=["--version"])
     assert context.value.code == 0
 
-    out, err = capsys.readouterr()
-    extra = out if six.PY2 else err
-    content = out if six.PY3 else err
-    assert not extra
+    content, err = capsys.readouterr()
+    assert not err
 
     assert __version__ in content
     import virtualenv


### PR DESCRIPTION
six not in requirements since:
b85542c ("Drop support of running under Python 2.7 (#2382)", 2022-07-25)

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
