### PR TITLE
fix: Update run_with_catch log flushing

### DIFF
--- a/src/virtualenv/__main__.py
+++ b/src/virtualenv/__main__.py
@@ -65,7 +65,8 @@ def run_with_catch(args=None, env=None):
             code = exception.code if isinstance(exception, SystemExit) else 1
             sys.exit(code)
         finally:
-            LOGGER.shutdown()  # force flush of log messages before the trace is printed
+            for handler in LOGGER.handlers:  # force flush of log messages before the trace is printed
+                handler.flush()
 
 
 if __name__ == "__main__":  # pragma: no cov


### PR DESCRIPTION
`run_with_catch` is flushing the Python standard library logger prior to any traces are printed.

It appears the function logger.shutdown() does not work. Instead each logger handler stream should be flushed individually.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
