### PR TITLE
Fix get_embed_wheel for unknown wheels

### DIFF
--- a/docs/changelog/2877.bugfix.rst
+++ b/docs/changelog/2877.bugfix.rst
@@ -1,0 +1,2 @@
+``get_embed_wheel()`` no longer fails with a :exc:`TypeError` when it is
+called with an unknown *distribution*.

--- a/src/virtualenv/seed/wheels/embed/__init__.py
+++ b/src/virtualenv/seed/wheels/embed/__init__.py
@@ -39,7 +39,10 @@ MAX = "3.8"
 
 
 def get_embed_wheel(distribution, for_py_version):
-    path = BUNDLE_FOLDER / (BUNDLE_SUPPORT.get(for_py_version, {}) or BUNDLE_SUPPORT[MAX]).get(distribution)
+    wheelfile = (BUNDLE_SUPPORT.get(for_py_version, {}) or BUNDLE_SUPPORT[MAX]).get(distribution)
+    if wheelfile is None:
+        return None
+    path = BUNDLE_FOLDER / wheelfile
     return Wheel.from_path(path)
 
 

--- a/tests/unit/seed/wheels/test_wheels_util.py
+++ b/tests/unit/seed/wheels/test_wheels_util.py
@@ -29,3 +29,8 @@ def test_wheel_not_support():
 def test_wheel_repr():
     wheel = get_embed_wheel("setuptools", MAX)
     assert str(wheel.path) in repr(wheel)
+
+
+def test_unknown_distribution():
+    wheel = get_embed_wheel("unknown", MAX)
+    assert wheel is None


### PR DESCRIPTION
`get_embed_wheel()` no longer fails with `TypeError: unsupported operand type(s) for /: 'PosixPath' and 'NoneType'` for unsupport distributions. Callers like `load_embed_wheel()` and `get_wheel()` are handling `None` correctly.

The fix simplifies custom seed plugins. They no longer have to monkey-patch `BUNDLE_SUPPORT`. See
https://github.com/sclabs/virtualenv-seedhelper/blob/v0.0.1/virtualenv_seedhelper.py#L53-L56

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [X] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
