### PR TITLE
Fix wrong prompt in Nushell activation script

### DIFF
--- a/docs/changelog/2481.bugfix.rst
+++ b/docs/changelog/2481.bugfix.rst
@@ -1,0 +1,1 @@
+Fix broken prompt in Nushell when activating virtual environment.

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -92,7 +92,7 @@ export-env {
 
       # If there is no default prompt, then only the env is printed in the prompt
       let new_prompt = if (has-env 'PROMPT_COMMAND') {
-          if ($old_prompt_command | describe) == 'block' {
+          if 'closure' in ($old_prompt_command | describe) {
               { $'($virtual_prompt)(do $old_prompt_command)' }
           } else {
               { $'($virtual_prompt)($old_prompt_command)' }


### PR DESCRIPTION
Recently, the Nushell prompt was broken when running the activation script due to some recent language changes. This PR fixes it again.

Fixes https://github.com/pypa/virtualenv/issues/2480

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
