### PR TITLE
fix: Import fs_is_case_sensitive absolutely in py_info.py

### DIFF
--- a/docs/changelog/2774.feature.rst
+++ b/docs/changelog/2774.feature.rst
@@ -1,1 +1,1 @@
-Ensure python3.exe and python3 on Windows for Python 3. - by :user:`esafak`.
+Ensure python3.exe and python3 on Windows for Python 3 - by :user:`esafak`.

--- a/docs/changelog/2944.bugfix.rst
+++ b/docs/changelog/2944.bugfix.rst
@@ -1,1 +1,1 @@
-Replaced direct references to tcl/tk library paths with getattr. By :user:`esafak`
+Replaced direct references to tcl/tk library paths with getattr - by :user:`esafak`

--- a/docs/changelog/2955.bugfix.rst
+++ b/docs/changelog/2955.bugfix.rst
@@ -1,0 +1,1 @@
+Restore absolute import of fs_is_case_sensitive - by :user:`esafak`.

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -660,7 +660,7 @@ class PythonInfo:
             lower = base.lower()
             yield lower
 
-            from .info import fs_is_case_sensitive  # noqa: PLC0415
+            from virtualenv.discovery.info import fs_is_case_sensitive  # noqa: PLC0415
 
             if fs_is_case_sensitive():
                 if base != lower:


### PR DESCRIPTION
The relative import of .info does not work when py_info is invoked as a script:

```python
ModuleNotFoundError
  No module named 'virtualenv.discovery.info'
  at .venv/lib/python3.9/site-packages/virtualenv/discovery/py_info.py:663 in _possible_base
```

Indeed, it used to be imported absolutely.

Fixes #2955

* Update changelog entry for 2944.bugfix.rst to use getattr.
* Update changelog entry for 2774.feature.rst for Windows python3.exe.
* Add new changelog entry for 2955.bugfix.rst regarding absolute import.
* Fix absolute import of fs_is_case_sensitive in py_info.py.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
