### PR TITLE
Updated CLI documentation with config file name

### DIFF
--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -35,7 +35,7 @@ Configuration file
 Unless ``VIRTUALENV_CONFIG_FILE`` is set, virtualenv looks for a standard ``virtualenv.ini`` configuration file.
 The exact location depends on the operating system you're using, as determined by :pypi:`platformdirs` application
 configuration definition. It can be overridden by setting the ``VIRTUALENV_CONFIG_FILE`` environment variable.
-The configuration file location is printed as at the end of the output when ``--help`` is passed. 
+The configuration file location is printed as at the end of the output when ``--help`` is passed.
 
 The keys of the settings are derived from the command line option (left strip the ``-`` characters, and replace ``-``
 with ``_``). Where multiple flags are available first found wins (where order is as it shows up under the ``--help``).

--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -32,9 +32,10 @@ Defaults
 Configuration file
 ^^^^^^^^^^^^^^^^^^
 
-virtualenv looks for a standard ini configuration file. The exact location depends on the operating system you're using,
-as determined by :pypi:`platformdirs` application configuration definition. The configuration file location is printed as at
-the end of the output when ``--help`` is passed.
+Unless ``VIRTUALENV_CONFIG_FILE`` is set, virtualenv looks for a standard ``virtualenv.ini`` configuration file.
+The exact location depends on the operating system you're using, as determined by :pypi:`platformdirs` application
+configuration definition. It can be overridden by setting the ``VIRTUALENV_CONFIG_FILE`` environment variable.
+The configuration file location is printed as at the end of the output when ``--help`` is passed. 
 
 The keys of the settings are derived from the command line option (left strip the ``-`` characters, and replace ``-``
 with ``_``). Where multiple flags are available first found wins (where order is as it shows up under the ``--help``).


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [] N/A added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

---

This PR is to resolve #1792 by adding the config file name to the CLI Interface page of the documentation. The intro paragraph of the config file section was modified to accommodate the change.