### PR TITLE
Fix debug logging interpolation

### DIFF
--- a/src/virtualenv/app_data/via_disk_folder.py
+++ b/src/virtualenv/app_data/via_disk_folder.py
@@ -108,10 +108,9 @@ class AppDataDiskFolder(AppData):
 
 
 class JSONStoreDisk(ContentStore, ABC):
-    def __init__(self, in_folder, key, msg, msg_args) -> None:
+    def __init__(self, in_folder, key, msg_args) -> None:
         self.in_folder = in_folder
         self.key = key
-        self.msg = msg
         self.msg_args = (*msg_args, self.file)
 
     @property
@@ -130,7 +129,7 @@ class JSONStoreDisk(ContentStore, ABC):
         except Exception:  # noqa: BLE001, S110
             pass
         else:
-            LOGGER.debug("got %s from %s", self.msg, self.msg_args)
+            LOGGER.debug("got %s %s from %s", *self.msg_args)
             return data
         if bad_format:
             with suppress(OSError):  # reading and writing on the same file may cause race on multiple processes
@@ -139,7 +138,7 @@ class JSONStoreDisk(ContentStore, ABC):
 
     def remove(self):
         self.file.unlink()
-        LOGGER.debug("removed %s at %s", self.msg, self.msg_args)
+        LOGGER.debug("removed %s %s at %s", *self.msg_args)
 
     @contextmanager
     def locked(self):
@@ -150,13 +149,13 @@ class JSONStoreDisk(ContentStore, ABC):
         folder = self.file.parent
         folder.mkdir(parents=True, exist_ok=True)
         self.file.write_text(json.dumps(content, sort_keys=True, indent=2), encoding="utf-8")
-        LOGGER.debug("wrote %s at %s", self.msg, self.msg_args)
+        LOGGER.debug("wrote %s %s at %s", *self.msg_args)
 
 
 class PyInfoStoreDisk(JSONStoreDisk):
     def __init__(self, in_folder, path) -> None:
         key = sha256(str(path).encode("utf-8")).hexdigest()
-        super().__init__(in_folder, key, "python info of %s", (path,))
+        super().__init__(in_folder, key, ("python info of", path))
 
 
 class EmbedDistributionUpdateStoreDisk(JSONStoreDisk):
@@ -164,8 +163,7 @@ class EmbedDistributionUpdateStoreDisk(JSONStoreDisk):
         super().__init__(
             in_folder,
             distribution,
-            "embed update of distribution %s",
-            (distribution,),
+            ("embed update of distribution", distribution),
         )
 
 


### PR DESCRIPTION
Previously, message and args would each get interpolated separately, with a result like

```
wrote python info of %s at (PosixPath('/usr/bin/python3.12'), PosixPath('/home/...f265.json')) [DEBUG via_disk_folder:153]
```

Now, remove the formatting placeholder from the message passed by concrete classes. msg then becomes unnecessary; pass it in as part of msg_args. The result is more like

```
wrote python info of /usr/bin/python3.12 at /home/...f265.json [DEBUG via_disk_folder:153]
```

Sorry; previously was #2848 but I accidentally closed it.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
