### PR TITLE
Make `ReentrantFileLock` thread-safe and, thereby, fix race condition in `virtualenv.cli_run`

### DIFF
--- a/docs/changelog/2516.bugfix.rst
+++ b/docs/changelog/2516.bugfix.rst
@@ -1,0 +1,2 @@
+Make ``ReentrantFileLock`` thread-safe and,
+thereby, fix race condition in ``virtualenv.cli_run`` - by :user:`radoering`.

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,3 +1,9 @@
+import concurrent.futures
+import traceback
+
+import pytest
+
+from virtualenv.util.lock import ReentrantFileLock
 from virtualenv.util.subprocess import run_cmd
 
 
@@ -6,3 +12,25 @@ def test_run_fail(tmp_path):
     assert err
     assert not out
     assert code
+
+
+def test_reentrant_file_lock_is_thread_safe(tmp_path):
+    lock = ReentrantFileLock(tmp_path)
+    target_file = tmp_path / "target"
+    target_file.touch()
+
+    def recreate_target_file():
+        with lock.lock_for_key("target"):
+            target_file.unlink()
+            target_file.touch()
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        tasks = []
+        for _ in range(4):
+            tasks.append(executor.submit(recreate_target_file))
+        concurrent.futures.wait(tasks)
+        for task in tasks:
+            try:
+                task.result()
+            except Exception:
+                pytest.fail(traceback.format_exc())


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Resolves: #2516

This PR makes `ReentrantFileLock` thread-safe and, thereby, fixes a race condition in `virtualenv.cli_run`.