### PR TITLE
fix cache invalidation for PythonInfo

### DIFF
--- a/docs/changelog/2467.bugfix.rst
+++ b/docs/changelog/2467.bugfix.rst
@@ -1,0 +1,2 @@
+Fix cache invalidation for PythonInfo by hashing `py_info.py`.
+Contributed by :user:`esafak`.


### PR DESCRIPTION
The cache for PythonInfo is now invalidated if the PythonInfo class changes. I achieved this by hashing the py_info.py file and storing the hash in the cache. When loading from the cache, the hash is recomputed and compared with the stored hash. If they don't match, the cache is invalidated.

Fixes #2647

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
