### PR TITLE
fix: Use getattr for tcl/tk library paths

### DIFF
--- a/docs/changelog/2944.bugfix.rst
+++ b/docs/changelog/2944.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced direct references to tcl/tk library paths with getattr. By :user:`esafak`

--- a/src/virtualenv/activation/bash/__init__.py
+++ b/src/virtualenv/activation/bash/__init__.py
@@ -15,8 +15,8 @@ class BashActivator(ViaTemplateActivator):
     def replacements(self, creator, dest):
         data = super().replacements(creator, dest)
         data.update({
-            "__TCL_LIBRARY__": creator.interpreter.tcl_lib or "",
-            "__TK_LIBRARY__": creator.interpreter.tk_lib or "",
+            "__TCL_LIBRARY__": getattr(creator.interpreter, "tcl_lib", ""),
+            "__TK_LIBRARY__": getattr(creator.interpreter, "tk_lib", ""),
         })
         return data
 

--- a/src/virtualenv/activation/fish/__init__.py
+++ b/src/virtualenv/activation/fish/__init__.py
@@ -10,8 +10,8 @@ class FishActivator(ViaTemplateActivator):
     def replacements(self, creator, dest):
         data = super().replacements(creator, dest)
         data.update({
-            "__TCL_LIBRARY__": creator.interpreter.tcl_lib or "",
-            "__TK_LIBRARY__": creator.interpreter.tk_lib or "",
+            "__TCL_LIBRARY__": getattr(creator.interpreter, "tcl_lib", ""),
+            "__TK_LIBRARY__": getattr(creator.interpreter, "tk_lib", ""),
         })
         return data
 

--- a/src/virtualenv/activation/nushell/__init__.py
+++ b/src/virtualenv/activation/nushell/__init__.py
@@ -34,8 +34,8 @@ class NushellActivator(ViaTemplateActivator):
             "__VIRTUAL_ENV__": str(creator.dest),
             "__VIRTUAL_NAME__": creator.env_name,
             "__BIN_NAME__": str(creator.bin_dir.relative_to(creator.dest)),
-            "__TCL_LIBRARY__": creator.interpreter.tcl_lib or "",
-            "__TK_LIBRARY__": creator.interpreter.tk_lib or "",
+            "__TCL_LIBRARY__": getattr(creator.interpreter, "tcl_lib", ""),
+            "__TK_LIBRARY__": getattr(creator.interpreter, "tk_lib", ""),
         }
 
 

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -47,8 +47,8 @@ class ViaTemplateActivator(Activator, ABC):
             "__VIRTUAL_NAME__": creator.env_name,
             "__BIN_NAME__": str(creator.bin_dir.relative_to(creator.dest)),
             "__PATH_SEP__": os.pathsep,
-            "__TCL_LIBRARY__": creator.interpreter.tcl_lib or "",
-            "__TK_LIBRARY__": creator.interpreter.tk_lib or "",
+            "__TCL_LIBRARY__": getattr(creator.interpreter, "tcl_lib", ""),
+            "__TK_LIBRARY__": getattr(creator.interpreter, "tk_lib", ""),
         }
 
     def _generate(self, replacements, templates, to_folder, creator):


### PR DESCRIPTION
* Safely access tcl_lib and tk_lib attributes on the interpreter.
* This prevents AttributeError if these attributes are not present.
* Applied to nushell, bash, fish, and via_template activation scripts.

Fixes #2944 

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
