### PR TITLE
refactor: Decouple discovery from creator plugins

### DIFF
--- a/docs/changelog/2074c.feature.rst
+++ b/docs/changelog/2074c.feature.rst
@@ -1,0 +1,1 @@
+Decouple discovery from creator plugins - by :user:`esafak`.

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -30,7 +30,7 @@ EXTENSIONS = _get_path_extensions()
 _CONF_VAR_RE = re.compile(r"\{\w+\}")
 
 
-class PythonInfo:  # noqa: PLR0904
+class PythonInfo:
     """Contains information for a Python interpreter."""
 
     def __init__(self) -> None:  # noqa: PLR0915
@@ -135,7 +135,6 @@ class PythonInfo:  # noqa: PLR0904
         self.system_stdlib = self.sysconfig_path("stdlib", confs)
         self.system_stdlib_platform = self.sysconfig_path("platstdlib", confs)
         self.max_size = getattr(sys, "maxsize", getattr(sys, "maxint", None))
-        self._creators = None
 
     @staticmethod
     def _get_tcl_tk_libs():
@@ -311,13 +310,6 @@ class PythonInfo:  # noqa: PLR0904
             config_var = base
         return pattern.format(**config_var).replace("/", sep)
 
-    def creators(self, refresh=False):  # noqa: FBT002
-        if self._creators is None or refresh is True:
-            from virtualenv.run.plugin.creators import CreatorSelector  # noqa: PLC0415
-
-            self._creators = CreatorSelector.for_interpreter(self)
-        return self._creators
-
     @property
     def system_include(self):
         path = self.sysconfig_path(
@@ -467,8 +459,7 @@ class PythonInfo:  # noqa: PLR0904
         return json.dumps(self._to_dict(), indent=2)
 
     def _to_dict(self):
-        data = {var: (getattr(self, var) if var != "_creators" else None) for var in vars(self)}
-
+        data = {var: getattr(self, var) for var in vars(self)}
         data["version_info"] = data["version_info"]._asdict()  # namedtuple to dictionary
         return data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from virtualenv.app_data import AppDataDiskFolder
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import IS_GRAALPY, IS_PYPY, IS_WIN, fs_supports_symlink
 from virtualenv.report import LOGGER
+from virtualenv.run.plugin.creators import CreatorSelector
 
 
 def pytest_addoption(parser):
@@ -308,7 +309,7 @@ def special_name_dir(tmp_path, special_char_name):
 
 @pytest.fixture(scope="session")
 def current_creators(session_app_data):
-    return PythonInfo.current_system(session_app_data).creators()
+    return CreatorSelector.for_interpreter(PythonInfo.current_system(session_app_data))
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -31,6 +31,7 @@ from virtualenv.create.via_global_ref.builtin.cpython.cpython3 import CPython3Po
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.info import IS_PYPY, IS_WIN, fs_is_case_sensitive
 from virtualenv.run import cli_run, session_via_cli
+from virtualenv.run.plugin.creators import CreatorSelector
 
 CURRENT = PythonInfo.current_system()
 
@@ -93,9 +94,9 @@ def system(session_app_data):
     return get_env_debug_info(Path(CURRENT.system_executable), DEBUG_SCRIPT, session_app_data, os.environ)
 
 
-CURRENT_CREATORS = [i for i in CURRENT.creators().key_to_class if i != "builtin"]
+CURRENT_CREATORS = [i for i in CreatorSelector.for_interpreter(CURRENT).key_to_class if i != "builtin"]
 CREATE_METHODS = []
-for k, v in CURRENT.creators().key_to_meta.items():
+for k, v in CreatorSelector.for_interpreter(CURRENT).key_to_meta.items():
     if k in CURRENT_CREATORS:
         if v.can_copy:
             if k == "venv" and CURRENT.implementation == "PyPy" and CURRENT.pypy_version_info >= [7, 3, 13]:
@@ -400,7 +401,10 @@ def test_create_long_path(tmp_path):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("creator", sorted(set(PythonInfo.current_system().creators().key_to_class) - {"builtin"}))
+@pytest.mark.parametrize(
+    "creator",
+    sorted(set(CreatorSelector.for_interpreter(PythonInfo.current_system()).key_to_class) - {"builtin"}),
+)
 @pytest.mark.usefixtures("session_app_data")
 def test_create_distutils_cfg(creator, tmp_path, monkeypatch):
     result = cli_run(

--- a/tests/unit/create/via_global_ref/test_build_c_ext.py
+++ b/tests/unit/create/via_global_ref/test_build_c_ext.py
@@ -10,9 +10,10 @@ import pytest
 
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.run import cli_run
+from virtualenv.run.plugin.creators import CreatorSelector
 
 CURRENT = PythonInfo.current_system()
-CREATOR_CLASSES = CURRENT.creators().key_to_class
+CREATOR_CLASSES = CreatorSelector.for_interpreter(CURRENT).key_to_class
 
 
 def builtin_shows_marker_missing():


### PR DESCRIPTION
The PythonInfo class had a method called creators() that directly imported and used CreatorSelector from `virtualenv.run.plugin.creators`. This created a tight coupling between the discovery and creator plugin systems.

This commit removes the creators() method from PythonInfo, making it a pure data class. The logic for selecting a creator has been moved to the call sites, which now directly use `CreatorSelector.for_interpreter(python_info)`.

This change prepares the discovery code to be moved into a new, standalone package (#2074).

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
