### PR TITLE
Update activate_this.py documentation to use runpy instead of exec

### DIFF
--- a/src/virtualenv/activation/python/activate_this.py
+++ b/src/virtualenv/activation/python/activate_this.py
@@ -1,7 +1,8 @@
 """
 Activate virtualenv for current interpreter:
 
-Use exec(open(this_file).read(), {'__file__': this_file}).
+import runpy
+runpy.run_path(this_file)
 
 This can be used when you must use an existing Python interpreter, not the virtualenv bin/python.
 """  # noqa: D415
@@ -15,7 +16,7 @@ import sys
 try:
     abs_file = os.path.abspath(__file__)
 except NameError as exc:
-    msg = "You must use exec(open(this_file).read(), {'__file__': this_file})"
+    msg = "You must use import runpy; runpy.run_path(this_file)"
     raise AssertionError(msg) from exc
 
 bin_dir = os.path.dirname(abs_file)


### PR DESCRIPTION
runpy.run_path was added in python 2.7 and 3.2 - and every python that is not EOL supports it.

It is arguably nicer to read and the path is only given once in the command.

At least right now, runpy - unlike exec with S102 - is not flagged by bandit or bandit-derived (eg. ruff) checks.
(I guess because it loads from a file instead of a simple string...)

Because of the import, it is also not a one-liner anymore. 

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix - the change only updates documentation
- [X] added news fragment in `docs/changelog` folder: This is a tiny change, so I'm not sure it warrants a news fragment
- [X] updated/extended the documentation
