### PR TITLE
Add free-threaded Python support

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -105,7 +105,14 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Pick environment to run
+        if: matrix.py != '3.13t'
         run: python tasks/pick_tox_env.py ${{ matrix.py }}
+      - name: Pick environment to run
+        if: matrix.py == '3.13t' && runner.os != 'Windows'
+        run: python tasks/pick_tox_env.py ${{ matrix.py }} $Python_ROOT_DIR/bin/python
+      - name: Pick environment to run
+        if: matrix.py == '3.13t' && runner.os == 'Windows'
+        run: python tasks/pick_tox_env.py ${{ matrix.py }} $Python_ROOT_DIR\python.exe
       - name: Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false
       - name: Run test suite

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -117,7 +117,7 @@ jobs:
         run: tox run -vv --notest --skip-missing-interpreters false
       - name: Run test suite
         run: tox run --skip-pkg-install
-        timeout-minutes: 20
+        timeout-minutes: 25
         env:
           PYTEST_ADDOPTS: "-vv --durations=20"
           CI_RUN: "yes"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -78,10 +78,10 @@ jobs:
         shell: bash
         run: echo ~/.local/bin >> $GITHUB_PATH
       - name: Install tox
-        if: matrix.py == '3.13'
+        if: matrix.py == '3.13' || matrix.py == '3.13t'
         run: uv tool install --python-preference only-managed --python 3.12 tox --with tox-uv
       - name: Install tox
-        if: matrix.py != '3.13'
+        if: "!(matrix.py == '3.13' || matrix.py == '3.13t')"
         run: uv tool install --python-preference only-managed --python 3.13 tox --with tox-uv
       - name: Setup brew python for test ${{ matrix.py }}
         if: startsWith(matrix.py, 'brew@')

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -92,7 +92,7 @@ jobs:
           echo "/usr/local/opt/python@$PY/libexec/bin" >>"${GITHUB_PATH}"
         shell: bash
       - name: Setup python for test ${{ matrix.py }}
-        if: "!( startsWith(matrix.py, 'brew@') || endsWith(matrix.py, 't'))"
+        if: "!(startsWith(matrix.py, 'brew@') || endsWith(matrix.py, 't'))"
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.13t"
           - "3.13"
           - "3.12"
           - "3.11"
@@ -83,7 +84,7 @@ jobs:
         if: matrix.py != '3.13'
         run: uv tool install --python-preference only-managed --python 3.13 tox --with tox-uv
       - name: Setup brew python for test ${{ matrix.py }}
-        if: startsWith(matrix.py,'brew@')
+        if: startsWith(matrix.py, 'brew@')
         run: |
           set -e
           PY=$(echo '${{ matrix.py }}' | cut -c 6-)
@@ -91,11 +92,18 @@ jobs:
           echo "/usr/local/opt/python@$PY/libexec/bin" >>"${GITHUB_PATH}"
         shell: bash
       - name: Setup python for test ${{ matrix.py }}
-        if: "!( startsWith(matrix.py,'brew@') || endsWith(matrix.py, '-dev') )"
+        if: "!( startsWith(matrix.py, 'brew@') || endsWith(matrix.py, 't'))"
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
           allow-prereleases: true
+      # quansight-labs to install free-threaded python until actions/setup-python supports it
+      # https://github.com/actions/setup-python/issues/771
+      - name: Setup python for test ${{ matrix.py }}
+        if: endsWith(matrix.py, 't')
+        uses: quansight-labs/setup-python@v5.3.1
+        with:
+          python-version: ${{ matrix.py }}
       - name: Pick environment to run
         run: python tasks/pick_tox_env.py ${{ matrix.py }}
       - name: Setup test suite

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -112,7 +112,7 @@ jobs:
         run: python tasks/pick_tox_env.py ${{ matrix.py }} $Python_ROOT_DIR/bin/python
       - name: Pick environment to run
         if: matrix.py == '3.13t' && runner.os == 'Windows'
-        run: python tasks/pick_tox_env.py ${{ matrix.py }} $Python_ROOT_DIR\python.exe
+        run: python tasks/pick_tox_env.py ${{ matrix.py }} $env:Python_ROOT_DIR\python.exe
       - name: Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false
       - name: Run test suite

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -117,7 +117,7 @@ jobs:
         run: tox run -vv --notest --skip-missing-interpreters false
       - name: Run test suite
         run: tox run --skip-pkg-install
-        timeout-minutes: 25
+        timeout-minutes: 20
         env:
           PYTEST_ADDOPTS: "-vv --durations=20"
           CI_RUN: "yes"

--- a/docs/changelog/2809.feature.rst
+++ b/docs/changelog/2809.feature.rst
@@ -1,0 +1,1 @@
+Add support for selecting free-threaded Python interpreters, e.g., `python3.13t`.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -84,7 +84,7 @@ Python and OS Compatibility
 
 virtualenv works with the following Python interpreter implementations:
 
-- `CPython <https://www.python.org/>`_: ``3.12 >= python_version >= 3.7``
+- `CPython <https://www.python.org/>`_: ``3.13 >= python_version >= 3.7``
 - `PyPy <https://pypy.org/>`_: ``3.10 >= python_version >= 3.7``
 
 This means virtualenv works on the latest patch version of each of these minor versions. Previous patch versions are

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -86,7 +86,7 @@ format is either:
 
     - the python implementation is all alphabetic characters (``python`` means any implementation, and if is missing it
       defaults to ``python``),
