### PR TITLE
chore: Request shell and python details in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -15,6 +15,8 @@ Describe what's the expected behavior and what you're observing.
 Provide at least:
 
 - OS:
+- Shell:
+- Python version and path:
 - `pip list` of the host python where `virtualenv` is installed:
 
   ```console


### PR DESCRIPTION
Knowing which shell and python interpreter- and version the user is using is often crucial to resolving issues.

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
