### PR TITLE
feat: Support python.exe fallback on Windows

### DIFF
--- a/docs/changelog/2774.bugfix.rst
+++ b/docs/changelog/2774.bugfix.rst
@@ -1,0 +1,2 @@
+Fall back to python.exe if python3.exe is not found on Windows.
+Contributed by :user:`esafak`.

--- a/docs/changelog/2774.bugfix.rst
+++ b/docs/changelog/2774.bugfix.rst
@@ -1,2 +1,0 @@
-Fall back to python.exe if python3.exe is not found on Windows.
-Contributed by :user:`esafak`.


### PR DESCRIPTION
On Windows, when discovering Python interpreters via PEP 514, if the `ExecutablePath` is not present in the registry, the discovery mechanism will now look for `python3.exe` first, and then fall back to `python.exe`.

This allows virtualenv to discover Python on Windows installations that use the `python.exe` executable name.

Fixes #2774

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