-    - the version is a dot separated version number,
+    - the version is a dot separated version number optionally followed by ``t`` for free-threading,
     - the architecture is either ``-64`` or ``-32`` (missing means ``any``).
 
     For example:

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -93,6 +93,7 @@ format is either:
 
     - ``python3.8.1`` means any python implementation having the version ``3.8.1``,
     - ``3`` means any python implementation having the major version ``3``,
+    - ``3.13t`` means any python implementation having the version ``3.13`` with free threading,
     - ``cpython3`` means a ``CPython`` implementation having the version ``3``,
     - ``pypy2`` means a python interpreter with the ``PyPy`` implementation and major version ``2``.
 

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -52,6 +52,7 @@ class PythonInfo:  # noqa: PLR0904
 
         self.version = sys.version
         self.os = os.name
+        self.free_threaded = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
 
         # information about the prefix - determines python home
         self.prefix = abs_path(getattr(sys, "prefix", None))  # prefix we think
@@ -290,7 +291,12 @@ class PythonInfo:  # noqa: PLR0904
 
     @property
     def spec(self):
-        return "{}{}-{}".format(self.implementation, ".".join(str(i) for i in self.version_info), self.architecture)
+        return "{}{}{}-{}".format(
+            self.implementation,
+            ".".join(str(i) for i in self.version_info),
+            "t" if self.free_threaded else "",
+            self.architecture,
+        )
 
     @classmethod
     def clear_cache(cls, app_data):

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -306,7 +306,7 @@ class PythonInfo:  # noqa: PLR0904
         clear(app_data)
         cls._cache_exe_discovery.clear()
 
-    def satisfies(self, spec, impl_must_match):  # noqa: C901
+    def satisfies(self, spec, impl_must_match):  # noqa: C901, PLR0911
         """Check if a given specification can be satisfied by the this python interpreter instance."""
         if spec.path:
             if self.executable == os.path.abspath(spec.path):
@@ -330,6 +330,9 @@ class PythonInfo:  # noqa: PLR0904
             return False
 
         if spec.architecture is not None and spec.architecture != self.architecture:
+            return False
+
+        if spec.free_threaded is not None and spec.free_threaded != self.free_threaded:
             return False
 
         for our, req in zip(self.version_info[0:3], (spec.major, spec.minor, spec.micro)):
@@ -528,10 +531,14 @@ class PythonInfo:  # noqa: PLR0904
         for name in self._possible_base():
             for at in (3, 2, 1, 0):
                 version = ".".join(str(i) for i in self.version_info[:at])
-                for arch in [f"-{self.architecture}", ""]:
-                    for ext in EXTENSIONS:
-                        candidate = f"{name}{version}{arch}{ext}"
-                        name_candidate[candidate] = None
+                mods = [""]
+                if self.free_threaded:
+                    mods.append("t")
+                for mod in mods:
+                    for arch in [f"-{self.architecture}", ""]:
+                        for ext in EXTENSIONS:
+                            candidate = f"{name}{version}{mod}{arch}{ext}"
+                            name_candidate[candidate] = None
         return list(name_candidate.keys())
 
     def _possible_base(self):

--- a/src/virtualenv/discovery/py_spec.py
+++ b/src/virtualenv/discovery/py_spec.py
@@ -21,7 +21,7 @@ class PythonSpec:
         architecture: int | None,
         path: str | None,
         *,
-        free_threaded: bool = False,
+        free_threaded: bool | None = None,
     ) -> None:
         self.str_spec = str_spec
         self.implementation = implementation
@@ -34,7 +34,7 @@ class PythonSpec:
 
     @classmethod
     def from_string_spec(cls, string_spec: str):  # noqa: C901, PLR0912
-        impl, major, minor, micro, threaded, arch, path = None, None, None, None, False, None, None
+        impl, major, minor, micro, threaded, arch, path = None, None, None, None, None, None, None
         if os.path.isabs(string_spec):  # noqa: PLR1702
             path = string_spec
         else:

--- a/src/virtualenv/discovery/windows/__init__.py
+++ b/src/virtualenv/discovery/windows/__init__.py
@@ -27,14 +27,14 @@ def propose_interpreters(spec, cache_dir, env):
         reverse=True,
     )
 
-    for name, major, minor, arch, exe, _ in existing:
+    for name, major, minor, arch, threaded, exe, _ in existing:
         # Map well-known/most common organizations to a Python implementation, use the org name as a fallback for
         # backwards compatibility.
         implementation = _IMPLEMENTATION_BY_ORG.get(name, name)
 
         # Pre-filtering based on Windows Registry metadata, for CPython only
         skip_pre_filter = implementation.lower() != "cpython"
-        registry_spec = PythonSpec(None, implementation, major, minor, None, arch, exe)
+        registry_spec = PythonSpec(None, implementation, major, minor, None, arch, exe, free_threaded=threaded)
         if skip_pre_filter or registry_spec.satisfies(spec):
             interpreter = Pep514PythonInfo.from_exe(exe, cache_dir, env=env, raise_on_error=False)
             if interpreter is not None and interpreter.satisfies(spec, impl_must_match=True):

--- a/src/virtualenv/discovery/windows/pep514.py
+++ b/src/virtualenv/discovery/windows/pep514.py
@@ -142,10 +142,12 @@ def parse_version(version_str):
 def load_threaded(hive_name, company, tag, tag_key):
     display_name = get_value(tag_key, "DisplayName")
     if display_name is not None:
