### PR TITLE
fix(testing): Prevent logging setup when --help is passed

### DIFF
--- a/docs/changelog/u.bugfix.rst
+++ b/docs/changelog/u.bugfix.rst
@@ -1,0 +1,2 @@
+Prevent logging setup when --help is passed, fixing a flaky test.
+Contributed by :user:`esafak`.

--- a/src/virtualenv/run/__init__.py
+++ b/src/virtualenv/run/__init__.py
@@ -154,6 +154,9 @@ def _do_report_setup(parser, args, setup_logging):
     verbosity = verbosity_group.add_mutually_exclusive_group()
     verbosity.add_argument("-v", "--verbose", action="count", dest="verbose", help="increase verbosity", default=2)
     verbosity.add_argument("-q", "--quiet", action="count", dest="quiet", help="decrease verbosity", default=0)
+    # do not configure logging if only help is requested, as no logging is required for this
+    if args and any(i in args for i in ("-h", "--help")):
+        return
     option, _ = parser.parse_known_args(args)
     if setup_logging:
         setup_report(option.verbosity)

--- a/tests/integration/test_zipapp.py
+++ b/tests/integration/test_zipapp.py
@@ -104,7 +104,6 @@ def test_zipapp_in_symlink(capsys, call_zipapp_symlink):
     assert not err
 
 
-@pytest.mark.flaky(max_runs=2, min_passes=1)
 def test_zipapp_help(call_zipapp, capsys):
     call_zipapp("-h")
     _out, err = capsys.readouterr()


### PR DESCRIPTION
This commit fixes a flaky test, `test_zipapp_help`, which would fail intermittently due to unexpected output on stderr.

The root cause of the flakiness was that `virtualenv` would set up its logging framework based on verbosity flags (`-v`, `-vv`, etc.) *before* processing the `--help` flag. This could lead to log messages being generated during the initialization process, which, under certain conditions, would be written to stderr, causing the test to fail.

The fix is to check for the presence of `-h` or `--help` in the command-line arguments within the `_do_report_setup` function. If either of these flags is found, the logging setup is skipped entirely. This is safe because the application will exit immediately after printing the help message, so no logging is required.

This change ensures that no logging output is generated when you request help, which resolves the flaky test and makes the application's behavior more predictable.

Following the fix, the `@pytest.mark.flaky` annotation has been removed from the `test_zipapp_help` test, as it is no longer needed.

I am not sure how to name the news fragment when there is no corresponding Issue so I copied an example in commit history.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
