### PR TITLE
Fix Nushell installation failures

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,18 +36,20 @@ jobs:
           - { os: macos-12, py: "brew@3.9" }
           - { os: macos-12, py: "brew@3.8" }
     steps:
+      - uses: taiki-e/install-action@cargo-binstall
       - name: Install OS dependencies
         run: |
           for i in 1 2 3; do
             echo "try $i" && \
             ${{ runner.os == 'Linux' && 'sudo apt-get update -y && sudo apt-get install snapd fish csh -y' || true }} && \
-            ${{ runner.os == 'Linux' && 'sudo apt-get install curl wget -y' || true }} && \
-            ${{ runner.os == 'Linux' && 'nushell_url=$(curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep "browser_" | grep "x86_64" | grep "linux" | grep "gnu" | cut -d\" -f4 )' || true }} && \
-            ${{ runner.os == 'Linux' && 'wget -O nushell.tar.gz $nushell_url' || true }} && \
-            ${{ runner.os == 'Linux' && 'tar -zxf nushell.tar.gz' || true }} && \
-            ${{ runner.os == 'Linux' && 'sudo cp nu-*-x86_64-unknown-linux-gnu/nu /usr/bin' || true }} && \
-            ${{ runner.os == 'Windows' && 'choco install nushell' || true }} && \
-            ${{ runner.os == 'macOS' && 'brew install fish tcsh nushell' || true }} && \
+            # ${{ runner.os == 'Linux' && 'sudo apt-get install curl wget -y' || true }} && \
+            # ${{ runner.os == 'Linux' && 'nushell_url=$(curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep "browser_" | grep "x86_64" | grep "linux" | grep "gnu" | cut -d\" -f4 )' || true }} && \
+            # ${{ runner.os == 'Linux' && 'wget -O nushell.tar.gz $nushell_url' || true }} && \
+            # ${{ runner.os == 'Linux' && 'tar -zxf nushell.tar.gz' || true }} && \
+            # ${{ runner.os == 'Linux' && 'sudo cp nu-*-x86_64-unknown-linux-gnu/nu /usr/bin' || true }} && \
+            ${{ 'cargo binstall -y nu' || true }} && \
+            # ${{ runner.os == 'Windows' && 'choco install nushell' || true }} && \
+            ${{ runner.os == 'macOS' && 'brew install fish tcsh' || true }} && \
             exit 0 || true;
           done
           exit 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,8 +42,9 @@ jobs:
           for i in 1 2 3; do
             echo "try $i" && \
             ${{ runner.os == 'Linux' && 'sudo apt-get update -y && sudo apt-get install snapd fish csh -y' || true }} && \
-            ${{ runner.os == 'macOS' && 'brew install fish tcsh' || true }} && \
-            ${{ 'cargo binstall -y nu' || true }} && \
+            ${{ runner.os == 'Linux' && 'cargo binstall -y nu' || true }} && \
+            ${{ runner.os == 'macOS' && 'brew install fish tcsh nushell' || true }} && \
+            ${{ runner.os == 'Windows' && 'choco install nushell' || true }} && \
             exit 0 || true;
           done
           exit 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,14 +42,8 @@ jobs:
           for i in 1 2 3; do
             echo "try $i" && \
             ${{ runner.os == 'Linux' && 'sudo apt-get update -y && sudo apt-get install snapd fish csh -y' || true }} && \
-            # ${{ runner.os == 'Linux' && 'sudo apt-get install curl wget -y' || true }} && \
-            # ${{ runner.os == 'Linux' && 'nushell_url=$(curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep "browser_" | grep "x86_64" | grep "linux" | grep "gnu" | cut -d\" -f4 )' || true }} && \
-            # ${{ runner.os == 'Linux' && 'wget -O nushell.tar.gz $nushell_url' || true }} && \
-            # ${{ runner.os == 'Linux' && 'tar -zxf nushell.tar.gz' || true }} && \
-            # ${{ runner.os == 'Linux' && 'sudo cp nu-*-x86_64-unknown-linux-gnu/nu /usr/bin' || true }} && \
-            ${{ 'cargo binstall -y nu' || true }} && \
-            # ${{ runner.os == 'Windows' && 'choco install nushell' || true }} && \
             ${{ runner.os == 'macOS' && 'brew install fish tcsh' || true }} && \
+            ${{ 'cargo binstall -y nu' || true }} && \
             exit 0 || true;
           done
           exit 1


### PR DESCRIPTION
This changes the Nushell installation method to use https://github.com/marketplace/actions/install-development-tools which in turn uses [cargo binstall](https://github.com/cargo-bins/cargo-binstall) to install Nushell binary directly from GitHub releases. Unlike the previous method which points at https://api.github.com/repos/nushell/nushell/releases/latest this one should point at the build artifacts directly and hopefully avoids the 403 problems.

Also makes the CI script simpler.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
