### PR TITLE
feat: Write CACHEDIR.TAG file

### DIFF
--- a/docs/changelog/2803.feature.rst
+++ b/docs/changelog/2803.feature.rst
@@ -1,0 +1,1 @@
+write CACHEDIR.TAG file on creation - by "user:`neilramsay`

--- a/docs/changelog/2803.feature.rst
+++ b/docs/changelog/2803.feature.rst
@@ -1,1 +1,1 @@
-write CACHEDIR.TAG file on creation - by "user:`neilramsay`
+Write CACHEDIR.TAG file on creation - by "user:`neilramsay`.

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -164,22 +164,14 @@ class Creator(ABC):
             self.setup_ignore_vcs()
 
     def add_cachedir_tag(self):
-        """
-        Add a Cache Directory Tag file "CACHEDIR.TAG".
-
-        The CACHEDIR.TAG file is used by various tools to mark
-        a directory as cache, so that it can be handled differently.
-        Some backup tools look for this file to exclude the directory.
-
-        See https://bford.info/cachedir/ for more details.
-        """
+        """Generate a file indicating that this is not meant to be backed up."""
         cachedir_tag_file = self.dest / "CACHEDIR.TAG"
         if not cachedir_tag_file.exists():
             cachedir_tag_text = textwrap.dedent("""
                 Signature: 8a477f597d28d172789f06886806bc55
                 # This file is a cache directory tag created by Python virtualenv.
                 # For information about cache directory tags, see:
-                #   http://www.brynosaurus.com/cachedir/
+                #   https://bford.info/cachedir/
             """).strip()
             cachedir_tag_file.write_text(cachedir_tag_text, encoding="utf-8")
 

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sys
+import textwrap
 from abc import ABC, abstractmethod
 from argparse import ArgumentTypeError
 from ast import literal_eval
@@ -157,9 +158,30 @@ class Creator(ABC):
             LOGGER.debug("delete %s", self.dest)
             safe_delete(self.dest)
         self.create()
+        self.add_cachedir_tag()
         self.set_pyenv_cfg()
         if not self.no_vcs_ignore:
             self.setup_ignore_vcs()
+
+    def add_cachedir_tag(self):
+        """
+        Add a Cache Directory Tag file "CACHEDIR.TAG".
+
+        The CACHEDIR.TAG file is used by various tools to mark
+        a directory as cache, so that it can be handled differently.
+        Some backup tools look for this file to exclude the directory.
+
+        See https://bford.info/cachedir/ for more details.
+        """
+        cachedir_tag_file = self.dest / "CACHEDIR.TAG"
+        if not cachedir_tag_file.exists():
+            cachedir_tag_text = textwrap.dedent("""
+                Signature: 8a477f597d28d172789f06886806bc55
+                # This file is a cache directory tag created by Python virtualenv.
+                # For information about cache directory tags, see:
+                #   http://www.brynosaurus.com/cachedir/
+            """).strip()
+            cachedir_tag_file.write_text(cachedir_tag_text, encoding="utf-8")
 
     def set_pyenv_cfg(self):
         self.pyenv_cfg.content = OrderedDict()

