### PR TITLE
Fix typo in Nushell activation script

### DIFF
--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -17,7 +17,7 @@ export-env {
         } | all {|i| $i == true}
     }
 
-    # Emulates a `test -z`, but btter as it handles e.g 'false'
+    # Emulates a `test -z`, but better as it handles e.g 'false'
     def is-env-true [name: string] {
       if (has-env $name) {
         # Try to parse 'true', '0', '1', and fail if not convertible


### PR DESCRIPTION
Spotted as part of https://github.com/astral-sh/uv/pull/6910, since uv vendors this file.
