### PR TITLE
Mimic symlinks of standard python installation on Posix

### DIFF
--- a/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
@@ -25,7 +25,7 @@ class CPythonPosix(CPython, PosixSupports, metaclass=ABCMeta):
     def _executables(cls, interpreter):
         host_exe = Path(interpreter.system_executable)
         major, minor = interpreter.version_info.major, interpreter.version_info.minor
-        targets = OrderedDict((i, None) for i in ["python", f"python{major}", f"python{major}.{minor}", host_exe.name])
+        targets = OrderedDict((i, None) for i in [host_exe.name, f"python{major}.{minor}", f"python{major}", "python"])
         must = RefMust.COPY if interpreter.version_info.major == 2 else RefMust.NA
         yield host_exe, list(targets.keys()), must, RefWhen.ANY
 


### PR DESCRIPTION
Reverse the current order in which the symlinks are created (`python` points to system python and `python{major}` & `python{major}{minor}` point to the local `python`) on posix systems to allow:
1. Installing multiple versions of python to the same virtualenv (currently broken).
2. Mimic the standard symlinks created by a python installation on linux

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [X] ran the linter to address style issues (`tox -e fix_lint`)
- [X] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
