### PR TITLE
test_too_many_open_files: assert on `errno.EMFILE` instead of `strerror`

### DIFF
--- a/tests/unit/test_file_limit.py
+++ b/tests/unit/test_file_limit.py
@@ -13,13 +13,12 @@ from virtualenv.run import cli_run
 @pytest.mark.skipif(sys.platform == "win32", reason="resource module not available on Windows")
 def test_too_many_open_files(tmp_path):
     """
-    Test that we get a specific error message when we have too many open files.
+    Test that we get a specific error when we have too many open files.
     """
     import resource  # noqa: PLC0415
 
     soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
 
-    # Lower the soft limit to a small number to trigger the error
     try:
         resource.setrlimit(resource.RLIMIT_NOFILE, (32, hard_limit))
     except ValueError:
@@ -28,24 +27,27 @@ def test_too_many_open_files(tmp_path):
         if "module 'resource' has no attribute 'setrlimit'" in str(exc):
             pytest.skip(f"{IMPLEMENTATION} does not support resource.setrlimit")
 
-    # Keep some file descriptors open to make it easier to trigger the error
     fds = []
     try:
-        # JIT implementations use more file descriptors up front so we can run out early
+        # JIT implementations may use more file descriptors up front, so we can run out early
         try:
             fds.extend(os.open(os.devnull, os.O_RDONLY) for _ in range(20))
-        except OSError as jit_exceptions:  # pypy, graalpy
-            assert jit_exceptions.errno == errno.EMFILE  # noqa: PT017
-            assert "Too many open files" in str(jit_exceptions)  # noqa: PT017
+        except OSError as jit_exc:  # pypy, graalpy
+            assert jit_exc.errno == errno.EMFILE  # noqa: PT017
 
-        expected_exceptions = SystemExit, OSError, RuntimeError
-        with pytest.raises(expected_exceptions) as too_many_open_files_exc:
+        expected_exceptions = (SystemExit, OSError, RuntimeError)
+        with pytest.raises(expected_exceptions) as excinfo:
             cli_run([str(tmp_path / "venv")])
 
-        if isinstance(too_many_open_files_exc, SystemExit):
-            assert too_many_open_files_exc.code != 0
+        exc = excinfo.value
+        if isinstance(exc, SystemExit):
+            assert exc.code != 0
+        elif isinstance(exc, OSError):
+            assert exc.errno == errno.EMFILE
         else:
-            assert "Too many open files" in str(too_many_open_files_exc.value)
+            # RuntimeError wrapper path: don't assert on libc-specific strerror text.
+            msg = str(exc)
+            assert ("code 24" in msg) or ("errno 24" in msg) or ("EMFILE" in msg)
 
     finally:
         for fd in fds:


### PR DESCRIPTION
POSIX does not define `strerror()` wording.

Replace string assertions with errno-based checks and fix `ExceptionInfo` handling.

This way, `test_too_many_open_files(tmp_path)` is libc-agnostic (currently fails on musl-libc Linux distros).

Fixes #3000 

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] added news fragment in `docs/changelog` folder
- [ ] ensured there are test(s) validating the fix
- [ ] updated/extended the documentation