-        if isinstance(display_name, str) and "freethreaded" in display_name.lower():
-            return True
-        key_path = f"{hive_name}/{company}/{tag}/DisplayName"
-        msg(key_path, f"display name is not string: {display_name!r}")
+        if isinstance(display_name, str):
+            if "freethreaded" in display_name.lower():
+                return True
+        else:
+            key_path = f"{hive_name}/{company}/{tag}/DisplayName"
+            msg(key_path, f"display name is not string: {display_name!r}")
     return bool(re.match(r"^\d+(\.\d+){0,2}t$", tag, flags=re.IGNORECASE))
 
 

--- a/src/virtualenv/discovery/windows/pep514.py
+++ b/src/virtualenv/discovery/windows/pep514.py
@@ -65,7 +65,8 @@ def process_tag(hive_name, company, company_key, tag, default_arch):
                 exe_data = load_exe(hive_name, company, company_key, tag)
                 if exe_data is not None:
                     exe, args = exe_data
-                    return company, major, minor, arch, exe, args
+                    threaded = load_threaded(hive_name, company, tag, tag_key)
+                    return company, major, minor, arch, threaded, exe, args
                 return None
             return None
         return None
@@ -136,6 +137,16 @@ def parse_version(version_str):
     else:
         error = f"version is not string: {version_str!r}"
     raise ValueError(error)
+
+
+def load_threaded(hive_name, company, tag, tag_key):
+    display_name = get_value(tag_key, "DisplayName")
+    if display_name is not None:
+        if isinstance(display_name, str):
+            return "freethreaded" in display_name.lower()
+        key_path = f"{hive_name}/{company}/{tag}/DisplayName"
+        msg(key_path, f"display name is not string: {display_name!r}")
+    return bool(re.match(r"^\d+(\.\d+){0,2}t$", tag, flags=re.IGNORECASE))
 
 
 def msg(path, what):

--- a/src/virtualenv/discovery/windows/pep514.py
+++ b/src/virtualenv/discovery/windows/pep514.py
@@ -142,8 +142,8 @@ def parse_version(version_str):
 def load_threaded(hive_name, company, tag, tag_key):
     display_name = get_value(tag_key, "DisplayName")
     if display_name is not None:
-        if isinstance(display_name, str):
-            return "freethreaded" in display_name.lower()
+        if isinstance(display_name, str) and "freethreaded" in display_name.lower():
+            return True
         key_path = f"{hive_name}/{company}/{tag}/DisplayName"
         msg(key_path, f"display name is not string: {display_name!r}")
     return bool(re.match(r"^\d+(\.\d+){0,2}t$", tag, flags=re.IGNORECASE))

--- a/tasks/pick_tox_env.py
+++ b/tasks/pick_tox_env.py
@@ -8,5 +8,7 @@ py = sys.argv[1]
 if py.startswith("brew@"):
     py = py[len("brew@") :]
 env = f"TOXENV={py}"
+if len(sys.argv) > 2:  # noqa: PLR2004
+    env += f"\nTOX_BASEPYTHON={sys.argv[2]}"
 with Path(os.environ["GITHUB_ENV"]).open("ta", encoding="utf-8") as file_handler:
     file_handler.write(env)

--- a/tests/integration/test_zipapp.py
+++ b/tests/integration/test_zipapp.py
@@ -26,23 +26,26 @@ def zipapp_build_env(tmp_path_factory):
         exe, found = None, False
         # prefer CPython as builder as pypy is slow
         for impl in ["cpython", ""]:
-            for version in range(11, 6, -1):
-                with suppress(Exception):
-                    # create a virtual environment which is also guaranteed to contain a recent enough pip (bundled)
-                    session = cli_run(
-                        [
-                            "-vvv",
-                            "-p",
-                            f"{impl}3.{version}",
-                            "--activators",
-                            "",
-                            str(create_env_path),
-                            "--no-download",
-                            "--no-periodic-update",
-                        ],
-                    )
-                    exe = str(session.creator.exe)
-                    found = True
+            for threaded in ["", "t"]:
+                for version in range(11, 6, -1):
+                    with suppress(Exception):
+                        # create a virtual environment which is also guaranteed to contain a recent enough pip (bundled)
+                        session = cli_run(
+                            [
+                                "-vvv",
+                                "-p",
+                                f"{impl}3.{version}{threaded}",
+                                "--activators",
+                                "",
+                                str(create_env_path),
+                                "--no-download",
+                                "--no-periodic-update",
+                            ],
+                        )
+                        exe = str(session.creator.exe)
+                        found = True
+                        break
+                if found:
                     break
             if found:
                 break

--- a/tests/unit/create/via_global_ref/builtin/cpython/cpython3_win_embed.json
+++ b/tests/unit/create/via_global_ref/builtin/cpython/cpython3_win_embed.json
@@ -57,5 +57,6 @@
   "system_stdlib": "c:\\path\\to\\python\\Lib",
   "system_stdlib_platform": "c:\\path\\to\\python\\Lib",
   "max_size": 9223372036854775807,
-  "_creators": null
+  "_creators": null,
+  "free_threaded": false
 }

--- a/tests/unit/create/via_global_ref/builtin/pypy/deb_pypy37.json
+++ b/tests/unit/create/via_global_ref/builtin/pypy/deb_pypy37.json
@@ -60,5 +60,6 @@
   "system_stdlib": "/usr/lib/pypy3/lib-python/3.7",
   "system_stdlib_platform": "/usr/lib/pypy3/lib-python/3.7",
   "max_size": 9223372036854775807,
