### PR TITLE
Fix HelpFormatter for Python 3.14

### DIFF
--- a/docs/changelog/2878.bugfix.rst
+++ b/docs/changelog/2878.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``HelpFormatter`` error with Python 3.14.0b1.

--- a/src/virtualenv/config/cli/parser.py
+++ b/src/virtualenv/config/cli/parser.py
@@ -107,8 +107,8 @@ class VirtualEnvConfigParser(ArgumentParser):
 
 
 class HelpFormatter(ArgumentDefaultsHelpFormatter):
-    def __init__(self, prog) -> None:
-        super().__init__(prog, max_help_position=32, width=240)
+    def __init__(self, prog, **kwargs) -> None:
+        super().__init__(prog, max_help_position=32, width=240, **kwargs)
 
     def _get_help_string(self, action):
         text = super()._get_help_string(action)


### PR DESCRIPTION
https://github.com/python/cpython/pull/132323 added new arguments to the default `HelpFormatter` which are conditionally called in Python 3.14. The subclass neither accept additional arguments nor passes these along which causes an error, see https://github.com/python/cpython/pull/132323#issuecomment-2848672377.

/CC @asottile

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
