### PR TITLE
Fixed a case when template variable is WindowsPath

### DIFF
--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -48,7 +48,7 @@ class ViaTemplateActivator(Activator, ABC):
             if dest.exists():
                 dest.unlink()
             # Powershell assumes Windows 1252 encoding when reading files without BOM
-            encoding = "utf-8-sig" if template.endswith(".ps1") else "utf-8"
+            encoding = "utf-8-sig" if str(template).endswith(".ps1") else "utf-8"
             # use write_bytes to avoid platform specific line normalization (\n -> \r\n)
             dest.write_bytes(text.encode(encoding))
             generated.append(dest)


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

I think the fix is trivial enough not to create new tests on them.
Also I'm unsure if it's going to be a new release, hence I didn't change the changelog.