-  "_creators": null
+  "_creators": null,
+  "free_threaded": false
 }

--- a/tests/unit/create/via_global_ref/builtin/pypy/deb_pypy38.json
+++ b/tests/unit/create/via_global_ref/builtin/pypy/deb_pypy38.json
@@ -60,5 +60,6 @@
   "system_stdlib": "/usr/lib/pypy3.8",
   "system_stdlib_platform": "/usr/lib/pypy3.8",
   "max_size": 9223372036854775807,
-  "_creators": null
+  "_creators": null,
+  "free_threaded": false
 }

--- a/tests/unit/create/via_global_ref/builtin/pypy/portable_pypy38.json
+++ b/tests/unit/create/via_global_ref/builtin/pypy/portable_pypy38.json
@@ -59,5 +59,6 @@
   "system_stdlib": "/tmp/pypy3.8-v7.3.8-linux64/lib/pypy3.8",
   "system_stdlib_platform": "/tmp/pypy3.8-v7.3.8-linux64/lib/pypy3.8",
   "max_size": 9223372036854775807,
-  "_creators": null
+  "_creators": null,
+  "free_threaded": false
 }

--- a/tests/unit/create/via_global_ref/test_build_c_ext.py
+++ b/tests/unit/create/via_global_ref/test_build_c_ext.py
@@ -41,10 +41,19 @@ def test_can_build_c_extensions(creator, tmp_path, coverage_env):
     shutil.copytree(str(Path(__file__).parent.resolve() / "greet"), greet)
     session = cli_run(["--creator", creator, "--seeder", "app-data", str(env), "-vvv"])
     coverage_env()
