### PR TITLE
Avoid importing contextlib in `_virtualenv`

### DIFF
--- a/docs/changelog/2688.misc.rst
+++ b/docs/changelog/2688.misc.rst
@@ -1,0 +1,1 @@
+Avoid importing :mod:`contextlib` in ``_virtualenv.py``

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -77,7 +77,7 @@ class _Finder:
                         old = getattr(spec.loader, func_name)
                         func = self.exec_module if is_new_api else self.load_module
                         if old is not func:
-                            try:
+                            try:  # noqa: SIM105
                                 setattr(spec.loader, func_name, partial(func, old))
                             except AttributeError:
                                 pass  # C-Extension loaders are r/o such as zipimporter with <3.7

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sys
-from contextlib import suppress
 
 VIRTUALENV_PATCH_FILE = os.path.join(__file__)
 
@@ -78,8 +77,10 @@ class _Finder:
                         old = getattr(spec.loader, func_name)
                         func = self.exec_module if is_new_api else self.load_module
                         if old is not func:
-                            with suppress(AttributeError):  # C-Extension loaders are r/o such as zipimporter with <3.7
+                            try:
                                 setattr(spec.loader, func_name, partial(func, old))
+                            except AttributeError:
+                                pass  # C-Extension loaders are r/o such as zipimporter with <3.7
                         return spec
                 finally:
                     self.fullname = None


### PR DESCRIPTION
This appears to be imported in a `.pth` file, so this file runs in basically every Python program in my environment. contextlib takes about 3ms to import and I'd prefer to not pay that cost if not strictly necessary.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [] updated/extended the documentation
