### PR TITLE
Test latest Python 3.13

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - "3.13.0-beta.2"
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -93,6 +93,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
+          allow-prereleases: true
       - name: Pick environment to run
         run: |
           import os; import platform; import sys; from pathlib import Path


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [n/a] updated/extended the documentation

Instead of pinning beta 2 of Python 3.13 on the CI, use `"3.13"` to install the latest release. Right now, that is RC1.
