### PR TITLE
update `Automated testing` documentation section

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -136,8 +136,8 @@ Automated testing
 ~~~~~~~~~~~~~~~~~
 
 All pull requests and merges to 'main' branch are tested using
-`Azure Pipelines <https://azure.microsoft.com/en-gb/services/devops/pipelines/>`_ (configured by
-``azure-pipelines.yml`` file at the root of the repository). You can find the status and results to the CI runs for your
+`GitHub Actions <https://docs.github.com/en/actions>`_ (configured by
+``.github/workflows/check.yaml`` file at the root of the repository). You can find the status and results to the CI runs for your
 PR on GitHub's Web UI for the pull request. You can also find links to the CI services' pages for the specific builds in
 the form of "Details" links, in case the CI run fails and you wish to view the output.
 


### PR DESCRIPTION
Update documentation on CI testing to talk about the GitHub Actions.

Replace text on Azure Pipelines with one on GitHub Actions. I'm guessing that Azure Pipelines have been replaced by GitHub Actions at some point as I don't see the `azure-pipelines.yml` file in the repository anymore.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [X] updated/extended the documentation
