### PR TITLE
Respect `VIRTUAL_ENV_DISABLE_PROMPT` in nushell activation script

### DIFF
--- a/docs/changelog/2461.bugfix.rst
+++ b/docs/changelog/2461.bugfix.rst
@@ -1,0 +1,1 @@
+Make ``activate.nu`` respect ``VIRTUAL_ENV_DISABLE_PROMPT`` and not set the prompt if reqeusted - by :user:`m-lima`.

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -101,7 +101,7 @@ export-env {
           { $'($virtual_prompt)' }
       }
 
-      $new_env | insert {
+      $new_env | merge {
         _OLD_VIRTUAL_PATH   : ($old_path | str collect $path_sep)
         _OLD_PROMPT_COMMAND : $old_prompt_command
         PROMPT_COMMAND      : $new_prompt

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -15,6 +15,21 @@ export-env {
         $name in (env).name
     }
 
+    # Emulates a `test -z`, but btter as it handles e.g 'false'
+    def is-env-true [name: string] {
+      if (has-env $name) {
+        # Try to parse 'true', '0', '1', and fail if not convertible
+        let parsed = do -i { $env | get $name | into bool }
+        if ($parsed | describe) == 'bool' {
+          $parsed
+        } else {
+          not ($env | get $name | is-empty)
+        }
+      } else {
+        false
+      }
+    }
+
     let is_windows = ($nu.os-info.name | str downcase) == 'windows'
     let virtual_env = '__VIRTUAL_ENV__'
     let bin = '__BIN_NAME__'
@@ -49,44 +64,53 @@ export-env {
     let venv_path = ([$virtual_env $bin] | path join)
     let new_path = ($old_path | prepend $venv_path | str collect $path_sep)
 
-    # Creating the new prompt for the session
-    let virtual_prompt = if ('__VIRTUAL_PROMPT__' == '') {
-        $'(char lparen)($virtual_env | path basename)(char rparen) '
-    } else {
-        '(__VIRTUAL_PROMPT__) '
+    let new_env = {
+        $path_name  : $new_path
+        VIRTUAL_ENV : $virtual_env
     }
 
-    # Back up the old prompt builder
-    let old_prompt_command = if (has-env 'VIRTUAL_ENV') and (has-env '_OLD_PROMPT_COMMAND') {
-        $env._OLD_PROMPT_COMMAND
+    let new_env = if (is-env-true 'VIRTUAL_ENV_DISABLE_PROMPT') {
+      $new_env
     } else {
-        if (has-env 'PROMPT_COMMAND') {
-            $env.PROMPT_COMMAND
-        } else {
-            ''
-        }
-    }
+      # Creating the new prompt for the session
+      let virtual_prompt = if ('__VIRTUAL_PROMPT__' == '') {
+          $'(char lparen)($virtual_env | path basename)(char rparen) '
+      } else {
+          '(__VIRTUAL_PROMPT__) '
+      }
 
-    # If there is no default prompt, then only the env is printed in the prompt
-    let new_prompt = if (has-env 'PROMPT_COMMAND') {
-        if ($old_prompt_command | describe) == 'block' {
-            { $'($virtual_prompt)(do $old_prompt_command)' }
-        } else {
-            { $'($virtual_prompt)($old_prompt_command)' }
-        }
-    } else {
-        { $'($virtual_prompt)' }
-    }
+      # Back up the old prompt builder
+      let old_prompt_command = if (has-env 'VIRTUAL_ENV') and (has-env '_OLD_PROMPT_COMMAND') {
+          $env._OLD_PROMPT_COMMAND
+      } else {
+          if (has-env 'PROMPT_COMMAND') {
+              $env.PROMPT_COMMAND
+          } else {
+              ''
+          }
+      }
 
-    # Environment variables that will be loaded as the virtual env
-    load-env {
-        $path_name          : $new_path
-        VIRTUAL_ENV         : $virtual_env
+      # If there is no default prompt, then only the env is printed in the prompt
+      let new_prompt = if (has-env 'PROMPT_COMMAND') {
+          if ($old_prompt_command | describe) == 'block' {
+              { $'($virtual_prompt)(do $old_prompt_command)' }
+          } else {
+              { $'($virtual_prompt)($old_prompt_command)' }
+          }
+      } else {
+          { $'($virtual_prompt)' }
+      }
+
+      $new_env | insert {
         _OLD_VIRTUAL_PATH   : ($old_path | str collect $path_sep)
         _OLD_PROMPT_COMMAND : $old_prompt_command
         PROMPT_COMMAND      : $new_prompt
         VIRTUAL_PROMPT      : $virtual_prompt
+      }
     }
+
+    # Environment variables that will be loaded as the virtual env
+    load-env $new_env
 }
 
 export alias pydoc = python -m pydoc


### PR DESCRIPTION
The `activate.nu` script was not respecting the `VIRTUAL_ENV_DISABLE_PROMPT` like other scripts. This PR addresses that.

The changes can be summarized as:
- Only add the prompt-related env vars if `$env.VIRTUAL_ENV_DISABLE_PROMPT` evaluates to `false`
- Like with other activation scripts, it will evaluate to false if the env var is missing, it is empty, it is '0'. Also, because of nushell type system and the use of the `into bool` built-in, anything that nushell can covert into a `false` will also work, e.g. the strings `false` and `0000` or `0.0`.

There are no changes to the documentation since this is already an expected behavior.
Also, I did not add an entry to the changelog as the developer documentation states that "non trivial" changes should be added. I considered this change trivial, but please let me know if an entry is required.

Fixes: #2461 
