### PR TITLE
docs: fix attribution in v20.11

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -305,7 +305,7 @@ Features - 20.11.0
 - Avoid deprecation warning from py-filelock argument - by :user:`ofek`. (`#2237 <https://github.com/pypa/virtualenv/issues/2237>`_)
 - Upgrade embedded setuptools to ``61.1.0`` from ``58.3.0`` - by :user:`gaborbernat`. (`#2240 <https://github.com/pypa/virtualenv/issues/2240>`_)
 - Drop the runtime dependency of ``backports.entry-points-selectable`` - by :user:`hroncok`. (`#2246 <https://github.com/pypa/virtualenv/issues/2246>`_)
-- Fish: PATH variables should not be quoted when being set - by :user:`hroncok`. (`#2248 <https://github.com/pypa/virtualenv/issues/2248>`_)
+- Fish: PATH variables should not be quoted when being set - by :user:`d3dave`. (`#2248 <https://github.com/pypa/virtualenv/issues/2248>`_)
 
 
 v20.10.0 (2021-11-01)


### PR DESCRIPTION
Fixed the attribution for #2248 :)

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
