### PR TITLE
Clarify that v20.22.0 dropped support for Python 3.6 too

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ v20.22.0 (2023-04-19)
 
 Features - 20.22.0
 ~~~~~~~~~~~~~~~~~~
-- Drop support for creating Python <3.6 (including 2) interpreters. Removed pip of ``20.3.4``, ``21.3.1``; wheel of
+- Drop support for creating Python <=3.6 (including 2) interpreters. Removed pip of ``20.3.4``, ``21.3.1``; wheel of
   ``0.37.1``; setuptools of ``59.6.0``, ``44.1.1``, ``50.3.2``- by :user:`gaborbernat`. (:issue:`2548`)
 
 


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
