### PR TITLE
fix: Python in `PATH` takes precedence over uv-managed Pythons

### DIFF
--- a/docs/changelog/2952.bugfix.rst
+++ b/docs/changelog/2952.bugfix.rst
@@ -1,0 +1,1 @@
+Python in PATH takes precedence over uv-managed python. Contributed by :user:`edgarrmondragon`.

--- a/src/virtualenv/discovery/builtin.py
+++ b/src/virtualenv/discovery/builtin.py
@@ -161,20 +161,7 @@ def propose_interpreters(  # noqa: C901, PLR0912, PLR0915
                 tested_exes.add(exe_id)
                 yield interpreter, True
 
-        # 4. otherwise try uv-managed python (~/.local/share/uv/python or platform equivalent)
-        if uv_python_dir := os.getenv("UV_PYTHON_INSTALL_DIR"):
-            uv_python_path = Path(uv_python_dir).expanduser()
-        elif xdg_data_home := os.getenv("XDG_DATA_HOME"):
-            uv_python_path = Path(xdg_data_home).expanduser() / "uv" / "python"
-        else:
-            uv_python_path = user_data_path("uv") / "python"
-
-        for exe_path in uv_python_path.glob("*/bin/python"):
-            interpreter = PathPythonInfo.from_exe(str(exe_path), app_data, raise_on_error=False, env=env)
-            if interpreter is not None:
-                yield interpreter, True
-
-    # finally just find on path, the path order matters (as the candidates are less easy to control by end user)
+    # try to find on path, the path order matters (as the candidates are less easy to control by end user)
     find_candidates = path_exe_finder(spec)
     for pos, path in enumerate(get_paths(env)):
         LOGGER.debug(LazyPathDump(pos, path, env))
@@ -187,6 +174,19 @@ def propose_interpreters(  # noqa: C901, PLR0912, PLR0915
             interpreter = PathPythonInfo.from_exe(exe_raw, app_data, raise_on_error=False, env=env)
             if interpreter is not None:
                 yield interpreter, impl_must_match
+
+    # otherwise try uv-managed python (~/.local/share/uv/python or platform equivalent)
+    if uv_python_dir := os.getenv("UV_PYTHON_INSTALL_DIR"):
+        uv_python_path = Path(uv_python_dir).expanduser()
+    elif xdg_data_home := os.getenv("XDG_DATA_HOME"):
+        uv_python_path = Path(xdg_data_home).expanduser() / "uv" / "python"
+    else:
+        uv_python_path = user_data_path("uv") / "python"
+
+    for exe_path in uv_python_path.glob("*/bin/python"):
+        interpreter = PathPythonInfo.from_exe(str(exe_path), app_data, raise_on_error=False, env=env)
+        if interpreter is not None:
+            yield interpreter, True
 
 
 def get_paths(env: Mapping[str, str]) -> Generator[Path, None, None]:

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -89,6 +89,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.setenv("PATH", "")
     mocker.patch.object(PythonInfo, "satisfies", return_value=False)
+    python_exe = "python.exe" if IS_WIN else "python"
 
     # UV_PYTHON_INSTALL_DIR
     uv_python_install_dir = tmp_path_factory.mktemp("uv_python_install_dir")
@@ -100,7 +101,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
 
         bin_path = uv_python_install_dir.joinpath("some-py-impl", "bin")
         bin_path.mkdir(parents=True)
-        bin_path.joinpath("python").touch()
+        bin_path.joinpath(python_exe).touch()
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
         assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
@@ -108,7 +109,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
         # PATH takes precedence
         mock_from_exe.reset_mock()
         dir_in_path = tmp_path_factory.mktemp("path_bin_dir")
-        dir_in_path.joinpath("python").touch()
+        dir_in_path.joinpath(python_exe).touch()
         m.setenv("PATH", str(dir_in_path))
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
@@ -124,7 +125,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
 
         bin_path = xdg_data_home.joinpath("uv", "python", "some-py-impl", "bin")
         bin_path.mkdir(parents=True)
-        bin_path.joinpath("python").touch()
+        bin_path.joinpath(python_exe).touch()
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
         assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
@@ -139,7 +140,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
 
         bin_path = user_data_path.joinpath("uv", "python", "some-py-impl", "bin")
         bin_path.mkdir(parents=True)
-        bin_path.joinpath("python").touch()
+        bin_path.joinpath(python_exe).touch()
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
         assert mock_from_exe.call_args[0][0] == str(bin_path / "python")

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -89,7 +89,6 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.setenv("PATH", "")
     mocker.patch.object(PythonInfo, "satisfies", return_value=False)
-    python_exe = "python.exe" if IS_WIN else "python"
 
     # UV_PYTHON_INSTALL_DIR
     uv_python_install_dir = tmp_path_factory.mktemp("uv_python_install_dir")
@@ -101,7 +100,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
 
         bin_path = uv_python_install_dir.joinpath("some-py-impl", "bin")
         bin_path.mkdir(parents=True)
-        bin_path.joinpath(python_exe).touch()
+        bin_path.joinpath("python").touch()
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
         assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
@@ -109,7 +108,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
         # PATH takes precedence
         mock_from_exe.reset_mock()
         dir_in_path = tmp_path_factory.mktemp("path_bin_dir")
-        dir_in_path.joinpath(python_exe).touch()
+        dir_in_path.joinpath("python.exe" if IS_WIN else "python").touch()
         m.setenv("PATH", str(dir_in_path))
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
@@ -125,7 +124,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
 
         bin_path = xdg_data_home.joinpath("uv", "python", "some-py-impl", "bin")
         bin_path.mkdir(parents=True)
-        bin_path.joinpath(python_exe).touch()
+        bin_path.joinpath("python").touch()
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
         assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
@@ -140,7 +139,7 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
 
         bin_path = user_data_path.joinpath("uv", "python", "some-py-impl", "bin")
         bin_path.mkdir(parents=True)
-        bin_path.joinpath(python_exe).touch()
+        bin_path.joinpath("python").touch()
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
         assert mock_from_exe.call_args[0][0] == str(bin_path / "python")

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -107,12 +107,13 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
 
         # PATH takes precedence
         mock_from_exe.reset_mock()
+        python_exe = "python.exe" if IS_WIN else "python"
         dir_in_path = tmp_path_factory.mktemp("path_bin_dir")
-        dir_in_path.joinpath("python.exe" if IS_WIN else "python").touch()
+        dir_in_path.joinpath(python_exe).touch()
         m.setenv("PATH", str(dir_in_path))
         get_interpreter("python", [])
         mock_from_exe.assert_called_once()
-        assert mock_from_exe.call_args[0][0] == str(dir_in_path / "python")
+        assert mock_from_exe.call_args[0][0] == str(dir_in_path / python_exe)
 
     # XDG_DATA_HOME
     xdg_data_home = tmp_path_factory.mktemp("xdg_data_home")

--- a/tests/unit/discovery/test_discovery.py
+++ b/tests/unit/discovery/test_discovery.py
@@ -105,6 +105,15 @@ def test_uv_python(monkeypatch, tmp_path_factory, mocker):
         mock_from_exe.assert_called_once()
         assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
 
+        # PATH takes precedence
+        mock_from_exe.reset_mock()
+        dir_in_path = tmp_path_factory.mktemp("path_bin_dir")
+        dir_in_path.joinpath("python").touch()
+        m.setenv("PATH", str(dir_in_path))
+        get_interpreter("python", [])
+        mock_from_exe.assert_called_once()
+        assert mock_from_exe.call_args[0][0] == str(dir_in_path / "python")
+
     # XDG_DATA_HOME
     xdg_data_home = tmp_path_factory.mktemp("xdg_data_home")
     with patch("virtualenv.discovery.builtin.PathPythonInfo.from_exe") as mock_from_exe, monkeypatch.context() as m:


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
