### PR TITLE
Set 'home' to parent directory of system_executable

### DIFF
--- a/docs/changelog/2440.bugfix.rst
+++ b/docs/changelog/2440.bugfix.rst
@@ -1,0 +1,1 @@
+Use parent directory of python executable for pyvenv.cfg "home" value per PEP 405 - by :user:`vfazio`.

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -157,7 +157,7 @@ class Creator(metaclass=ABCMeta):
 
     def set_pyenv_cfg(self):
         self.pyenv_cfg.content = OrderedDict()
-        self.pyenv_cfg["home"] = self.interpreter.system_exec_prefix
+        self.pyenv_cfg["home"] = os.path.dirname(os.path.abspath(self.interpreter.system_executable))
         self.pyenv_cfg["implementation"] = self.interpreter.implementation
         self.pyenv_cfg["version_info"] = ".".join(str(i) for i in self.interpreter.version_info)
         self.pyenv_cfg["virtualenv"] = __version__


### PR DESCRIPTION
PEP 405 says of the "home" key:

"If a home key is found, this signifies that the Python binary belongs to a virtual environment, and the value of the home key is the directory containing the Python executable used to create this virtual environment."

And:

"In this case, prefix-finding continues as normal using the value of the home key as the effective Python binary location, which finds the prefix of the base installation."

Previously, "home" was being set to `interpreter.system_exec_prefix` which does not abide by the PEP specification.

In Python 3.11, the "home" directory is used to determine the value of `sys._base_executable`, so if the path specified is incorrect, the path + interpreter returned will be invalid. This can cause headaches later when trying to probe info via the discovery module.

Now, set this to the parent directory of `interpreter.system_executable`.

close #2440 

It may not resolve the problem fully as virtualenv cannot control the `sys._base_executable` "calculation" short of specifying the home directory. This means there's still a chance that a path to "python" gets returned even though there may not be one available in the parent-most non-venv python directory (the python interpreter path that created the upper-most venv).

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
