### PR TITLE
add support for RustPython under posix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ entry-points."virtualenv.create".graalpy-posix = "virtualenv.create.via_global_r
 entry-points."virtualenv.create".graalpy-win = "virtualenv.create.via_global_ref.builtin.graalpy:GraalPyWindows"
 entry-points."virtualenv.create".pypy3-posix = "virtualenv.create.via_global_ref.builtin.pypy.pypy3:PyPy3Posix"
 entry-points."virtualenv.create".pypy3-win = "virtualenv.create.via_global_ref.builtin.pypy.pypy3:Pypy3Windows"
+entry-points."virtualenv.create".rustpython-posix = "virtualenv.create.via_global_ref.builtin.rustpython:RustPythonPosix"
 entry-points."virtualenv.create".venv = "virtualenv.create.via_global_ref.venv:Venv"
 entry-points."virtualenv.discovery".builtin = "virtualenv.discovery.builtin:Builtin"
 entry-points."virtualenv.seed".app-data = "virtualenv.seed.embed.via_app_data.via_app_data:FromAppData"

--- a/src/virtualenv/create/via_global_ref/builtin/rustpython/__init__.py
+++ b/src/virtualenv/create/via_global_ref/builtin/rustpython/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from virtualenv.create.via_global_ref.builtin.cpython.cpython3 import CPython3Posix
+
+
+class RustPythonPosix(CPython3Posix):
+    """
+    Creator for RustPython.
+
+    RustPython is mostly compatible with CPython3,
+    so we can reuse cpython creator code.
+    """
+
+    @classmethod
+    def can_describe(cls, interpreter):
+        return interpreter.implementation == "RustPython"

--- a/tests/unit/create/via_global_ref/builtin/rustpython/test_rustpython.py
+++ b/tests/unit/create/via_global_ref/builtin/rustpython/test_rustpython.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from virtualenv.create.via_global_ref.builtin.rustpython import RustPythonPosix
+from virtualenv.discovery.py_info import PythonInfo
+
+
+def test_can_describe():
+    """
+    Test RustPythonPosix.can_describe() class method.
+    """
+    interpreter = PythonInfo()
+
+    # check that RustPython implementation is supported
+    interpreter.implementation = "RustPython"
+    assert RustPythonPosix.can_describe(interpreter)
+
+    # check that non-RustPython implementation is not supported
+    interpreter.implementation = "CPython"
+    assert not RustPythonPosix.can_describe(interpreter)


### PR DESCRIPTION
Adds support for creating virtual environment using RustPython interpreter:
https://github.com/RustPython/RustPython

Without this 'custom' RustPython creator `virtualenv` fails, when specifying rustpython binary with` --python` argument. For example:

```
$ virtualenv --with-traceback --python <...>/target/release/rustpython foo

Traceback (most recent call last):
  File "/opt/mamba/envs/virtenvbug/bin/virtualenv", line 7, in <module>
    sys.exit(run_with_catch())
             ~~~~~~~~~~~~~~^^
  File "/opt/mamba/envs/virtenvbug/lib/python3.14/site-packages/virtualenv/__main__.py", line 68, in run_with_catch
    run(args, options, env)
    ~~~^^^^^^^^^^^^^^^^^^^^
  File "/opt/mamba/envs/virtenvbug/lib/python3.14/site-packages/virtualenv/__main__.py", line 21, in run
    session = cli_run(args, options, env)
  File "/opt/mamba/envs/virtenvbug/lib/python3.14/site-packages/virtualenv/run/__init__.py", line 31, in cli_run
    of_session = session_via_cli(args, options, setup_logging, env)
  File "/opt/mamba/envs/virtenvbug/lib/python3.14/site-packages/virtualenv/run/__init__.py", line 52, in session_via_cli
    creator, seeder, activators = tuple(e.create(options) for e in elements)  # create types
                                  ^^^^^
  File "/opt/mamba/envs/virtenvbug/lib/python3.14/site-packages/virtualenv/run/__init__.py", line 52, in <genexpr>
    creator, seeder, activators = tuple(e.create(options) for e in elements)  # create types
                                        ~~~~~~~~^^^^^^^^^
  File "/opt/mamba/envs/virtenvbug/lib/python3.14/site-packages/virtualenv/run/plugin/creators.py", line 84, in create
    options.describe = self.describe(options, self.interpreter)
                       ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not callable
```


- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
