### PR TITLE
fix: resolve TOCTOU vulnerabilities in app_data and lock directory creation

### DIFF
--- a/docs/changelog/3013.bugfix.rst
+++ b/docs/changelog/3013.bugfix.rst
@@ -1,0 +1,1 @@
+Fix TOCTOU vulnerabilities in app_data and lock directory creation that could be exploited via symlink attacks - reported by :user:`tsigouris007`, fixed by :user:`gaborbernat`.

--- a/src/virtualenv/app_data/__init__.py
+++ b/src/virtualenv/app_data/__init__.py
@@ -36,12 +36,11 @@ def make_app_data(folder, **kwargs):
     if is_read_only:
         return ReadOnlyAppData(folder)
 
-    if not os.path.isdir(folder):
-        try:
-            os.makedirs(folder)
-            LOGGER.debug("created app data folder %s", folder)
-        except OSError as exception:
-            LOGGER.info("could not create app data folder %s due to %r", folder, exception)
+    try:
+        os.makedirs(folder, exist_ok=True)
+        LOGGER.debug("created app data folder %s", folder)
+    except OSError as exception:
+        LOGGER.info("could not create app data folder %s due to %r", folder, exception)
 
     if os.access(folder, os.W_OK):
         return AppDataDiskFolder(folder)

--- a/src/virtualenv/util/lock.py
+++ b/src/virtualenv/util/lock.py
@@ -17,9 +17,8 @@ LOGGER = logging.getLogger(__name__)
 class _CountedFileLock(FileLock):
     def __init__(self, lock_file) -> None:
         parent = os.path.dirname(lock_file)
-        if not os.path.isdir(parent):
-            with suppress(OSError):
-                os.makedirs(parent)
+        with suppress(OSError):
+            os.makedirs(parent, exist_ok=True)
 
         super().__init__(lock_file)
         self.count = 0
@@ -117,7 +116,7 @@ class ReentrantFileLock(PathLockBase):
         # a lock, but that lock might then become expensive, and it's not clear where that lock should live.
         # Instead here we just ignore if we fail to create the directory.
         with suppress(OSError):
-            os.makedirs(str(self.path))
+            os.makedirs(str(self.path), exist_ok=True)
 
         try:
             lock.acquire(0.0001)


### PR DESCRIPTION
TOCTOU (Time-of-Check-Time-of-Use) vulnerabilities in directory creation have been fixed to prevent symlink-based attacks.

Two check-then-act patterns in the codebase could be exploited by an attacker with local access:

1. `src/virtualenv/app_data/__init__.py:39-41` checks if the app_data directory exists with `os.path.isdir()`, then creates it with `os.makedirs()`. An attacker could create a symlink at the target path between the check and creation, causing virtualenv to write cache files (wheels, Python metadata) to an attacker-controlled location.

2. `src/virtualenv/util/lock.py:19-22` has the same pattern when creating parent directories for lock files. When combined with the first vulnerability, this could allow an attacker to control lock file semantics and bypass concurrent access protections, enabling cache poisoning, information disclosure, lock bypass, and denial of service attacks.

The fix replaces both check-then-act patterns with atomic `os.makedirs(..., exist_ok=True)` operations. This is atomic at the OS level and eliminates the TOCTOU window, preventing symlink following attacks while maintaining backward compatibility.

Reported by: @tsigouris007