### PR TITLE
fix(test): Restore mtime of py_info.py in test

### DIFF
--- a/docs/changelog/2933.bugfix.rst
+++ b/docs/changelog/2933.bugfix.rst
@@ -1,0 +1,2 @@
+Restore `py_info.py` timestamp in `test_py_info_cache_invalidation_on_py_info_change`
+Contributed by :user:`esafak`.

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -165,6 +165,7 @@ def test_py_info_cache_invalidation_on_py_info_change(mocker, session_app_data):
     # 3. Modify the content of py_info.py
     py_info_script = Path(cached_py_info.__file__).parent / "py_info.py"
     original_content = py_info_script.read_text(encoding="utf-8")
+    original_stat = py_info_script.stat()
 
     try:
         # 4. Clear the in-memory cache
@@ -181,8 +182,9 @@ def test_py_info_cache_invalidation_on_py_info_change(mocker, session_app_data):
             assert spy.call_count == 2
 
     finally:
-        # Restore the original content
+        # Restore the original content and timestamp
         py_info_script.write_text(original_content, encoding="utf-8")
+        os.utime(str(py_info_script), (original_stat.st_atime, original_stat.st_mtime))
 
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink is not supported")


### PR DESCRIPTION
The test `test_py_info_cache_invalidation_on_py_info_change` modifies the `py_info.py` script to test cache invalidation. However, it did not restore the original modification time of the file, which caused `.pyc` files to be invalidated, leading to QA notices in some packaging environments.

This change remedies the situation by saving the file's stat info before modification and restoring the atime and mtime in the test's finally block. This ensures that the file's timestamp is not permanently altered by the test run.

Fixes #2933

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
