### PR TITLE
Fix deprecation warning in importlib.resources

### DIFF
--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -4,10 +4,14 @@ from abc import ABCMeta, abstractmethod
 
 from .activator import Activator
 
-if sys.version_info >= (3, 7):
-    from importlib.resources import read_binary
-else:
-    from importlib_resources import read_binary
+try:
+    from importlib.resources import files
+    read_binary = lambda package, resource: files(package).joinpath(resource).read_bytes()
+except ImportError:
+    if sys.version_info >= (3, 7):
+        from importlib.resources import read_binary
+    else:
+        from importlib_resources import read_binary
 
 
 class ViaTemplateActivator(Activator, metaclass=ABCMeta):

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -6,6 +6,7 @@ from .activator import Activator
 
 try:
     from importlib.resources import files
+
     read_binary = lambda package, resource: files(package).joinpath(resource).read_bytes()
 except ImportError:
     if sys.version_info >= (3, 7):


### PR DESCRIPTION
`read_binary` was deprecated in 3.11: https://docs.python.org/3/library/importlib.resources.html#deprecated-functions

The `files` API was added in 3.9, use it to implement reimplement `read_binary` following documentation guidance, it's not exactly how the stdlib implements it but since `instantiate_template` only calls `read_binary` with an explicit string it seems good enough.

Ideally it would make sense for the `ViaTemplateActivator` to instantiate a `files` during initialisation, then just get the relevant resource from that, but that's a much larger API divergence, so seems easier this way unless a shim is implemented the other way around (that is an object with a `joinpath` / `__truediv__` and a `read_bytes` is implemented on top of `read_binary` for pre-3.9).

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
