### PR TITLE
Update pyproject.toml so it validates.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ keywords = [
   "isolated",
   "virtual",
 ]
-license = "MIT"
 maintainers = [
   { name = "Bernat Gabor", email = "gaborjbernat@gmail.com" },
 ]


### PR DESCRIPTION
While working with the Poetry's [proposed support for the `project` section](https://github.com/python-poetry/poetry/pull/9135) in pyproject.toml, it identified the following problems:

``` console
$ poetry check

The Poetry configuration is invalid:
  - project.license must be valid exactly by one definition (0 matches found)
  - Either [project.version] or [tool.poetry.version] is required in package mode.
```

Since the [license field is awkward](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license), [is not required](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license), and is specified in the classifiers, it could be removed.

The second issue from `poetry check` is probably a non-issue since the version is dynamic.