### PR TITLE
Update Nushell 'let' syntax

### DIFF
--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -19,7 +19,7 @@ export-env {
     def is-env-true [name: string] {
       if (has-env $name) {
         # Try to parse 'true', '0', '1', and fail if not convertible
-        let parsed = do -i { $env | get $name | into bool }
+        let parsed = (do -i { $env | get $name | into bool })
         if ($parsed | describe) == 'bool' {
           $parsed
         } else {
@@ -34,7 +34,7 @@ export-env {
     let virtual_env = '__VIRTUAL_ENV__'
     let bin = '__BIN_NAME__'
     let path_sep = (char esep)
-    let path_name = if $is_windows {
+    let path_name = (if $is_windows {
         if (has-env 'Path') {
             'Path'
         } else {
@@ -42,7 +42,7 @@ export-env {
         }
     } else {
         'PATH'
-    }
+    })
 
     let old_path = (
         if $is_windows {
@@ -69,18 +69,18 @@ export-env {
         VIRTUAL_ENV : $virtual_env
     }
 
-    let new_env = if (is-env-true 'VIRTUAL_ENV_DISABLE_PROMPT') {
+    let new_env = (if (is-env-true 'VIRTUAL_ENV_DISABLE_PROMPT') {
       $new_env
     } else {
       # Creating the new prompt for the session
-      let virtual_prompt = if ('__VIRTUAL_PROMPT__' == '') {
+      let virtual_prompt = (if ('__VIRTUAL_PROMPT__' == '') {
           $'(char lparen)($virtual_env | path basename)(char rparen) '
       } else {
           '(__VIRTUAL_PROMPT__) '
-      }
+      })
 
       # Back up the old prompt builder
-      let old_prompt_command = if (has-env 'VIRTUAL_ENV') and (has-env '_OLD_PROMPT_COMMAND') {
+      let old_prompt_command = (if (has-env 'VIRTUAL_ENV') and (has-env '_OLD_PROMPT_COMMAND') {
           $env._OLD_PROMPT_COMMAND
       } else {
           if (has-env 'PROMPT_COMMAND') {
@@ -88,10 +88,10 @@ export-env {
           } else {
               ''
           }
-      }
+      })
 
       # If there is no default prompt, then only the env is printed in the prompt
-      let new_prompt = if (has-env 'PROMPT_COMMAND') {
+      let new_prompt = (if (has-env 'PROMPT_COMMAND') {
           if 'closure' in ($old_prompt_command | describe) {
               {|| $'($virtual_prompt)(do $old_prompt_command)' }
           } else {
@@ -99,7 +99,7 @@ export-env {
           }
       } else {
           {|| $'($virtual_prompt)' }
-      }
+      })
 
       $new_env | merge {
         _OLD_VIRTUAL_PATH   : ($old_path | str collect $path_sep)
@@ -107,7 +107,7 @@ export-env {
         PROMPT_COMMAND      : $new_prompt
         VIRTUAL_PROMPT      : $virtual_prompt
       }
-    }
+    })
 
     # Environment variables that will be loaded as the virtual env
     load-env $new_env


### PR DESCRIPTION
We're currently investigating a future breaking change to Nushell that [changes how `let` works](https://github.com/nushell/nushell/pull/8545). With this PR, the activate.nu script will work with both the current and possible future syntax.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
