### PR TITLE
fix: Update venv redirector detection for Python 3.13 on Windows

### DIFF
--- a/docs/changelog/2851.bugfix.rst
+++ b/docs/changelog/2851.bugfix.rst
@@ -1,0 +1,2 @@
+Support renamed Windows venv redirector (`venvlauncher.exe` and `venvwlauncher.exe`) on Python 3.13
+Contributed by :user:`esafak`.

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
@@ -77,7 +77,11 @@ class CPython3Windows(CPythonWindows, CPython3):
 
     @classmethod
     def shim(cls, interpreter):
-        shim = Path(interpreter.system_stdlib) / "venv" / "scripts" / "nt" / "python.exe"
+        root = Path(interpreter.system_stdlib) / "venv" / "scripts" / "nt"
+        # Before 3.13 the launcher was called python.exe, after is venvlauncher.exe
+        # https://github.com/python/cpython/issues/112984
+        exe_name = "venvlauncher.exe" if interpreter.version_info >= (3, 13) else "python.exe"
+        shim = root / exe_name
         if shim.exists():
             return shim
         return None


### PR DESCRIPTION
* Detect the new `venvlauncher.exe` and `venvwlauncher.exe` on Windows for Python 3.13 and later.
* Previously, virtualenv expected `python.exe` which is no longer the case on newer Python versions.
* This ensures that virtualenv can correctly create environments using the system Python interpreter on Windows for Python 3.13+.

Fixes #2851

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
