### PR TITLE
Makes --python command-line flag take precedence over env var

### DIFF
--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections import deque
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -22,13 +23,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Builtin(Discover):
-    python_spec: Sequence[str]
+    python_spec: Sequence[str] | deque[str]
     app_data: AppData
     try_first_with: Sequence[str]
 
     def __init__(self, options) -> None:
         super().__init__(options)
         self.python_spec = options.python or [sys.executable]
+        if self._env.get("VIRTUALENV_PYTHON"):
+            self.python_spec = deque(self.python_spec)
+            self.python_spec.rotate(-1)
         self.app_data = options.app_data
         self.try_first_with = options.try_first_with
 


### PR DESCRIPTION
PR fixes #2285

The problem is caused by the current handling of environment variables, which replaces the default value of an action (an empty list) with a list containing the value of the environment variable. The `argparse` module's `"append"` action adds to the list rather than overriding it.

The fix ensures the environment variable value becomes the last element. Since default discovery uses the first valid interpreter in the `python_spec` list, placing the environment variable last allows `--python` to take precedence.

This solution is not ideal. A proper fix would require a complete rewrite of environment variable handling. The current implementation in `config/cli/parser.py` appears to be based on incorrect assumptions about the `"append"` action. This PR offers a reasonable compromise between resolving the issue and avoiding a large refactor.