### PR TITLE
Ignore directories in PATH that can't be opened

### DIFF
--- a/docs/changelog/2794.bugfix.rst
+++ b/docs/changelog/2794.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore unreadable directories in ``PATH``.

--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -171,7 +171,7 @@ def get_paths(env: Mapping[str, str]) -> Generator[Path, None, None]:
     if path:
         for p in map(Path, path.split(os.pathsep)):
             with suppress(OSError):
-                if p.exists():
+                if next(p.iterdir(), None):
                     yield p
 
 

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -63,6 +63,11 @@ def test_discovery_via_path_not_found(tmp_path, monkeypatch):
 def test_discovery_via_path_in_nonbrowseable_directory(tmp_path, monkeypatch):
     bad_perm = tmp_path / "bad_perm"
     bad_perm.mkdir(mode=0o000)
+    # path entry is unreadable
+    monkeypatch.setenv("PATH", str(bad_perm))
+    interpreter = get_interpreter(uuid4().hex, [])
+    assert interpreter is None
+    # path entry parent is unreadable
     monkeypatch.setenv("PATH", str(bad_perm / "bin"))
     interpreter = get_interpreter(uuid4().hex, [])
     assert interpreter is None


### PR DESCRIPTION
When enumerating search paths in `$PATH`, ignore any entry where `Path.iterdir()` fails or produces no results.

See https://github.com/pypa/virtualenv/issues/2794

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
