### PR TITLE
Allow builtin interpreter discovery to find specific Python versions given a general spec

### DIFF
--- a/docs/changelog/2709.bugfix.rst
+++ b/docs/changelog/2709.bugfix.rst
@@ -1,0 +1,1 @@
+allow builtin discovery to discover specific interpreters (e.g. ``python3.12``) given an unspecific spec (e.g. ``python3``) - by :user:`flying-sheep`.

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -344,7 +344,7 @@ class PythonInfo:  # noqa: PLR0904
         return cls._current
 
     @classmethod
-    def current_system(cls, app_data=None):
+    def current_system(cls, app_data=None) -> PythonInfo:
         """
         This locates the current host interpreter information. This might be different than what we run into in case
         the host python has been upgraded from underneath us.

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import os
 import re
 
-from virtualenv.info import fs_is_case_sensitive
-
 PATTERN = re.compile(r"^(?P<impl>[a-zA-Z]+)?(?P<version>[0-9.]+)?(?:-(?P<arch>32|64))?$")
 
 
@@ -84,7 +82,7 @@ class PythonSpec:
         # Try matching `direct` first, so the `direct` group is filled when possible.
         return re.compile(
             rf"(?P<impl>{impl})(?P<v>{version}){suffix}$",
-            flags=re.IGNORECASE if fs_is_case_sensitive() else 0,
+            flags=re.IGNORECASE,
         )
 
     @property

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import re
 
+from virtualenv.info import fs_is_case_sensitive
+
 PATTERN = re.compile(r"^(?P<impl>[a-zA-Z]+)?(?P<version>[0-9.]+)?(?:-(?P<arch>32|64))?$")
 
 
@@ -82,7 +84,7 @@ class PythonSpec:
         # Try matching `direct` first, so the `direct` group is filled when possible.
         return re.compile(
             rf"(?P<impl>{impl})(?P<v>{version}){suffix}$",
-            flags=re.IGNORECASE,
+            flags=re.IGNORECASE if fs_is_case_sensitive() else 0,
         )
 
     @property

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -58,6 +58,9 @@ def test_discovery_via_path_specific(
     target.mkdir(parents=True)
     executable = target / exe_name
     os.symlink(sys.executable, str(executable))
+    pyvenv_cfg = Path(sys.executable).parents[1] / "pyvenv.cfg"
+    if pyvenv_cfg.exists():
+        (target / pyvenv_cfg.name).write_bytes(pyvenv_cfg.read_bytes())
     monkeypatch.setenv("PATH", str(target))
     interpreter = get_interpreter(spec, [])
 

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -5,7 +5,6 @@ import os
 import sys
 from argparse import Namespace
 from pathlib import Path
-from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
@@ -14,22 +13,28 @@ from virtualenv.discovery.builtin import Builtin, get_interpreter
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import fs_supports_symlink
 
-if TYPE_CHECKING:
-    from virtualenv.app_data.base import AppData
-
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink not supported")
 @pytest.mark.parametrize("case", ["mixed", "lower", "upper"])
-def test_discovery_via_path(monkeypatch, case, tmp_path, caplog, session_app_data):
+@pytest.mark.parametrize("specificity", ["more", "less"])
+def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, session_app_data):  # noqa: PLR0913
     caplog.set_level(logging.DEBUG)
     current = PythonInfo.current_system(session_app_data)
-    core = f"somethingVeryCryptic{'.'.join(str(i) for i in current.version_info[0:3])}"
     name = "somethingVeryCryptic"
     if case == "lower":
         name = name.lower()
     elif case == "upper":
         name = name.upper()
-    exe_name = f"{name}{current.version_info.major}{'.exe' if sys.platform == 'win32' else ''}"
+    if specificity == "more":
+        # e.g. spec: python3, exe: /bin/python3.12
+        core_ver = current.version_info.major
+        exe_ver = ".".join(str(i) for i in current.version_info[0:2])
+    elif specificity == "less":
+        # e.g. spec: python3.12.1, exe: /bin/python3
+        core_ver = ".".join(str(i) for i in current.version_info[0:3])
+        exe_ver = current.version_info.major
+    core = f"{name}{core_ver}"
+    exe_name = f"{name}{exe_ver}{'.exe' if sys.platform == 'win32' else ''}"
     target = tmp_path / current.install_path("scripts")
     target.mkdir(parents=True)
     executable = target / exe_name
@@ -40,29 +45,6 @@ def test_discovery_via_path(monkeypatch, case, tmp_path, caplog, session_app_dat
     new_path = os.pathsep.join([str(target), *os.environ.get("PATH", "").split(os.pathsep)])
     monkeypatch.setenv("PATH", new_path)
     interpreter = get_interpreter(core, [])
-
-    assert interpreter is not None
-
-
-@pytest.mark.skipif(not fs_supports_symlink(), reason="symlink not supported")
-def test_discovery_via_path_specific(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture, session_app_data: AppData
-):
-    """Test that a generic spec (e.g. python3) can be used to find a specific interpreter (e.g. python3.12)"""
-    caplog.set_level(logging.DEBUG)
-    current = PythonInfo.current_system(session_app_data)
-    name = "somethingVeryCryptic"
-    spec = f"{name}{current.version_info.major}"
-    exe_name = f"{name}{'.'.join(str(i) for i in current.version_info[:2])}{'.exe' if sys.platform == 'win32' else ''}"
-    target = tmp_path / current.install_path("scripts")
-    target.mkdir(parents=True)
-    executable = target / exe_name
-    os.symlink(sys.executable, str(executable))
-    pyvenv_cfg = Path(sys.executable).parents[1] / "pyvenv.cfg"
-    if pyvenv_cfg.exists():
-        (target / pyvenv_cfg.name).write_bytes(pyvenv_cfg.read_bytes())
-    monkeypatch.setenv("PATH", str(target))
-    interpreter = get_interpreter(spec, [])
 
     assert interpreter is not None
 

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -58,9 +58,6 @@ def test_discovery_via_path_specific(
     target.mkdir(parents=True)
     executable = target / exe_name
     os.symlink(sys.executable, str(executable))
-    pyvenv_cfg = Path(sys.executable).parents[1] / "pyvenv.cfg"
-    if pyvenv_cfg.exists():
-        (target / pyvenv_cfg.name).write_bytes(pyvenv_cfg.read_bytes())
     monkeypatch.setenv("PATH", str(target))
     interpreter = get_interpreter(spec, [])
 

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -33,7 +33,7 @@ def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, se
         # e.g. spec: python3.12.1, exe: /bin/python3
         core_ver = ".".join(str(i) for i in current.version_info[0:3])
         exe_ver = current.version_info.major
-    core = f"{name}{core_ver}"
+    core = f"somethingVeryCryptic{core_ver}"
     exe_name = f"{name}{exe_ver}{'.exe' if sys.platform == 'win32' else ''}"
     target = tmp_path / current.install_path("scripts")
     target.mkdir(parents=True)

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -5,6 +5,7 @@ import os
 import sys
 from argparse import Namespace
 from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
@@ -12,6 +13,9 @@ import pytest
 from virtualenv.discovery.builtin import Builtin, get_interpreter
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import fs_supports_symlink
+
+if TYPE_CHECKING:
+    from virtualenv.app_data.base import AppData
 
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink not supported")
@@ -36,6 +40,29 @@ def test_discovery_via_path(monkeypatch, case, tmp_path, caplog, session_app_dat
     new_path = os.pathsep.join([str(target), *os.environ.get("PATH", "").split(os.pathsep)])
     monkeypatch.setenv("PATH", new_path)
     interpreter = get_interpreter(core, [])
+
+    assert interpreter is not None
+
+
+@pytest.mark.skipif(not fs_supports_symlink(), reason="symlink not supported")
+def test_discovery_via_path_specific(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture, session_app_data: AppData
+):
+    """Test that a generic spec (e.g. python3) can be used to find a specific interpreter (e.g. python3.12)"""
+    caplog.set_level(logging.DEBUG)
+    current = PythonInfo.current_system(session_app_data)
+    name = "somethingVeryCryptic"
+    spec = f"{name}{current.version_info.major}"
+    exe_name = f"{name}{'.'.join(str(i) for i in current.version_info[:2])}{'.exe' if sys.platform == 'win32' else ''}"
+    target = tmp_path / current.install_path("scripts")
+    target.mkdir(parents=True)
+    executable = target / exe_name
+    os.symlink(sys.executable, str(executable))
+    pyvenv_cfg = Path(sys.executable).parents[1] / "pyvenv.cfg"
+    if pyvenv_cfg.exists():
+        (target / pyvenv_cfg.name).write_bytes(pyvenv_cfg.read_bytes())
+    monkeypatch.setenv("PATH", str(target))
+    interpreter = get_interpreter(spec, [])
 
     assert interpreter is not None
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,10 @@ set_env =
     _COVERAGE_SRC = {envsitepackagesdir}/virtualenv
 commands =
     coverage erase
-    coverage run -m pytest {posargs:--junitxml {toxworkdir}/junit.{envname}.xml tests --int}
+    coverage run -m pytest {posargs:--junitxml "{toxworkdir}/junit.{envname}.xml" tests --int}
     coverage combine
     coverage report --skip-covered --show-missing
-    coverage xml -o {toxworkdir}/coverage.{envname}.xml
+    coverage xml -o "{toxworkdir}/coverage.{envname}.xml"
     coverage html -d {envtmpdir}/htmlcov --show-contexts  --title virtualenv-{envname}-coverage
 uv_seed = true
 


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

Fixes https://github.com/pypa/virtualenv/issues/2708, fixes https://github.com/pypa/hatch/issues/1395

This PR fixes the discovery in `virtualenv.discovery.builtin`. 

It works by removing the method `PythonSpec.generate_names` and replacing it with `generate_re`:

A static name list can’t represent all Python executables that are compatible with a given spec, i.e. `PythonSpec.from_string_spec('3')` should match a executable called `/usr/bin/python3.12`. I therefore inverted the way candidates are found. Instead of generating all possible candidates, we simply loop and use a regex to find candidates.

Pro:
- Fixes the bug
- Instead of just trying all-lowercase and all-uppercase variants of candidates, we’re now truly case-insensitive

Con:
- Might be slower if a lot of executables hang out on PATH. Since Python’s `glob` just traverses directories in Python code as well, it wouldn‘t help here.

## How to review

The main commits are
- f29be4a71d09afef4aece4adef89a2e47dd4086f: Fixes the tox configuration so it can cope with spaces. Allows me to run tests on my system. Humanity needs to stop interpolating strings into shell scripts.
- 6f9f270ebfa491cdf5d9c3a3bd97c9647d7a8a74: Adds typing to the file I’m going to edit so I can make sense of what’s going on
- 16a6e1d5a0ccf1aaf9f44400f4f8bd0eb0ced9c6: Switch that file to pathlib, since you seem to be doing that elsewhere and it makes things more readable
- d9b52ada0f67e8c85ce58bd6f46c5aa37e1201bd: The actual changes, described above
