### PR TITLE
refactor: Decouple discovery by duplicating info utils

### DIFF
--- a/docs/changelog/2074d.feature.rst
+++ b/docs/changelog/2074d.feature.rst
@@ -1,0 +1,1 @@
+Decouple discovery by duplicating info utils - by :user:`esafak`.

--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -9,9 +9,8 @@ from typing import TYPE_CHECKING
 
 from platformdirs import user_data_path
 
-from virtualenv.info import IS_WIN, fs_path_id
-
 from .discover import Discover
+from .info import IS_WIN, fs_path_id
 from .py_info import PythonInfo
 from .py_spec import PythonSpec
 

--- a/src/virtualenv/discovery/cached_py_info.py
+++ b/src/virtualenv/discovery/cached_py_info.py
@@ -12,12 +12,12 @@ import importlib.util
 import logging
 import os
 import random
+import subprocess
 import sys
 from collections import OrderedDict
 from pathlib import Path
 from shlex import quote
 from string import ascii_lowercase, ascii_uppercase, digits
-from subprocess import Popen
 from typing import TYPE_CHECKING
 
 from virtualenv.app_data.na import AppDataDisabled
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from virtualenv.app_data.base import AppData
     from virtualenv.cache import Cache
 from virtualenv.discovery.py_info import PythonInfo
-from virtualenv.util.subprocess import subprocess
 
 _CACHE = OrderedDict()
 _CACHE[Path(sys.executable)] = PythonInfo()
@@ -145,7 +144,7 @@ def _run_subprocess(cls, exe, app_data, env):
         env.pop("__PYVENV_LAUNCHER__", None)
         LOGGER.debug("get interpreter info via cmd: %s", LogCmd(cmd))
         try:
-            process = Popen(
+            process = subprocess.Popen(
                 cmd,
                 universal_newlines=True,
                 stdin=subprocess.PIPE,

--- a/src/virtualenv/discovery/info.py
+++ b/src/virtualenv/discovery/info.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+
+_FS_CASE_SENSITIVE = None
+LOGGER = logging.getLogger(__name__)
+IS_WIN = sys.platform == "win32"
+
+
+def fs_is_case_sensitive():
+    """Check if the file system is case-sensitive."""
+    global _FS_CASE_SENSITIVE  # noqa: PLW0603
+
+    if _FS_CASE_SENSITIVE is None:
+        with tempfile.NamedTemporaryFile(prefix="TmP") as tmp_file:
+            _FS_CASE_SENSITIVE = not os.path.exists(tmp_file.name.lower())
+            LOGGER.debug("filesystem is %scase-sensitive", "" if _FS_CASE_SENSITIVE else "not ")
+    return _FS_CASE_SENSITIVE
+
+
+def fs_path_id(path: str) -> str:
+    """Get a case-normalized path identifier."""
+    return path.casefold() if fs_is_case_sensitive() else path
+
+
+__all__ = (
+    "IS_WIN",
+    "fs_is_case_sensitive",
+    "fs_path_id",
+)

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -18,8 +18,6 @@ import warnings
 from collections import OrderedDict, namedtuple
 from string import digits
 
-from .info import fs_is_case_sensitive
-
 VersionInfo = namedtuple("VersionInfo", ["major", "minor", "micro", "releaselevel", "serial"])  # noqa: PYI024
 LOGGER = logging.getLogger(__name__)
 
@@ -661,6 +659,8 @@ class PythonInfo:
         for base in possible_base:
             lower = base.lower()
             yield lower
+
+            from .info import fs_is_case_sensitive  # noqa: PLC0415
 
             if fs_is_case_sensitive():
                 if base != lower:

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -18,6 +18,8 @@ import warnings
 from collections import OrderedDict, namedtuple
 from string import digits
 
+from .info import fs_is_case_sensitive
+
 VersionInfo = namedtuple("VersionInfo", ["major", "minor", "micro", "releaselevel", "serial"])  # noqa: PYI024
 LOGGER = logging.getLogger(__name__)
 
@@ -659,7 +661,6 @@ class PythonInfo:
         for base in possible_base:
             lower = base.lower()
             yield lower
-            from virtualenv.info import fs_is_case_sensitive  # noqa: PLC0415
 
             if fs_is_case_sensitive():
                 if base != lower:


### PR DESCRIPTION
This change decouples the discovery module from the main virtualenv module by duplicating utility functions from `virtualenv.info` into the `virtualenv.discovery` module.

* A new `virtualenv.discovery.info` module was created with a copy of `fs_is_case_sensitive`, `fs_path_id`, and `IS_WIN`.
* `virtualenv.info` is left unchanged to maintain its functionality for the core library.
* The discovery-related files (`py_info.py`, `builtin.py`) now use their own private copy of these utilities from `discovery.info`.
* The dependency of `cached_py_info.py` on `virtualenv.util.subprocess` was removed.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
