### PR TITLE
fix: resolve EncodingWarning in tox upgrade environment

### DIFF
--- a/tasks/update_embedded.py
+++ b/tasks/update_embedded.py
@@ -25,7 +25,10 @@ file_template = '# file {filename}\n{variable} = convert(\n    """\n{data}"""\n)
 
 
 def rebuild(script_path):
-    with script_path.open(encoding=locale.getpreferredencoding(False)) as current_fh:  # noqa: FBT003
+    encoding = (
+        locale.getencoding() if hasattr(locale, "getencoding") else locale.getpreferredencoding(do_setlocale=False)
+    )
+    with script_path.open(encoding=encoding) as current_fh:
         script_content = current_fh.read()
     script_parts = []
     match_end = 0

--- a/tasks/upgrade_wheels.py
+++ b/tasks/upgrade_wheels.py
@@ -23,6 +23,8 @@ def download(ver, dest, package):
     subprocess.call(
         [
             sys.executable,
+            "-W",
+            "ignore::EncodingWarning",
             "-m",
             "pip",
             "--disable-pip-version-check",


### PR DESCRIPTION
## Summary
- Use `locale.getencoding()` (Python 3.11+) with fallback for older versions in `update_embedded.py`
- Suppress pip's internal `EncodingWarning` in `upgrade_wheels.py` since we cannot modify pip's deprecated API usage

## Test plan
- [x] Run `tox r -e upgrade` and verify no warnings appear