### PR TITLE
feat: Abstract out caching in discovery

### DIFF
--- a/docs/changelog/2074.feature.rst
+++ b/docs/changelog/2074.feature.rst
@@ -1,0 +1,1 @@
+Abstract out caching in discovery - by :user:`esafak`.

--- a/src/virtualenv/discovery/cache.py
+++ b/src/virtualenv/discovery/cache.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Self
+
+
+class Cache(ABC):
+    """A generic cache interface."""
+
+    @abstractmethod
+    def get(self, key: str) -> Any | None:
+        """
+        Get a value from the cache.
+
+        :param key: the key to retrieve
+        :return: the cached value, or None if not found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def set(self, key: str, value: Any) -> None:
+        """
+        Set a value in the cache.
+
+        :param key: the key to set
+        :param value: the value to cache
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def remove(self, key: str) -> None:
+        """
+        Remove a value from the cache.
+
+        :param key: the key to remove
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear the entire cache."""
+        raise NotImplementedError
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def close(self) -> None:  # noqa: B027
+        """
+        Close the cache, releasing any resources.
+
+        This is a no-op by default but can be overridden in subclasses.
+        """
+
+
+__all__ = [
+    "Cache",
+]

--- a/src/virtualenv/discovery/file_cache.py
+++ b/src/virtualenv/discovery/file_cache.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from virtualenv.app_data.na import AppDataDisabled
+from virtualenv.discovery.cache import Cache
+
+if TYPE_CHECKING:
+    from virtualenv.app_data.base import AppData
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FileCache(Cache):
+    def __init__(self, app_data: AppData) -> None:
+        self.app_data = app_data if app_data is not None else AppDataDisabled()
+
+    def get(self, key: Path):
+        """Get a value from the file cache."""
+        py_info, py_info_store = None, self.app_data.py_info(key)
+        with py_info_store.locked():
+            if py_info_store.exists():
+                py_info = self._read_from_store(py_info_store, key)
+        return py_info
+
+    def set(self, key: Path, value: dict) -> None:
+        """Set a value in the file cache."""
+        py_info_store = self.app_data.py_info(key)
+        with py_info_store.locked():
+            path_text = str(key)
+            try:
+                path_modified = key.stat().st_mtime
+            except OSError:
+                path_modified = -1
+
+            py_info_script = Path(__file__).parent / "py_info.py"
+            try:
+                py_info_hash = hashlib.sha256(py_info_script.read_bytes()).hexdigest()
+            except OSError:
+                py_info_hash = None
+
+            data = {
+                "st_mtime": path_modified,
+                "path": path_text,
+                "content": value,
+                "hash": py_info_hash,
+            }
+            py_info_store.write(data)
+
+    def remove(self, key: Path) -> None:
+        """Remove a value from the file cache."""
+        py_info_store = self.app_data.py_info(key)
+        with py_info_store.locked():
+            if py_info_store.exists():
+                py_info_store.remove()
+
+    def clear(self) -> None:
+        """Clear the entire file cache."""
+        self.app_data.py_info_clear()
+
+    def _read_from_store(self, py_info_store, path: Path):
+        data = py_info_store.read()
+        path_text = str(path)
+        try:
+            path_modified = path.stat().st_mtime
+        except OSError:
+            path_modified = -1
+
+        py_info_script = Path(__file__).parent / "py_info.py"
+        try:
+            py_info_hash = hashlib.sha256(py_info_script.read_bytes()).hexdigest()
+        except OSError:
+            py_info_hash = None
+
+        of_path = data.get("path")
+        of_st_mtime = data.get("st_mtime")
+        of_content = data.get("content")
+        of_hash = data.get("hash")
+
+        if of_path == path_text and of_st_mtime == path_modified and of_hash == py_info_hash:
+            return of_content
+
+        py_info_store.remove()
+        return None
+
+
+__all__ = [
+    "FileCache",
+]

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -287,7 +287,7 @@ def test_system_executable_no_exact_match(  # noqa: PLR0913
     mocker.patch.object(target_py_info, "_find_possible_exe_names", return_value=names)
     mocker.patch.object(target_py_info, "_find_possible_folders", return_value=[str(tmp_path)])
 
-    def func(k, app_data, resolve_to_host, raise_on_error, env):  # noqa: ARG001
+    def func(k, app_data, resolve_to_host, raise_on_error, env, cache=None):  # noqa: ARG001, PLR0913
         return discovered_with_path[k]
 
     mocker.patch.object(target_py_info, "from_exe", side_effect=func)


### PR DESCRIPTION
I refactored the code to abstract out caching through an interface. This change lays the groundwork for extracting discovery into its own package.

Here’s a summary of what I did:
* I introduced a new `Cache` interface in `src/virtualenv/discovery/cache.py`.
* I created a file-based implementation of this interface, `FileCache`, in `src/virtualenv/discovery/file_cache.py`.
* I refactored the existing `cached_py_info.py` to use the `Cache` interface, decoupling it from the file-based implementation.
* I updated `py_info.py` to work with the refactored `cached_py_info`.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
