### PR TITLE
GitHub Actions: Replace deprecated macos-12 with macos-13

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,10 +42,10 @@ jobs:
           - { os: macos-latest, py: "brew@3.8" }
           - { os: ubuntu-latest, py: "3.7" }
           - { os: windows-latest, py: "3.7" }
-          - { os: macos-12, py: "3.7" }
+          - { os: macos-13, py: "3.7" }
           - { os: ubuntu-latest, py: "pypy-3.7" }
           - { os: windows-latest, py: "pypy-3.7" }
-          - { os: macos-12, py: "pypy-3.7" }
+          - { os: macos-13, py: "pypy-3.7" }
         exclude:
           - { os: windows-latest, py: "pypy-3.10" }
           - { os: windows-latest, py: "pypy-3.9" }


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [n/a] updated/extended the documentation


> **macOS12 runner image**
We are beginning the deprecation process for the macOS 12 runner image, which allows us to balance our fleet capacity ahead of our upcoming [macOS 15 launch](https://github.com/github/roadmap/issues/986). This image will be fully retired by the December 3rd, 2024. We recommend updating workflows to use `macos-14`, `macos-13`, or `macos-latest`.

https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

Replace macos-12 with macos-13, both are Intel and pass for Python 3.7.
