### PR TITLE
limit filelock to highest compatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dynamic = [
 ]
 dependencies = [
   "distlib<1,>=0.3.7",
-  "filelock<4,>=3.12.2",
+  "filelock<3.15,>=3.12.2",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs<5,>=3.9.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dynamic = [
 ]
 dependencies = [
   "distlib<1,>=0.3.7",
-  "filelock<4,>=3.12.2,!=3.15.0",
+  "filelock<4,>=3.12.2,!=3.15",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs<5,>=3.9.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dynamic = [
 ]
 dependencies = [
   "distlib<1,>=0.3.7",
-  "filelock<3.15,>=3.12.2",
+  "filelock<4,>=3.12.2,!=3.15.0",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs<5,>=3.9.1",
 ]


### PR DESCRIPTION
filelock 3.15.0 was just released and causes the following crash when used with the latest version of virtualenv

```
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.10.11/lib/python3.10/site-packages/filelock/_api.py", line 365, in __del__
    self.release(force=True)
  File "/root/.pyenv/versions/3.10.11/lib/python3.10/site-packages/virtualenv/util/lock.py", line 34, in release
    with self.thread_safe:
AttributeError: '_CountedFileLock' object has no attribute 'thread_safe'
```

This change avoids depending on this new incompatible version of filelock.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
