### PR TITLE
fix: invalid $PATH on nushell

### DIFF
--- a/docs/changelog/2839.bugfix.rst
+++ b/docs/changelog/2839.bugfix.rst
@@ -1,0 +1,1 @@
+invalid ``$PATH`` on nushell post-v0.101.0 - by :user:`midrare`.

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -44,7 +44,22 @@ export-env {
     )
 
     let venv_path = ([$virtual_env $bin] | path join)
-    let new_path = ($env | get $path_name | prepend $venv_path)
+    let old_path = ($env | get $path_name)
+    let new_path = (if (is-string $old_path) {
+      # nushell post-0.101.0 behavior
+      let sep = (if (is_windows
+          and !($env | get -i CYGWIN)
+          and !($env | get -i MSYSTEM)) {
+        ";"
+      } else {
+        ":"
+      })
+
+      $"($venv_path)($sep)($old_path)"
+    } else {
+      # backwards compatability for nushell pre-0.101.0
+      $old_path | prepend $venv_path
+    })
 
     # If there is no default prompt, then use the env name instead
     let virtual_env_prompt = (if (__VIRTUAL_PROMPT__ | is-empty) {

--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -57,7 +57,7 @@ export-env {
 
       $"($venv_path)($sep)($old_path)"
     } else {
-      # backwards compatability for nushell pre-0.101.0
+      # backwards compatibility for nushell pre-0.101.0
       $old_path | prepend $venv_path
     })
 


### PR DESCRIPTION
Treat `$PATH` as a `string` (post nushell v0.101.0 behavior) and not a `list<string>`.

Closes #2838 

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [X] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [X] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
