### PR TITLE
Fix windows utf8 encoding issue

### DIFF
--- a/src/virtualenv/activation/batch/activate.bat
+++ b/src/virtualenv/activation/batch/activate.bat
@@ -1,3 +1,11 @@
+@REM This file is UTF-8 encoded, so we need to update the current code page while executing it
+@for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do (
+    @set _OLD_CODEPAGE=%%a
+)
+@if defined _OLD_CODEPAGE (
+    "%SystemRoot%\System32\chcp.com" 65001 > nul
+)
+
 @set "VIRTUAL_ENV=__VIRTUAL_ENV__"
 
 @set "VIRTUAL_ENV_PROMPT=__VIRTUAL_PROMPT__"
@@ -36,3 +44,8 @@
 :ENDIFVPATH2
 
 @set "PATH=%VIRTUAL_ENV%\__BIN_NAME__;%PATH%"
+
+@if defined _OLD_CODEPAGE (
+    "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
+    @set _OLD_CODEPAGE=
+)

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -47,8 +47,10 @@ class ViaTemplateActivator(Activator, ABC):
             # errors when the dest is not writable
             if dest.exists():
                 dest.unlink()
+            # Powershell assumes Windows 1252 encoding when reading files without BOM
+            encoding = "utf-8-sig" if template.endswith(".ps1") else "utf-8"
             # use write_bytes to avoid platform specific line normalization (\n -> \r\n)
-            dest.write_bytes(text.encode("utf-8"))
+            dest.write_bytes(text.encode(encoding))
             generated.append(dest)
         return generated
 

--- a/tests/unit/activation/test_batch.py
+++ b/tests/unit/activation/test_batch.py
@@ -23,8 +23,7 @@ def test_batch(activation_tester_class, activation_tester, tmp_path):
             self.unix_line_ending = False
 
         def _get_test_lines(self, activate_script):
-            # for BATCH utf-8 support need change the character code page to 650001
-            return ["@echo off", "", "chcp 65001 1>NUL", *super()._get_test_lines(activate_script)]
+            return ["@echo off", *super()._get_test_lines(activate_script)]
 
         def quote(self, s):
             """double quotes needs to be single, and single need to be double"""

--- a/tests/unit/activation/test_powershell.py
+++ b/tests/unit/activation/test_powershell.py
@@ -19,7 +19,7 @@ def test_powershell(activation_tester_class, activation_tester, monkeypatch):
             self._version_cmd = [cmd, "-c", "$PSVersionTable"]
             self._invoke_script = [cmd, "-ExecutionPolicy", "ByPass", "-File"]
             self.activate_cmd = "."
-            self.script_encoding = "utf-16"
+            self.script_encoding = "utf-8-sig"
 
         def quote(self, s):
             """powershell double quote needed for quotes within single quotes"""
@@ -27,7 +27,6 @@ def test_powershell(activation_tester_class, activation_tester, monkeypatch):
             return text.replace('"', '""') if sys.platform == "win32" else text
 
         def _get_test_lines(self, activate_script):
-            # for BATCH utf-8 support need change the character code page to 650001
             return super()._get_test_lines(activate_script)
 
         def invoke_script(self):


### PR DESCRIPTION
Batch and Powershell do not work properly if non-ASCII text (e.g. "аạąäàáą") is used in the folder name or prompt name.
For Batch case, there is a codepage issue under the problem and [cpython's venv](https://github.com/python/cpython/blob/main/Lib/venv/scripts/nt/activate.bat) has the solution already.
And Powershell assumes Windows 1252 encoding when reading files without BOM. So I added Bom using utf-8-sig encoding.

Batch error screenshot (see broken prompt name after activate)
![Batch error screenshot](https://github.com/pypa/virtualenv/assets/60059706/b4397a4a-15f2-4992-b302-de1cac68e07d)

Powershell error screenshot
![Powershell error screenshot](https://github.com/pypa/virtualenv/assets/60059706/d834c835-aad6-4ca4-9656-5c266c321b9c)

