### PR TITLE
test: Use `@pytest.mark.flaky` instead of `@flaky.flaky`

### DIFF
--- a/tests/integration/test_zipapp.py
+++ b/tests/integration/test_zipapp.py
@@ -6,7 +6,6 @@ from contextlib import suppress
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import fs_supports_symlink
@@ -105,7 +104,7 @@ def test_zipapp_in_symlink(capsys, call_zipapp_symlink):
     assert not err
 
 
-@flaky(max_runs=2, min_passes=1)
+@pytest.mark.flaky(max_runs=2, min_passes=1)
 def test_zipapp_help(call_zipapp, capsys):
     call_zipapp("-h")
     _out, err = capsys.readouterr()


### PR DESCRIPTION
Use the more modern `@pytest.mark.flaky` decorator to mark tests as flaky, rather than `@flaky.flaky`.  This avoids type checking issues, and improves compatibility with other implementations of the marker, such as `pytest-rerunfailures`.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

-----

I think this doesn't justify a news item, since it won't affect end users — but I can write one if you wish.