### PR TITLE
[enhancement] chore: update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.3
+    rev: 0.34.0
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.13.0"
+    rev: "v0.13.3"
     hooks:
       - id: ruff-format
       - id: ruff


### PR DESCRIPTION
## Type/Tag: enhancement, maintenance

This updates selected pre-commit hooks to their latest stable versions:
- python-jsonschema/check-jsonschema: 0.33.3 → 0.34.0
- astral-sh/ruff-pre-commit: v0.13.0 → v0.13.3

Closes #2967