### PR TITLE
Fix Tox environment name for running linting tools in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))
 
-- [ ] ran the linter to address style issues (`tox -e fix_lint`)
+- [ ] ran the linter to address style issues (`tox -e fix`)
 - [ ] wrote descriptive pull request text
 - [ ] ensured there are test(s) validating the fix
 - [ ] added news fragment in `docs/changelog` folder


### PR DESCRIPTION
Trivial doc change.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
