### PR TITLE
feat: ✨ update and simplify nushell activation

### DIFF
--- a/docs/changelog/2572.bugfix.rst
+++ b/docs/changelog/2572.bugfix.rst
@@ -1,0 +1,1 @@
+update and simplify nushell activation script, fixes an issue on Windows resulting in consecutive command not found - by :user:`melMass`.

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -11,8 +11,10 @@ export-env {
         ($x | describe) == 'string'
     }
 
-    def has-env [name: string] {
-        $name in $env
+    def has-env [...names] {
+        $names | each {|n|
+            $n in $env
+        } | all {|i| $i == true}
     }
 
     # Emulates a `test -z`, but btter as it handles e.g 'false'
@@ -23,46 +25,26 @@ export-env {
         if ($parsed | describe) == 'bool' {
           $parsed
         } else {
-          not ($env | get $name | is-empty)
+          not ($env | get -i $name | is-empty)
         }
       } else {
         false
       }
     }
 
-    let is_windows = ($nu.os-info.name | str downcase) == 'windows'
     let virtual_env = '__VIRTUAL_ENV__'
     let bin = '__BIN_NAME__'
-    let path_sep = (char esep)
-    let path_name = (if $is_windows {
-        if (has-env 'Path') {
+
+    let is_windows = ($nu.os-info.family) == 'windows'
+    let path_name = (if (has-env 'Path') {
             'Path'
         } else {
             'PATH'
         }
-    } else {
-        'PATH'
-    })
-
-    let old_path = (
-        if $is_windows {
-            if (has-env 'Path') {
-                $env.Path
-            } else {
-                $env.PATH
-            }
-        } else {
-            $env.PATH
-        } | if (is-string $in) {
-            # if Path/PATH is a string, make it a list
-            $in | split row $path_sep | path expand
-        } else {
-            $in
-        }
     )
 
     let venv_path = ([$virtual_env $bin] | path join)
-    let new_path = ($old_path | prepend $venv_path | str join $path_sep)
+    let new_path = ($env | get $path_name | prepend $venv_path)
 
     let new_env = {
         $path_name  : $new_path
@@ -73,22 +55,18 @@ export-env {
       $new_env
     } else {
       # Creating the new prompt for the session
-      let virtual_prompt = (if ('__VIRTUAL_PROMPT__' == '') {
+      let virtual_prompt = (if ('__VIRTUAL_PROMPT__' | is-empty) {
           $'(char lparen)($virtual_env | path basename)(char rparen) '
       } else {
           '(__VIRTUAL_PROMPT__) '
       })
 
       # Back up the old prompt builder
-      let old_prompt_command = (if (has-env 'VIRTUAL_ENV') and (has-env '_OLD_PROMPT_COMMAND') {
-          $env._OLD_PROMPT_COMMAND
-      } else {
-          if (has-env 'PROMPT_COMMAND') {
+      let old_prompt_command = (if (has-env 'PROMPT_COMMAND') {
               $env.PROMPT_COMMAND
           } else {
               ''
-          }
-      })
+        })
 
       # If there is no default prompt, then only the env is printed in the prompt
       let new_prompt = (if (has-env 'PROMPT_COMMAND') {
@@ -102,8 +80,6 @@ export-env {
       })
 
       $new_env | merge {
-        _OLD_VIRTUAL_PATH   : ($old_path | str join $path_sep)
-        _OLD_PROMPT_COMMAND : $old_prompt_command
         PROMPT_COMMAND      : $new_prompt
         VIRTUAL_PROMPT      : $virtual_prompt
       }


### PR DESCRIPTION
- Storing "Old" env variables is handled by overlays OOB
- Fix an issue caused by the conversion of Path/PATH to string, it now uses a list as what nushell expects. This lead to repeating command not found issues.
- Use `-i` in is-env-true in case the env name does not exist.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ~~ran the linter to address style issues (`tox -e fix`)~~
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix (**If there is a proper way let me know, I manually tested it**)
- [x] added news fragment in `docs/changelog` folder (let me check other PRs to understand the expectations there)
- [ ] ~~updated/extended the documentation (same as previous)~~
