### PR TITLE
Replace ty: ignore with proper type declarations for inheritance patterns

### DIFF
--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -10,6 +10,7 @@ from argparse import ArgumentTypeError
 from ast import literal_eval
 from collections import OrderedDict
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from virtualenv.discovery.cached_py_info import LogCmd
 from virtualenv.util.path import safe_delete
@@ -46,6 +47,11 @@ class Creator(ABC):
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
         self.app_data = options.app_data
         self.env = options.env
+
+    if TYPE_CHECKING:
+
+        @property
+        def exe(self) -> Path: ...
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(f'{k}={v}' for k, v in self._args())})"
@@ -197,8 +203,8 @@ class Creator(ABC):
     @property
     def debug(self):
         """:return: debug information about the virtual environment (only valid after :meth:`create` has run)"""
-        if self._debug is None and self.exe is not None:  # ty: ignore[unresolved-attribute]
-            self._debug = get_env_debug_info(self.exe, self.debug_script(), self.app_data, self.env)  # ty: ignore[unresolved-attribute]
+        if self._debug is None and self.exe is not None:
+            self._debug = get_env_debug_info(self.exe, self.debug_script(), self.app_data, self.env)
         return self._debug
 
     @staticmethod

--- a/src/virtualenv/create/via_global_ref/api.py
+++ b/src/virtualenv/create/via_global_ref/api.py
@@ -4,6 +4,7 @@ import logging
 import os
 from abc import ABC
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from virtualenv.create.creator import Creator, CreatorMeta
 from virtualenv.info import fs_supports_symlink
@@ -33,6 +34,14 @@ class ViaGlobalRefApi(Creator, ABC):
         super().__init__(options, interpreter)
         self.symlinks = self._should_symlink(options)
         self.enable_system_site_package = options.system_site
+
+    if TYPE_CHECKING:
+
+        @property
+        def purelib(self) -> Path: ...
+
+        @property
+        def script_dir(self) -> Path: ...
 
     @staticmethod
     def _should_symlink(options):
@@ -94,10 +103,10 @@ class ViaGlobalRefApi(Creator, ABC):
     def install_patch(self):
         text = self.env_patch_text()
         if text:
-            pth = self.purelib / "_virtualenv.pth"  # ty: ignore[unresolved-attribute]
+            pth = self.purelib / "_virtualenv.pth"
             LOGGER.debug("create virtualenv import hook file %s", pth)
             pth.write_text("import _virtualenv", encoding="utf-8")
-            dest_path = self.purelib / "_virtualenv.py"  # ty: ignore[unresolved-attribute]
+            dest_path = self.purelib / "_virtualenv.py"
             LOGGER.debug("create %s", dest_path)
             dest_path.write_text(text, encoding="utf-8")
 
@@ -106,7 +115,7 @@ class ViaGlobalRefApi(Creator, ABC):
         with self.app_data.ensure_extracted(Path(__file__).parent / "_virtualenv.py") as resolved_path:
             text = resolved_path.read_text(encoding="utf-8")
             # script_dir and purelib are defined in subclasses
-            return text.replace('"__SCRIPT_DIR__"', repr(os.path.relpath(str(self.script_dir), str(self.purelib))))  # ty: ignore[unresolved-attribute]
+            return text.replace('"__SCRIPT_DIR__"', repr(os.path.relpath(str(self.script_dir), str(self.purelib))))
 
     def _args(self):
         return [*super()._args(), ("global", self.enable_system_site_package)]

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py
@@ -34,7 +34,7 @@ class CPythonmacOsFramework(CPython, ABC):
         # change the install_name of the copied python executables
         target = self.desired_mach_o_image_path()
         current = self.current_mach_o_image_path()
-        for src in self._sources:  # ty: ignore[not-iterable]
+        for src in self._sources:
             if isinstance(src, ExePathRefToDest) and (src.must == RefMust.COPY or not self.symlinks):
                 exes = [self.bin_dir / src.base]
                 if not self.symlinks:

--- a/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
+++ b/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
@@ -22,7 +22,9 @@ class BuiltinViaGlobalRefMeta(ViaGlobalRefMeta):
 class ViaGlobalRefVirtualenvBuiltin(ViaGlobalRefApi, VirtualenvBuiltin, ABC):
     def __init__(self, options, interpreter) -> None:
         super().__init__(options, interpreter)
-        self._sources = getattr(options.meta, "sources", None)  # if we're created as a describer this might be missing
+        self._sources: list = (
+            getattr(options.meta, "sources", None) or []
+        )  # if created as a describer this might be missing
 
     @classmethod
     def can_create(cls, interpreter):
@@ -86,7 +88,7 @@ class ViaGlobalRefVirtualenvBuiltin(ViaGlobalRefApi, VirtualenvBuiltin, ABC):
         true_system_site = self.enable_system_site_package
         try:
             self.enable_system_site_package = False
-            for src in self._sources:  # ty: ignore[not-iterable]
+            for src in self._sources:
                 if (
                     src.when == RefWhen.ANY
                     or (src.when == RefWhen.SYMLINK and self.symlinks is True)


### PR DESCRIPTION
Several base classes used attributes that are only defined in subclasses (via mixins). ty couldn't see those attributes from the base class perspective, so we had `ty: ignore[unresolved-attribute]` and `ty: ignore[not-iterable]` comments.

Type checkers analyze each class in isolation. When `Describe` provides `exe` but `Creator` accesses `self.exe`, the checker doesn't see the connection because they're only combined at the concrete class level. Our fix was to add property stubs in the base class

Extension work of: https://github.com/pypa/virtualenv/issues/3029


### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
