### PR TITLE
Fix test expectations for .gitignore comment created by Python 3.13+ venv

### DIFF
--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -217,7 +217,11 @@ def test_create_no_seed(  # noqa: C901, PLR0912, PLR0913, PLR0915
         assert result == "None"
 
     git_ignore = (dest / ".gitignore").read_text(encoding="utf-8")
-    assert git_ignore.splitlines() == ["# created by virtualenv automatically", "*"]
+    if creator_key == "venv" and sys.version_info >= (3, 13):
+        comment = "# Created by venv; see https://docs.python.org/3/library/venv.html"
+    else:
+        comment = "# created by virtualenv automatically"
+    assert git_ignore.splitlines() == [comment, "*"]
 
 
 def test_create_vcs_ignore_exists(tmp_path):


### PR DESCRIPTION
Since Python 3.13, the .gitignore file is created by venv:
https://github.com/python/cpython/pull/108125

Fixes https://github.com/pypa/virtualenv/issues/2670

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
