### PR TITLE
fix: update filelock dependency version to 3.20.1 to fix CVE CVE-2025-68146

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dynamic = [
 ]
 dependencies = [
   "distlib>=0.3.7,<1",
-  "filelock>=3.12.2,<4",
+  "filelock>=3.20.1,<4",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs>=3.9.1,<5",
   "typing-extensions>=4.13.2; python_version<'3.11'",


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
