### PR TITLE
feat: ensure creation of python3.exe and python3 on Windows

### DIFF
--- a/docs/changelog/2774.feature.rst
+++ b/docs/changelog/2774.feature.rst
@@ -1,0 +1,1 @@
+Ensure python3.exe and python3 on Windows for Python 3. - by :user:`esafak`.

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
@@ -32,13 +32,18 @@ class CPythonPosix(CPython, PosixSupports, ABC):
 
 
 class CPythonWindows(CPython, WindowsSupports, ABC):
+    PY_3 = 3
+
     @classmethod
     def _executables(cls, interpreter):
         # symlink of the python executables does not work reliably, copy always instead
         # - https://bugs.python.org/issue42013
         # - venv
         host = cls.host_python(interpreter)
-        for path in (host.parent / n for n in {"python.exe", host.name}):
+        names = {"python.exe", host.name}
+        if interpreter.version_info.major == cls.PY_3:
+            names.update({"python3.exe", "python3"})
+        for path in (host.parent / n for n in names):
             yield host, [path.name], RefMust.COPY, RefWhen.ANY
         # for more info on pythonw.exe see https://stackoverflow.com/a/30313091
         python_w = host.parent / "pythonw.exe"

--- a/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
+++ b/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
@@ -99,3 +99,11 @@ def test_no_python_zip_if_not_exists(py_info, mock_files):
     sources = tuple(CPython3Windows.sources(interpreter=py_info))
     assert python_zip in py_info.path
     assert not contains_ref(sources, python_zip)
+
+
+@pytest.mark.parametrize("py_info_name", ["cpython3_win_embed"])
+def test_python3_exe_present(py_info, mock_files):
+    mock_files(CPYTHON3_PATH, [py_info.system_executable])
+    sources = tuple(CPython3Windows.sources(interpreter=py_info))
+    assert contains_exe(sources, py_info.system_executable, "python3.exe")
+    assert contains_exe(sources, py_info.system_executable, "python3")


### PR DESCRIPTION
On Windows, when creating a virtual environment with a Python 3.x interpreter, ensure that `python3.exe` and `python3` executables are created in the virtual environment's scripts directory.

This makes the behavior on Windows more consistent with POSIX platforms and user expectations, regardless of whether the source Python executable is named `python.exe` or `python3.exe`.

Fixes #2774 

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [  ]ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
