### PR TITLE
Change "Virtualenv" to "virtualenv" to match style

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Virtualenv
+virtualenv
 ==========
 
 .. image:: https://img.shields.io/pypi/v/virtualenv?style=flat-square


### PR DESCRIPTION
This is a very minor change on the readme. 
virtualenv was capitalized in the title, but all other instances are lowercase. It seems to me that this should be lowercase as well. Ignore and close if you disagree.
