### PR TITLE
Fix #1949: zipapp virtual environment creation fails if zipapp path is symlinked

### DIFF
--- a/docs/changelog/1949.bugfix.rst
+++ b/docs/changelog/1949.bugfix.rst
@@ -1,0 +1,1 @@
+``virtualenv.pyz`` no longer fails when zipapp path contains a symlink - by :user:`petamas`.

--- a/src/virtualenv/util/zipapp.py
+++ b/src/virtualenv/util/zipapp.py
@@ -24,7 +24,9 @@ def extract(full_path, dest):
 
 def _get_path_within_zip(full_path):
     full_path = os.path.abspath(str(full_path))
-    sub_file = full_path[len(ROOT) + 1 :]
+    prefix = ROOT + os.sep
+    assert full_path.startswith(prefix), f"full_path={full_path} should start with prefix={prefix}"
+    sub_file = full_path[len(prefix) :]
     if IS_WIN:
         # paths are always UNIX separators, even on Windows, though __file__ still follows platform default
         sub_file = sub_file.replace(os.sep, "/")

--- a/src/virtualenv/util/zipapp.py
+++ b/src/virtualenv/util/zipapp.py
@@ -23,7 +23,7 @@ def extract(full_path, dest):
 
 
 def _get_path_within_zip(full_path):
-    full_path = os.path.abspath(str(full_path))
+    full_path = os.path.realpath(os.path.abspath(str(full_path)))
     prefix = ROOT + os.sep
     assert full_path.startswith(prefix), f"full_path={full_path} should start with prefix={prefix}"
     sub_file = full_path[len(prefix) :]


### PR DESCRIPTION
Original issue: https://github.com/pypa/virtualenv/issues/1949

The function in question assumes that `ROOT` is a prefix of `full_path`, and tries to remove it. However, it is not necessarily a prefix:
- when `ROOT` is determined, both `os.path.abspath()` and `os.path.realpath()` gets called
- when `full_path` is determined, only `os.path.abspath()` is called

This means that if the path contains a symlink, it will show up as resolved in `ROOT`, but not `full_path`, so simply removing the first X characters of `full_path` is not sufficient.

This PR adds an assertion to catch the bad situation early, then adds the `os.path.realpath` call to `full_path`.

I did not add a test because I was unable to figure out how to add it to the existing structure.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation