### PR TITLE
fix ResourceWarning on process exit (#2472)

### DIFF
--- a/docs/changelog/2472.bugfix.rst
+++ b/docs/changelog/2472.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ResourceWarning on exit caused by periodic update subprocess

--- a/src/virtualenv/seed/wheels/periodic_update.py
+++ b/src/virtualenv/seed/wheels/periodic_update.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from itertools import groupby
 from pathlib import Path
 from shutil import copy2
-from subprocess import PIPE, Popen
+from subprocess import DEVNULL, Popen
 from textwrap import dedent
 from threading import Thread
 from urllib.error import URLError
@@ -216,7 +216,7 @@ def trigger_update(distribution, for_py_version, wheel, search_dirs, app_data, e
         .format(distribution, for_py_version, wheel_path, str(app_data), [str(p) for p in search_dirs], periodic),
     ]
     debug = env.get("_VIRTUALENV_PERIODIC_UPDATE_INLINE") == "1"
-    pipe = None if debug else PIPE
+    pipe = None if debug else DEVNULL
     kwargs = {"stdout": pipe, "stderr": pipe}
     if not debug and sys.platform == "win32":
         kwargs["creationflags"] = CREATE_NO_WINDOW
@@ -230,6 +230,9 @@ def trigger_update(distribution, for_py_version, wheel, search_dirs, app_data, e
     )
     if debug:
         process.communicate()  # on purpose not called to make it a background process
+    else:
+        # set the returncode here -> no ResourceWarning on main process exit if the subprocess still runs
+        process.returncode = 0
 
 
 def do_update(distribution, for_py_version, embed_filename, app_data, search_dirs, periodic):  # noqa: PLR0913

--- a/tests/unit/seed/wheels/test_periodic_update.py
+++ b/tests/unit/seed/wheels/test_periodic_update.py
@@ -316,7 +316,7 @@ def test_trigger_update_no_debug(for_py_version, session_app_data, tmp_path, moc
     )
 
     assert args == ([sys.executable, "-c", cmd],)
-    expected = {"stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+    expected = {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
     if sys.platform == "win32":
         expected["creationflags"] = CREATE_NO_WINDOW
     assert kwargs == expected


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text - see #2472
- [] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [] updated/extended the documentation
