### PR TITLE
Fix PATH-based Python discovery on Windows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,11 +28,9 @@ jobs:
           - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
           - pypy-3.10
           - pypy-3.9
           - pypy-3.8
-          - pypy-3.7
         os:
           - ubuntu-latest
           - macos-latest
@@ -42,6 +40,12 @@ jobs:
           - { os: macos-latest, py: "brew@3.10" }
           - { os: macos-latest, py: "brew@3.9" }
           - { os: macos-latest, py: "brew@3.8" }
+          - { os: ubuntu-latest, py: "3.7" }
+          - { os: windows-latest, py: "3.7" }
+          - { os: macos-12, py: "3.7" }
+          - { os: ubuntu-latest, py: "pypy-3.7" }
+          - { os: windows-latest, py: "pypy-3.7" }
+          - { os: macos-12, py: "pypy-3.7" }
     steps:
       - uses: taiki-e/install-action@cargo-binstall
       - name: Install OS dependencies

--- a/docs/changelog/2712.bugfix.rst
+++ b/docs/changelog/2712.bugfix.rst
@@ -1,0 +1,1 @@
+fix PATH-based Python discovery on Windows - by :user:`ofek`.

--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -84,7 +84,7 @@ def get_interpreter(
     return None
 
 
-def propose_interpreters(  # noqa: C901, PLR0912
+def propose_interpreters(  # noqa: C901, PLR0912, PLR0915
     spec: PythonSpec,
     try_first_with: Iterable[str],
     app_data: AppData | None = None,

--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -124,7 +124,12 @@ def propose_interpreters(  # noqa: C901, PLR0912
             return
     else:
         # 2. otherwise try with the current
-        yield PythonInfo.current_system(app_data), True
+        current_python = PythonInfo.current_system(app_data)
+        exe_raw = str(current_python.executable)
+        exe_id = fs_path_id(exe_raw)
+        if exe_id not in tested_exes:
+            tested_exes.add(exe_id)
+            yield current_python, True
 
         # 3. otherwise fallback to platform default logic
         if IS_WIN:

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -83,7 +83,7 @@ class PythonSpec:
             "?"
             # Windows Python executables are almost always unversioned
             if windows
-            # Spec is an empty string, in which case the version part of the pattern will be: None
+            # Spec is an empty string
             or self.major is None
             else ""
         )

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -79,9 +79,17 @@ class PythonSpec:
         )
         impl = "python" if self.implementation is None else f"python|{re.escape(self.implementation)}"
         suffix = r"\.exe" if windows else ""
+        version_conditional = (
+            "?"
+            # Windows Python executables are almost always unversioned
+            if windows
+            # Spec is an empty string, in which case the version part of the pattern will be: None
+            or self.major is None
+            else ""
+        )
         # Try matching `direct` first, so the `direct` group is filled when possible.
         return re.compile(
-            rf"(?P<impl>{impl})(?P<v>{version}){suffix}$",
+            rf"(?P<impl>{impl})(?P<v>{version}){version_conditional}{suffix}$",
             flags=re.IGNORECASE,
         )
 

--- a/src/virtualenv/info.py
+++ b/src/virtualenv/info.py
@@ -48,6 +48,10 @@ def fs_supports_symlink():
     return _CAN_SYMLINK
 
 
+def fs_path_id(path: str) -> str:
+    return path.casefold() if fs_is_case_sensitive() else path
+
+
 __all__ = (
     "IS_CPYTHON",
     "IS_MAC_ARM64",
@@ -56,5 +60,6 @@ __all__ = (
     "IS_ZIPAPP",
     "ROOT",
     "fs_is_case_sensitive",
+    "fs_path_id",
     "fs_supports_symlink",
 )

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -37,7 +37,7 @@ def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, se
         # e.g. spec: python3.12.1, exe: /bin/python
         core_ver = ".".join(str(i) for i in current.version_info[0:3])
         exe_ver = ""
-    core = f"somethingVeryCryptic{core_ver}"
+    core = "" if specificity == "none" else f"{name}{core_ver}"
     exe_name = f"{name}{exe_ver}{'.exe' if sys.platform == 'win32' else ''}"
     target = tmp_path / current.install_path("scripts")
     target.mkdir(parents=True)

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -16,7 +16,7 @@ from virtualenv.info import fs_supports_symlink
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink not supported")
 @pytest.mark.parametrize("case", ["mixed", "lower", "upper"])
-@pytest.mark.parametrize("specificity", ["more", "less"])
+@pytest.mark.parametrize("specificity", ["more", "less", "none"])
 def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, session_app_data):  # noqa: PLR0913
     caplog.set_level(logging.DEBUG)
     current = PythonInfo.current_system(session_app_data)
@@ -33,6 +33,10 @@ def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, se
         # e.g. spec: python3.12.1, exe: /bin/python3
         core_ver = ".".join(str(i) for i in current.version_info[0:3])
         exe_ver = current.version_info.major
+    elif specificity == "none":
+        # e.g. spec: python3.12.1, exe: /bin/python
+        core_ver = ".".join(str(i) for i in current.version_info[0:3])
+        exe_ver = ""
     core = f"somethingVeryCryptic{core_ver}"
     exe_name = f"{name}{exe_ver}{'.exe' if sys.platform == 'win32' else ''}"
     target = tmp_path / current.install_path("scripts")


### PR DESCRIPTION
 This PR:

- Resolves #2711 
- Addresses another issue found during debugging which is that the PR that introduced the regression took out a check to make sure that executables exist before trying to gather data about the interpreter
- Added an optimization so that the entire discovery process prevents duplicate interpreter calls rather than just the PATH fallback at the end