### PR TITLE
Fix for tests: Python 3.13.0a6 renamed pathmod to parser

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - "3.13.0-alpha.2"
+          - "3.13.0-alpha.6"
           - "3.12"
           - "3.11"
           - "3.10"

--- a/docs/changelog/2702.bugfix.rst
+++ b/docs/changelog/2702.bugfix.rst
@@ -1,0 +1,1 @@
+Python 3.13.0a6 renamed pathmod to parser.

--- a/tests/unit/create/via_global_ref/builtin/testing/path.py
+++ b/tests/unit/create/via_global_ref/builtin/testing/path.py
@@ -51,10 +51,10 @@ class PathMockABC(FakeDataABC, Path):
         # Allows to pass some tests for Windows via PosixPath.
         _flavour.altsep = _flavour.altsep or "\\"
 
-    # Python 3.13 renamed _flavour to pathmod
-    pathmod = getattr(Path(), "pathmod", None)
-    if hasattr(pathmod, "altsep"):
-        pathmod.altsep = pathmod.altsep or "\\"
+    # Python 3.13 renamed _flavour to parser
+    parser = getattr(Path(), "parser", None)
+    if hasattr(parser, "altsep"):
+        parser.altsep = parser.altsep or "\\"
 
     def exists(self):
         return self.is_file() or self.is_dir()


### PR DESCRIPTION
This fixes https://github.com/pypa/virtualenv/issues/2671 which reappeared in alpha6 as a result of upstream renaming the attribute.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
