### PR TITLE
Simplify environment lookup in Nushell activation

### DIFF
--- a/docs/changelog/2506.feature.rst
+++ b/docs/changelog/2506.feature.rst
@@ -1,0 +1,1 @@
+Change environment variable existence check in Nushell activation script to not use deprecated command.

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -12,7 +12,7 @@ export-env {
     }
 
     def has-env [name: string] {
-        $name in (env).name
+        $name in $env
     }
 
     # Emulates a `test -z`, but btter as it handles e.g 'false'


### PR DESCRIPTION
Changes environment variable existence check to use the `$env` structure directly instead of `env` command because the `env` command is going to be deprecated.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