+    setuptools_index_args = ()
+    if CURRENT.version_info >= (3, 12):
+        # requires to be able to install setuptools as build dependency
+        setuptools_index_args = (
+            "--find-links",
+            "https://pypi.org/simple/setuptools/",
+        )
+
     cmd = [
         str(session.creator.script("pip")),
         "install",
         "--no-index",
+        *setuptools_index_args,
         "--no-deps",
         "--disable-pip-version-check",
         "-vvv",

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -94,7 +94,7 @@ def test_satisfy_not_arch():
 
 def test_satisfy_not_threaded():
     parsed_spec = PythonSpec.from_string_spec(
-        f"{CURRENT.implementation}{'' if CURRENT.free_threaded else 't'}",
+        f"{CURRENT.implementation}{CURRENT.version_info.major}{'' if CURRENT.free_threaded else 't'}",
     )
     matches = CURRENT.satisfies(parsed_spec, True)
     assert matches is False

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -26,7 +26,9 @@ def test_current_as_json():
     result = CURRENT._to_json()  # noqa: SLF001
     parsed = json.loads(result)
     a, b, c, d, e = sys.version_info
+    f = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
     assert parsed["version_info"] == {"major": a, "minor": b, "micro": c, "releaselevel": d, "serial": e}
+    assert parsed["free_threaded"] is f
 
 
 def test_bad_exe_py_info_raise(tmp_path, session_app_data):
@@ -59,7 +61,7 @@ def test_bad_exe_py_info_no_raise(tmp_path, caplog, capsys, session_app_data):
     itertools.chain(
         [sys.executable],
         [
-            f"{impl}{'.'.join(str(i) for i in ver)}{arch}"
+            f"{impl}{'.'.join(str(i) for i in ver)}{'t' if CURRENT.free_threaded else ''}{arch}"
             for impl, ver, arch in itertools.product(
                 (
                     [CURRENT.implementation]
@@ -85,6 +87,14 @@ def test_satisfy_py_info(spec):
 def test_satisfy_not_arch():
     parsed_spec = PythonSpec.from_string_spec(
         f"{CURRENT.implementation}-{64 if CURRENT.architecture == 32 else 32}",
+    )
+    matches = CURRENT.satisfies(parsed_spec, True)
+    assert matches is False
+
+
+def test_satisfy_not_threaded():
+    parsed_spec = PythonSpec.from_string_spec(
+        f"{CURRENT.implementation}{'' if CURRENT.free_threaded else 't'}",
     )
     matches = CURRENT.satisfies(parsed_spec, True)
     assert matches is False

--- a/tests/unit/discovery/py_info/test_py_info_exe_based_of.py
+++ b/tests/unit/discovery/py_info/test_py_info_exe_based_of.py
@@ -30,7 +30,7 @@ def test_discover_ok(tmp_path, suffix, impl, version, arch, into, caplog, sessio
     caplog.set_level(logging.DEBUG)
     folder = tmp_path / into
     folder.mkdir(parents=True, exist_ok=True)
-    name = f"{impl}{version}"
+    name = f"{impl}{version}{'t' if CURRENT.free_threaded else ''}"
     if arch:
         name += f"-{arch}"
     name += suffix

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -29,7 +29,7 @@ def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, se
     if specificity == "more":
         # e.g. spec: python3, exe: /bin/python3.12
         core_ver = current.version_info.major
-        exe_ver = ".".join(str(i) for i in current.version_info[0:2])
+        exe_ver = ".".join(str(i) for i in current.version_info[0:2]) + threaded
     elif specificity == "less":
         # e.g. spec: python3.12.1, exe: /bin/python3
         core_ver = ".".join(str(i) for i in current.version_info[0:3])
@@ -38,7 +38,7 @@ def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, se
         # e.g. spec: python3.12.1, exe: /bin/python
         core_ver = ".".join(str(i) for i in current.version_info[0:3])
         exe_ver = ""
-    core = threaded if specificity == "none" else f"{name}{threaded}{core_ver}"
+    core = "" if specificity == "none" else f"{name}{core_ver}{threaded}"
     exe_name = f"{name}{exe_ver}{'.exe' if sys.platform == 'win32' else ''}"
     target = tmp_path / current.install_path("scripts")
     target.mkdir(parents=True)

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -21,6 +21,7 @@ def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, se
     caplog.set_level(logging.DEBUG)
     current = PythonInfo.current_system(session_app_data)
     name = "somethingVeryCryptic"
+    threaded = "t" if current.free_threaded else ""
     if case == "lower":
         name = name.lower()
     elif case == "upper":
@@ -37,7 +38,7 @@ def test_discovery_via_path(monkeypatch, case, specificity, tmp_path, caplog, se
         # e.g. spec: python3.12.1, exe: /bin/python
         core_ver = ".".join(str(i) for i in current.version_info[0:3])
         exe_ver = ""
-    core = "" if specificity == "none" else f"{name}{core_ver}"
+    core = threaded if specificity == "none" else f"{name}{threaded}{core_ver}"
     exe_name = f"{name}{exe_ver}{'.exe' if sys.platform == 'win32' else ''}"
     target = tmp_path / current.install_path("scripts")
     target.mkdir(parents=True)

--- a/tests/unit/discovery/test_py_spec.py
+++ b/tests/unit/discovery/test_py_spec.py
@@ -45,6 +45,14 @@ def test_spec_satisfies_arch():
     assert spec_2.satisfies(spec_1) is False
 
 
+def test_spec_satisfies_free_threaded():
+    spec_1 = PythonSpec.from_string_spec("python3.13t")
+    spec_2 = PythonSpec.from_string_spec("python3.13")
+
+    assert spec_1.satisfies(spec_1) is True
+    assert spec_2.satisfies(spec_1) is False
+
+
 @pytest.mark.parametrize(
     ("req", "spec"),
     [("py", "python"), ("jython", "jython"), ("CPython", "cpython")],

--- a/tests/unit/discovery/test_py_spec.py
+++ b/tests/unit/discovery/test_py_spec.py
@@ -76,13 +76,22 @@ def test_spec_satisfies_implementation_nok():
 def _version_satisfies_pairs():
     target = set()
     version = tuple(str(i) for i in sys.version_info[0:3])
-    for i in range(len(version) + 1):
-        req = ".".join(version[0:i])
-        for j in range(i + 1):
-            sat = ".".join(version[0:j])
-            # can be satisfied in both directions
-            target.add((req, sat))
-            target.add((sat, req))
+    for threading in (False, True):
+        for i in range(len(version) + 1):
+            req = ".".join(version[0:i])
+            for j in range(i + 1):
+                sat = ".".join(version[0:j])
+                # can be satisfied in both directions
+                if sat:
+                    target.add((req, sat))
+                # else: no version => no free-threading info
+                target.add((sat, req))
+                if not threading or not sat or not req:
+                    # free-threading info requires a version
+                    continue
+                target.add((f"{req}t", f"{sat}t"))
+                target.add((f"{sat}t", f"{req}t"))
+
     return sorted(target)
 
 

--- a/tests/unit/discovery/test_py_spec.py
+++ b/tests/unit/discovery/test_py_spec.py
@@ -50,7 +50,9 @@ def test_spec_satisfies_free_threaded():
     spec_2 = PythonSpec.from_string_spec("python3.13")
 
     assert spec_1.satisfies(spec_1) is True
+    assert spec_1.free_threaded is True
     assert spec_2.satisfies(spec_1) is False
+    assert spec_2.free_threaded is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/discovery/windows/conftest.py
+++ b/tests/unit/discovery/windows/conftest.py
@@ -85,19 +85,21 @@ def _populate_pyinfo_cache(monkeypatch):
     import virtualenv.discovery.cached_py_info  # noqa: PLC0415
 
     # Data matches _mock_registry fixture
+    python_core_path = "C:\\Users\\user\\AppData\\Local\\Programs\\Python"
     interpreters = [
-        ("ContinuumAnalytics", 3, 10, 32, "C:\\Users\\user\\Miniconda3\\python.exe", None),
-        ("ContinuumAnalytics", 3, 10, 64, "C:\\Users\\user\\Miniconda3-64\\python.exe", None),
-        ("PythonCore", 3, 9, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python36\\python.exe", None),
-        ("PythonCore", 3, 9, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python36\\python.exe", None),
-        ("PythonCore", 3, 5, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python35\\python.exe", None),
-        ("PythonCore", 3, 9, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python36\\python.exe", None),
-        ("PythonCore", 3, 7, 32, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python37-32\\python.exe", None),
-        ("PythonCore", 3, 12, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe", None),
-        ("PythonCore", 2, 7, 64, "C:\\Python27\\python.exe", None),
-        ("PythonCore", 3, 4, 64, "C:\\Python34\\python.exe", None),
-        ("CompanyA", 3, 6, 64, "Z:\\CompanyA\\Python\\3.6\\python.exe", None),
+        ("ContinuumAnalytics", 3, 10, 32, False, "C:\\Users\\user\\Miniconda3\\python.exe"),
+        ("ContinuumAnalytics", 3, 10, 64, False, "C:\\Users\\user\\Miniconda3-64\\python.exe"),
+        ("PythonCore", 3, 9, 64, False, f"{python_core_path}\\Python36\\python.exe"),
+        ("PythonCore", 3, 9, 64, False, f"{python_core_path}\\Python36\\python.exe"),
+        ("PythonCore", 3, 5, 64, False, f"{python_core_path}\\Python35\\python.exe"),
+        ("PythonCore", 3, 9, 64, False, f"{python_core_path}\\Python36\\python.exe"),
+        ("PythonCore", 3, 7, 32, False, f"{python_core_path}\\Python37-32\\python.exe"),
+        ("PythonCore", 3, 12, 64, False, f"{python_core_path}\\Python312\\python.exe"),
+        ("PythonCore", 3, 13, 64, True, f"{python_core_path}\\Python313\\python3.13t.exe"),
+        ("PythonCore", 2, 7, 64, False, "C:\\Python27\\python.exe"),
+        ("PythonCore", 3, 4, 64, False, "C:\\Python34\\python.exe"),
+        ("CompanyA", 3, 6, 64, False, "Z:\\CompanyA\\Python\\3.6\\python.exe"),
     ]
-    for _, major, minor, arch, exe, _ in interpreters:
-        info = _mock_pyinfo(major, minor, arch, exe)
+    for _, major, minor, arch, threaded, exe in interpreters:
+        info = _mock_pyinfo(major, minor, arch, exe, threaded)
         monkeypatch.setitem(virtualenv.discovery.cached_py_info._CACHE, Path(info.executable), info)  # noqa: SLF001

--- a/tests/unit/discovery/windows/conftest.py
+++ b/tests/unit/discovery/windows/conftest.py
@@ -65,7 +65,7 @@ def _mock_registry(mocker):  # noqa: C901
     mocker.patch("os.path.exists", return_value=True)
 
 
-def _mock_pyinfo(major, minor, arch, exe):
+def _mock_pyinfo(major, minor, arch, exe, threaded=False):
     """Return PythonInfo objects with essential metadata set for the given args"""
     from virtualenv.discovery.py_info import PythonInfo, VersionInfo  # noqa: PLC0415
 
@@ -75,6 +75,7 @@ def _mock_pyinfo(major, minor, arch, exe):
     info.implementation = "CPython"
     info.architecture = arch
     info.version_info = VersionInfo(major, minor, 0, "final", 0)
+    info.free_threaded = threaded
     return info
 
 

--- a/tests/unit/discovery/windows/test_windows.py
+++ b/tests/unit/discovery/windows/test_windows.py
@@ -20,8 +20,10 @@ from virtualenv.discovery.py_spec import PythonSpec
         ("python3.12", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"),
         ("cpython3.12", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"),
         # resolves to highest available version
-        ("python", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"),
-        ("cpython", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"),
+        ("python", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python313\\python3.13t.exe"),
+        ("cpython", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python313\\python3.13t.exe"),
+        ("python3", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"),
+        ("cpython3", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"),
         # Non-standard org name
         ("python3.6", "Z:\\CompanyA\\Python\\3.6\\python.exe"),
         ("cpython3.6", "Z:\\CompanyA\\Python\\3.6\\python.exe"),

--- a/tests/unit/discovery/windows/test_windows.py
+++ b/tests/unit/discovery/windows/test_windows.py
@@ -25,6 +25,9 @@ from virtualenv.discovery.py_spec import PythonSpec
         # Non-standard org name
         ("python3.6", "Z:\\CompanyA\\Python\\3.6\\python.exe"),
         ("cpython3.6", "Z:\\CompanyA\\Python\\3.6\\python.exe"),
+        # free-threaded
+        ("3t", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python313\\python3.13t.exe"),
+        ("python3.13t", "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python313\\python3.13t.exe"),
     ],
 )
 def test_propose_interpreters(string_spec, expected_exe):

--- a/tests/unit/discovery/windows/test_windows_pep514.py
+++ b/tests/unit/discovery/windows/test_windows_pep514.py
@@ -13,17 +13,74 @@ def test_pep514():
 
     interpreters = list(discover_pythons())
     assert interpreters == [
-        ("ContinuumAnalytics", 3, 10, 32, "C:\\Users\\user\\Miniconda3\\python.exe", None),
-        ("ContinuumAnalytics", 3, 10, 64, "C:\\Users\\user\\Miniconda3-64\\python.exe", None),
-        ("PythonCore", 3, 9, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe", None),
-        ("PythonCore", 3, 9, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe", None),
-        ("PythonCore", 3, 8, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python38\\python.exe", None),
-        ("PythonCore", 3, 9, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe", None),
-        ("PythonCore", 3, 10, 32, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python310-32\\python.exe", None),
-        ("PythonCore", 3, 12, 64, "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe", None),
-        ("CompanyA", 3, 6, 64, "Z:\\CompanyA\\Python\\3.6\\python.exe", None),
-        ("PythonCore", 2, 7, 64, "C:\\Python27\\python.exe", None),
-        ("PythonCore", 3, 7, 64, "C:\\Python37\\python.exe", None),
+        ("ContinuumAnalytics", 3, 10, 32, False, "C:\\Users\\user\\Miniconda3\\python.exe", None),
+        ("ContinuumAnalytics", 3, 10, 64, False, "C:\\Users\\user\\Miniconda3-64\\python.exe", None),
+        (
+            "PythonCore",
+            3,
+            9,
+            64,
+            False,
+            "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe",
+            None,
+        ),
+        (
+            "PythonCore",
+            3,
+            9,
+            64,
+            False,
+            "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe",
+            None,
+        ),
+        (
+            "PythonCore",
+            3,
+            8,
+            64,
+            False,
+            "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python38\\python.exe",
+            None,
+        ),
+        (
+            "PythonCore",
+            3,
+            9,
+            64,
+            False,
+            "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe",
+            None,
+        ),
+        (
+            "PythonCore",
+            3,
+            10,
+            32,
+            False,
+            "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python310-32\\python.exe",
+            None,
+        ),
+        (
+            "PythonCore",
+            3,
+            12,
+            64,
+            False,
+            "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe",
+            None,
+        ),
+        (
+            "PythonCore",
+            3,
+            13,
+            64,
+            True,
+            "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python313\\python3.13t.exe",
+            None,
+        ),
+        ("CompanyA", 3, 6, 64, False, "Z:\\CompanyA\\Python\\3.6\\python.exe", None),
+        ("PythonCore", 2, 7, 64, False, "C:\\Python27\\python.exe", None),
+        ("PythonCore", 3, 7, 64, False, "C:\\Python37\\python.exe", None),
     ]
 
 
@@ -36,18 +93,19 @@ def test_pep514_run(capsys, caplog):
     out, err = capsys.readouterr()
     expected = textwrap.dedent(
         r"""
-    ('CompanyA', 3, 6, 64, 'Z:\\CompanyA\\Python\\3.6\\python.exe', None)
-    ('ContinuumAnalytics', 3, 10, 32, 'C:\\Users\\user\\Miniconda3\\python.exe', None)
-    ('ContinuumAnalytics', 3, 10, 64, 'C:\\Users\\user\\Miniconda3-64\\python.exe', None)
-    ('PythonCore', 2, 7, 64, 'C:\\Python27\\python.exe', None)
-    ('PythonCore', 3, 10, 32, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python310-32\\python.exe', None)
-    ('PythonCore', 3, 12, 64, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe', None)
-    ('PythonCore', 3, 7, 64, 'C:\\Python37\\python.exe', None)
-    ('PythonCore', 3, 8, 64, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python38\\python.exe', None)
-    ('PythonCore', 3, 9, 64, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe', None)
-    ('PythonCore', 3, 9, 64, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe', None)
-    ('PythonCore', 3, 9, 64, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe', None)
-    """,
+    ('CompanyA', 3, 6, 64, False, 'Z:\\CompanyA\\Python\\3.6\\python.exe', None)
+    ('ContinuumAnalytics', 3, 10, 32, False, 'C:\\Users\\user\\Miniconda3\\python.exe', None)
+    ('ContinuumAnalytics', 3, 10, 64, False, 'C:\\Users\\user\\Miniconda3-64\\python.exe', None)
+    ('PythonCore', 2, 7, 64, False, 'C:\\Python27\\python.exe', None)
+    ('PythonCore', 3, 10, 32, False, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python310-32\\python.exe', None)
+    ('PythonCore', 3, 12, 64, False, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe', None)
+    ('PythonCore', 3, 13, 64, True, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python313\\python3.13t.exe', None)
+    ('PythonCore', 3, 7, 64, False, 'C:\\Python37\\python.exe', None)
+    ('PythonCore', 3, 8, 64, False, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python38\\python.exe', None)
+    ('PythonCore', 3, 9, 64, False, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe', None)
+    ('PythonCore', 3, 9, 64, False, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe', None)
+    ('PythonCore', 3, 9, 64, False, 'C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe', None)
+    """,  # noqa: E501
     ).strip()
     assert out.strip() == expected
     assert not err

--- a/tests/unit/discovery/windows/winreg-mock-values.py
+++ b/tests/unit/discovery/windows/winreg-mock-values.py
@@ -35,6 +35,8 @@ key_open = {
         "3.11": 78700656,
         "3.12\\InstallPath": 78703632,
         "3.12": 78702608,
+        "3.13t\\InstallPath": 78703633,
+        "3.13t": 78702609,
         "3.X": 78703088,
     },
     78702960: {"2.7\\InstallPath": 78700912, "2.7": 78703136, "3.7\\InstallPath": 78703648, "3.7": 78704032},
@@ -45,27 +47,27 @@ key_open = {
     },
 }
 value_collect = {
-    78703568: {"SysVersion": ("3.10", 1), "SysArchitecture": ("32bit", 1)},
+    78703568: {"SysVersion": ("3.10", 1), "SysArchitecture": ("32bit", 1), "DisplayName": ("Python 3.10 (32-bit)", 1)},
     78703200: {
         "ExecutablePath": ("C:\\Users\\user\\Miniconda3\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
-    78702368: {"SysVersion": ("3.10", 1), "SysArchitecture": ("64bit", 1)},
+    78702368: {"SysVersion": ("3.10", 1), "SysArchitecture": ("64bit", 1), "DisplayName": ("Python 3.10 (64-bit)", 1)},
     78703520: {
         "ExecutablePath": ("C:\\Users\\user\\Miniconda3-64\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
-    78700704: {"SysVersion": ("3.9", 1), "SysArchitecture": ("magic", 1)},
+    78700704: {"SysVersion": ("3.9", 1), "SysArchitecture": ("magic", 1), "DisplayName": ("Python 3.9 (wizardry)", 1)},
     78701824: {
         "ExecutablePath": ("C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
-    78704368: {"SysVersion": ("3.9", 1), "SysArchitecture": (100, 4)},
+    78704368: {"SysVersion": ("3.9", 1), "SysArchitecture": (100, 4), "DisplayName": ("Python 3.9 (64-bit)", 1)},
     78704048: {
         "ExecutablePath": ("C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
-    78703024: {"SysVersion": ("3.9", 1), "SysArchitecture": ("64bit", 1)},
+    78703024: {"SysVersion": ("3.9", 1), "SysArchitecture": ("64bit", 1), "DisplayName": ("Python 3.9 (64-bit)", 1)},
     78701936: {
         "ExecutablePath": OSError(2, "The system cannot find the file specified"),
         None: OSError(2, "The system cannot find the file specified"),
@@ -73,17 +75,18 @@ value_collect = {
     78701792: {
         "SysVersion": OSError(2, "The system cannot find the file specified"),
         "SysArchitecture": OSError(2, "The system cannot find the file specified"),
+        "DisplayName": OSError(2, "The system cannot find the file specified"),
     },
     78703792: {
         "ExecutablePath": ("C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python38\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
-    78703424: {"SysVersion": ("3.9", 1), "SysArchitecture": ("64bit", 1)},
+    78703424: {"SysVersion": ("3.9", 1), "SysArchitecture": ("64bit", 1), "DisplayName": ("Python 3.9 (64-bit)", 1)},
     78701888: {
         "ExecutablePath": ("C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python39\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
-    78704512: {"SysVersion": ("3.10", 1), "SysArchitecture": ("32bit", 1)},
+    78704512: {"SysVersion": ("3.10", 1), "SysArchitecture": ("32bit", 1), "DisplayName": ("Python 3.10 (32-bit)", 1)},
     78703600: {
         "ExecutablePath": ("C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python310-32\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
@@ -91,16 +94,31 @@ value_collect = {
     78700656: {
         "SysVersion": OSError(2, "The system cannot find the file specified"),
         "SysArchitecture": OSError(2, "The system cannot find the file specified"),
+        "DisplayName": OSError(2, "The system cannot find the file specified"),
     },
-    78702608: {"SysVersion": ("magic", 1), "SysArchitecture": ("64bit", 1)},
+    78702608: {
+        "SysVersion": ("magic", 1),
+        "SysArchitecture": ("64bit", 1),
+        "DisplayName": ("Python 3.12 (wizard edition)", 1),
+    },
     78703632: {
         "ExecutablePath": ("C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python312\\python.exe", 1),
+        "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
+    },
+    78702609: {
+        "SysVersion": ("3.13", 1),
+        "SysArchitecture": ("64bit", 1),
+        "DisplayName": ("Python 3.13 (64-bit, freethreaded)", 1),
+    },
+    78703633: {
+        "ExecutablePath": ("C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python313\\python3.13t.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
     78703088: {"SysVersion": (2778, 11)},
     78703136: {
         "SysVersion": OSError(2, "The system cannot find the file specified"),
         "SysArchitecture": OSError(2, "The system cannot find the file specified"),
+        "DisplayName": OSError(2, "The system cannot find the file specified"),
     },
     78700912: {
         "ExecutablePath": OSError(2, "The system cannot find the file specified"),
@@ -110,6 +128,7 @@ value_collect = {
     78704032: {
         "SysVersion": OSError(2, "The system cannot find the file specified"),
         "SysArchitecture": OSError(2, "The system cannot find the file specified"),
+        "DisplayName": OSError(2, "The system cannot find the file specified"),
     },
     78703648: {
         "ExecutablePath": OSError(2, "The system cannot find the file specified"),
@@ -120,7 +139,11 @@ value_collect = {
         "ExecutablePath": ("Z:\\CompanyA\\Python\\3.6\\python.exe", 1),
         "ExecutableArguments": OSError(2, "The system cannot find the file specified"),
     },
-    88820000: {"SysVersion": ("3.6", 1), "SysArchitecture": ("64bit", 1)},
+    88820000: {
+        "SysVersion": ("3.6", 1),
+        "SysArchitecture": ("64bit", 1),
+        "DisplayName": OSError(2, "The system cannot find the file specified"),
+    },
 }
 enum_collect = {
     78701856: [
@@ -139,6 +162,7 @@ enum_collect = {
         "3.10-32",
         "3.11",
         "3.12",
+        "3.13t",
         "3.X",
         OSError(22, "No more data is available", None, 259, None),
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ skip_missing_interpreters = true
 
 [testenv]
 description = run tests with {basepython}
-base_python = {env:TOX_BASEPYTHON:{envname}}
 package = wheel
 wheel_build_env = .pkg
 extras =
@@ -68,6 +67,9 @@ extras =
 commands =
     sphinx-build -d "{envtmpdir}/doctree" docs "{toxworkdir}/docs_out" --color -b html {posargs:-W}
     python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+
+[testenv:3.13t]
+base_python = {env:TOX_BASEPYTHON}
 
 [testenv:upgrade]
 description = upgrade pip/wheels/setuptools to latest

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ skip_missing_interpreters = true
 
 [testenv]
 description = run tests with {basepython}
+base_python = {env:TOX_BASEPYTHON:{envname}}
 package = wheel
 wheel_build_env = .pkg
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ env_list =
     coverage
     readme
     docs
+    3.13t
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
# Add free-threaded Python support

This PR adds the possibility to specify a free threaded Python.
Examples:
 * `virtualenv -p 3.13t .venv`
 * `virtualenv -p 3t .venv`
 * `virtualenv -p cpython3.13t .venv`

To be able to change `PythonInfo` to contain a flag whether the python version is a free-threaded one or not, I've introduced versioning to the py info cache files as I couldn't find another way to invalidate old cached infos.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

Closes: #2776
