### PR TITLE
Simplify Solution to --python command-line flag precedence

### DIFF
--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from collections import deque
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -23,7 +22,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Builtin(Discover):
-    python_spec: Sequence[str] | deque[str]
+    python_spec: Sequence[str]
     app_data: AppData
     try_first_with: Sequence[str]
 
@@ -31,8 +30,7 @@ class Builtin(Discover):
         super().__init__(options)
         self.python_spec = options.python or [sys.executable]
         if self._env.get("VIRTUALENV_PYTHON"):
-            self.python_spec = deque(self.python_spec)
-            self.python_spec.rotate(-1)
+            self.python_spec = self.python_spec[1:] + self.python_spec[:1]  # Rotate the list
         self.app_data = options.app_data
         self.try_first_with = options.try_first_with
 


### PR DESCRIPTION
Update virtualenv/discovery/builtin.py

Simplify solution by operating on the sequence directly without creating a deque.

## TODO
- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
