### PR TITLE
`source venv/bin/activate` now works between different shells (fish/zsh/ect...)

### DIFF
--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -1,5 +1,5 @@
-# This file must be used with "source bin/activate" *from bash*
-# you cannot run it directly
+#!/usr/bin/env bash
+# you can run it directly `source venv/bin/activate`
 
 
 if [ "${BASH_SOURCE-}" = "$0" ]; then

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # you can run it directly `source venv/bin/activate`
+# if this doesn't work, try this running from bash.
 
 
 if [ "${BASH_SOURCE-}" = "$0" ]; then


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

Hey everyone I noticed `source venv/bin/activate` wasn't working on fish, and that is when I found a better way of passing environment variables around.  If you execute a bash script with `#!/usr/bin/env bash` you will pass in environment variables, and features like EXPORT and SET will also work. 

There is no reason not to have this feature, as it is helpful for anyone who cannot use bash, but would like to use the default venv files produced.
