### PR TITLE
macOS homebrew tests fail because dyld library not loaded

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,6 +68,7 @@ jobs:
           set -e
           PY=$(echo '${{ matrix.py }}' | cut -c 6-)
           brew upgrade python@$PY || brew install python@$PY
+          brew doctor  # Fix dyld library not loaded issues
           echo "/usr/local/opt/python@$PY/libexec/bin" >>"${GITHUB_PATH}"
         shell: bash
       - name: Setup python for test ${{ matrix.py }}


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

See https://github.com/pypa/virtualenv/actions for failures.
```
AssertionError: Exception("dyld[2661]: Library not loaded ...")
```
