### PR TITLE
feat: Remove references to py_info from FileCache

### DIFF
--- a/docs/changelog/2074b.feature.rst
+++ b/docs/changelog/2074b.feature.rst
@@ -1,0 +1,1 @@
+Remove references to py_info in FileCache - by :user:`esafak`.

--- a/src/virtualenv/discovery/cached_py_info.py
+++ b/src/virtualenv/discovery/cached_py_info.py
@@ -46,7 +46,9 @@ def from_exe(  # noqa: PLR0913
 ) -> PythonInfo | None:
     env = os.environ if env is None else env
     if cache is None:
-        cache = FileCache(app_data)
+        if app_data is None:
+            app_data = AppDataDisabled()
+        cache = FileCache(store_factory=app_data.py_info, clearer=app_data.py_info_clear)
     result = _get_from_cache(cls, app_data, exe, env, cache, ignore_cache=ignore_cache)
     if isinstance(result, Exception):
         if raise_on_error:
@@ -201,7 +203,7 @@ class LogCmd:
 def clear(app_data=None, cache=None):
     """Clear the cache."""
     if cache is None and app_data is not None:
-        cache = FileCache(app_data)
+        cache = FileCache(store_factory=app_data.py_info, clearer=app_data.py_info_clear)
     if cache is not None:
         cache.clear()
     _CACHE.clear()


### PR DESCRIPTION
This continues the work on decoupling caching from the discovery mechanism (#2074).

- Refactored `FileCache`'s constructor to accept a `store_factory` function. This factory is responsible for providing a storage object (with `locked`, `read`, `write` methods) for a given cache key.
- Updated `cached_py_info.py` to provide the specific factory when it creates the `FileCache` instance, e.g., `lambda key: app_data.py_info(key)`.

* [x] ran the linter to address style issues (`tox -e fix`)
* [x] wrote descriptive pull request text
* [x] ensured there are test(s) validating the fix
* [x] added news fragment in `docs/changelog` folder
* [ ] updated/extended the documentation