--- a/tests/integration/test_cachedir_tag.py
+++ b/tests/integration/test_cachedir_tag.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from virtualenv import cli_run
+
+
+@pytest.fixture(scope="session")
+def tar_test_env(tmp_path_factory):
+    base_path = tmp_path_factory.mktemp("tar-cachedir-test")
+    cli_run(["--activators", "", "--without-pip", str(base_path / ".venv")])
+    yield base_path
+    shutil.rmtree(str(base_path))
+
+
+def compatible_is_tar_present() -> bool:
+    try:
+        tar_result = subprocess.run(args=["tar", "--help"], capture_output=True, encoding="utf-8")
+        return tar_result.stdout.find("--exclude-caches") > -1
+    except FileNotFoundError:
+        return False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have tar")
+@pytest.mark.skipif(not compatible_is_tar_present(), reason="Compatible tar is not installed")
+def test_cachedir_tag_ignored_by_tag(tar_test_env):  # noqa: ARG001
+    tar_result = subprocess.run(
+        args=["tar", "--create", "--file", "/dev/null", "--exclude-caches", "--verbose", ".venv"],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert tar_result.stdout == ".venv/\n.venv/CACHEDIR.TAG\n"
+    assert tar_result.stderr == "tar: .venv/: contains a cache directory tag CACHEDIR.TAG; contents not dumped\n"

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -11,6 +11,7 @@ import site
 import stat
 import subprocess
 import sys
+import textwrap
 import zipfile
 from collections import OrderedDict
 from itertools import product
@@ -221,6 +222,34 @@ def test_create_no_seed(  # noqa: C901, PLR0912, PLR0913, PLR0915
     else:
         comment = "# created by virtualenv automatically"
     assert git_ignore.splitlines() == [comment, "*"]
+
+
+def test_create_cachedir_tag(tmp_path):
+    cachedir_tag_file = tmp_path / "CACHEDIR.TAG"
+    cli_run([str(tmp_path), "--without-pip", "--activators", ""])
+    assert (
+        cachedir_tag_file.read_text(encoding="utf-8")
+        == textwrap.dedent("""
+    Signature: 8a477f597d28d172789f06886806bc55
+    # This file is a cache directory tag created by Python virtualenv.
+    # For information about cache directory tags, see:
+    #   http://www.brynosaurus.com/cachedir/
+    """).strip()
+    )
+
+
+def test_create_cachedir_tag_exists(tmp_path):
+    cachedir_tag_file = tmp_path / "CACHEDIR.TAG"
+    cachedir_tag_file.write_text("magic", encoding="utf-8")
+    cli_run([str(tmp_path), "--without-pip", "--activators", ""])
+    assert cachedir_tag_file.read_text(encoding="utf-8") == "magic"
+
+
+def test_create_cachedir_tag_exists_override(tmp_path):
+    cachedir_tag_file = tmp_path / "CACHEDIR.TAG"
+    cachedir_tag_file.write_text("magic", encoding="utf-8")
+    cli_run([str(tmp_path), "--without-pip", "--activators", ""])
+    assert cachedir_tag_file.read_text(encoding="utf-8") == "magic"
 
 
 def test_create_vcs_ignore_exists(tmp_path):

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -227,25 +227,24 @@ def test_create_no_seed(  # noqa: C901, PLR0912, PLR0913, PLR0915
 def test_create_cachedir_tag(tmp_path):
     cachedir_tag_file = tmp_path / "CACHEDIR.TAG"
     cli_run([str(tmp_path), "--without-pip", "--activators", ""])
-    assert (
-        cachedir_tag_file.read_text(encoding="utf-8")
-        == textwrap.dedent("""
+
+    expected = """
     Signature: 8a477f597d28d172789f06886806bc55
     # This file is a cache directory tag created by Python virtualenv.
     # For information about cache directory tags, see:
-    #   http://www.brynosaurus.com/cachedir/
-    """).strip()
-    )
+    #   https://bford.info/cachedir/
+    """
+    assert cachedir_tag_file.read_text(encoding="utf-8") == textwrap.dedent(expected).strip()
 
 
-def test_create_cachedir_tag_exists(tmp_path):
+def test_create_cachedir_tag_exists(tmp_path: Path) -> None:
     cachedir_tag_file = tmp_path / "CACHEDIR.TAG"
     cachedir_tag_file.write_text("magic", encoding="utf-8")
     cli_run([str(tmp_path), "--without-pip", "--activators", ""])
     assert cachedir_tag_file.read_text(encoding="utf-8") == "magic"
 
 
-def test_create_cachedir_tag_exists_override(tmp_path):
+def test_create_cachedir_tag_exists_override(tmp_path: Path) -> None:
     cachedir_tag_file = tmp_path / "CACHEDIR.TAG"
     cachedir_tag_file.write_text("magic", encoding="utf-8")
     cli_run([str(tmp_path), "--without-pip", "--activators", ""])


### PR DESCRIPTION
Write a Cache Directory Tag file "CACHEDIR.TAG" to created directory.

The CACHEDIR.TAG file is used by various tools to mark a directory as cache, so that it can be handled differently. Some backup tools look for this file to exclude the directory. For example, tar includes the --exclude-caches option.

See https://bford.info/cachedir/ for more details.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation