### PR TITLE
fix(lint): Disable FIX002 to allow TODO comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ lint.ignore = [
   "D203",    # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible
   "D212",    # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible
   "DOC",     # no restructuredtext support
+  "FIX002",  # do not warn about TODOs
   "INP001",  # ignore implicit namespace packages
   "ISC001",  # conflict with formatter
   "PLR0914", # Too many local variables


### PR DESCRIPTION
The linter was configured to flag all TODO comments, which can discourage developers from leaving them. This change disables the FIX002 rule in ruff to allow TODO comments without triggering a linting error.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
