### PR TITLE
Fix bad return code in bash activation if hashing is disabled

### DIFF
--- a/docs/changelog/2717.bugfix.rst
+++ b/docs/changelog/2717.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bad return code from activate.sh if hashing is disabled - by :user:'fenkes-ibm'.

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -84,4 +84,4 @@ pydoc () {
 # The hash command must be called to get it to forget past
 # commands. Without forgetting past commands the $PATH changes
 # we made may not be respected
-hash -r 2>/dev/null
+hash -r 2>/dev/null || true

--- a/tests/unit/activation/conftest.py
+++ b/tests/unit/activation/conftest.py
@@ -79,6 +79,7 @@ class ActivationTester:
             process = Popen(invoke, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
             raw_, _ = process.communicate()
             raw = raw_.decode()
+            assert process.returncode == 0, raw
         except subprocess.CalledProcessError as exception:
             output = exception.output + exception.stderr
             assert not exception.returncode, output  # noqa: PT017

--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -7,7 +7,8 @@ from virtualenv.info import IS_WIN
 
 
 @pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
-def test_bash(raise_on_non_source_class, activation_tester):
+@pytest.mark.parametrize("hashing_enabled", [True, False])
+def test_bash(raise_on_non_source_class, hashing_enabled, activation_tester):
     class Bash(raise_on_non_source_class):
         def __init__(self, session) -> None:
             super().__init__(
@@ -18,6 +19,11 @@ def test_bash(raise_on_non_source_class, activation_tester):
                 "sh",
                 "You must source this script: $ source ",
             )
+            self.deactivate += " || exit 1"
+            self._invoke_script.append("-h" if hashing_enabled else "+h")
+
+        def activate_call(self, script):
+            return super().activate_call(script) + " || exit 1"
 
         def print_prompt(self):
             return self.print_os_env_var("PS1")


### PR DESCRIPTION
If hashing is disabled in bash, the `hash` command will return a nonzero return code. Since it is the last command in the script that return code will also be the "return code" of the source command, so if anyone uses

source activate.sh || die horribly

having hashing disabled will ruin their day.

Fix this by overriding the return code of `hash` if it's bad. Add tests to verify a good return code and try with and without hashing.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
