### PR TITLE
✨ feat(create): sync with upstream CPython/PyPy venv

### DIFF
--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -11,29 +11,28 @@ deactivate () {
     unset -f pydoc >/dev/null 2>&1 || true
 
     # reset old environment variables
-    # ! [ -z ${VAR+_} ] returns true if VAR is declared at all
-    if ! [ -z "${_OLD_VIRTUAL_PATH:+_}" ] ; then
+    if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
         PATH="$_OLD_VIRTUAL_PATH"
         export PATH
         unset _OLD_VIRTUAL_PATH
     fi
-    if ! [ -z "${_OLD_VIRTUAL_PYTHONHOME+_}" ] ; then
+    if [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
         PYTHONHOME="$_OLD_VIRTUAL_PYTHONHOME"
         export PYTHONHOME
         unset _OLD_VIRTUAL_PYTHONHOME
     fi
 
-    if ! [ -z "${_OLD_VIRTUAL_TCL_LIBRARY+_}" ]; then
+    if [ -n "${_OLD_VIRTUAL_TCL_LIBRARY:-}" ]; then
         TCL_LIBRARY="$_OLD_VIRTUAL_TCL_LIBRARY"
         export TCL_LIBRARY
         unset _OLD_VIRTUAL_TCL_LIBRARY
     fi
-    if ! [ -z "${_OLD_VIRTUAL_TK_LIBRARY+_}" ]; then
+    if [ -n "${_OLD_VIRTUAL_TK_LIBRARY:-}" ]; then
         TK_LIBRARY="$_OLD_VIRTUAL_TK_LIBRARY"
         export TK_LIBRARY
         unset _OLD_VIRTUAL_TK_LIBRARY
     fi
-    if ! [ -z "${_OLD_PKG_CONFIG_PATH+_}" ]; then
+    if [ -n "${_OLD_PKG_CONFIG_PATH:-}" ]; then
         PKG_CONFIG_PATH="$_OLD_PKG_CONFIG_PATH"
         export PKG_CONFIG_PATH
         unset _OLD_PKG_CONFIG_PATH
@@ -44,7 +43,7 @@ deactivate () {
     # we made may not be respected
     hash -r 2>/dev/null
 
-    if ! [ -z "${_OLD_VIRTUAL_PS1+_}" ] ; then
+    if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
         PS1="$_OLD_VIRTUAL_PS1"
         export PS1
         unset _OLD_VIRTUAL_PS1
@@ -70,9 +69,11 @@ else
     VIRTUAL_ENV=__VIRTUAL_ENV__
 fi
 
-if ([ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]) && $(command -v cygpath &> /dev/null) ; then
-    VIRTUAL_ENV=$(cygpath -u "$VIRTUAL_ENV")
-fi
+case "$(uname)" in
+    CYGWIN*|MSYS*|MINGW*)
+        VIRTUAL_ENV=$(cygpath "$VIRTUAL_ENV")
+        ;;
+esac
 export VIRTUAL_ENV
 
 _OLD_VIRTUAL_PATH="$PATH"
@@ -91,13 +92,13 @@ fi
 export VIRTUAL_ENV_PROMPT
 
 # unset PYTHONHOME if set
-if ! [ -z "${PYTHONHOME+_}" ] ; then
+if [ -n "${PYTHONHOME:-}" ] ; then
     _OLD_VIRTUAL_PYTHONHOME="$PYTHONHOME"
     unset PYTHONHOME
 fi
 
 if [ __TCL_LIBRARY__ != "" ]; then
-    if ! [ -z "${TCL_LIBRARY+_}" ] ; then
+    if [ -n "${TCL_LIBRARY:-}" ] ; then
         _OLD_VIRTUAL_TCL_LIBRARY="$TCL_LIBRARY"
     fi
     TCL_LIBRARY=__TCL_LIBRARY__
@@ -105,7 +106,7 @@ if [ __TCL_LIBRARY__ != "" ]; then
 fi
 
 if [ __TK_LIBRARY__ != "" ]; then
-    if ! [ -z "${TK_LIBRARY+_}" ] ; then
+    if [ -n "${TK_LIBRARY:-}" ] ; then
         _OLD_VIRTUAL_TK_LIBRARY="$TK_LIBRARY"
     fi
     TK_LIBRARY=__TK_LIBRARY__

--- a/src/virtualenv/activation/fish/activate.fish
+++ b/src/virtualenv/activation/fish/activate.fish
@@ -1,28 +1,10 @@
 # This file must be used using `source bin/activate.fish` *within a running fish ( http://fishshell.com ) session*.
 # Do not run it directly.
 
-function _bashify_path -d "Converts a fish path to something bash can recognize"
-    set fishy_path $argv
-    set bashy_path $fishy_path[1]
-    for path_part in $fishy_path[2..-1]
-        set bashy_path "$bashy_path:$path_part"
-    end
-    echo $bashy_path
-end
-
-function _fishify_path -d "Converts a bash path to something fish can recognize"
-    echo $argv | tr ':' '\n'
-end
-
 function deactivate -d 'Exit virtualenv mode and return to the normal environment.'
     # reset old environment variables
     if test -n "$_OLD_VIRTUAL_PATH"
-        # https://github.com/fish-shell/fish-shell/issues/436 altered PATH handling
-        if test (string sub -s 1 -l 1 $FISH_VERSION) -lt 3
-            set -gx PATH (_fishify_path "$_OLD_VIRTUAL_PATH")
-        else
-            set -gx PATH $_OLD_VIRTUAL_PATH
-        end
+        set -gx PATH $_OLD_VIRTUAL_PATH
         set -e _OLD_VIRTUAL_PATH
     end
 
@@ -72,8 +54,6 @@ function deactivate -d 'Exit virtualenv mode and return to the normal environmen
         # Self-destruct!
         functions -e pydoc
         functions -e deactivate
-        functions -e _bashify_path
-        functions -e _fishify_path
     end
 end
 
@@ -85,12 +65,7 @@ set -gx VIRTUAL_ENV __VIRTUAL_ENV__
 set -gx _OLD_PKG_CONFIG_PATH "$PKG_CONFIG_PATH"
 set -gx PKG_CONFIG_PATH "$VIRTUAL_ENV/lib/pkgconfig:$PKG_CONFIG_PATH"
 
-# https://github.com/fish-shell/fish-shell/issues/436 altered PATH handling
-if test (string sub -s 1 -l 1 $FISH_VERSION) -lt 3
-    set -gx _OLD_VIRTUAL_PATH (_bashify_path $PATH)
-else
-    set -gx _OLD_VIRTUAL_PATH $PATH
-end
+set -gx _OLD_VIRTUAL_PATH $PATH
 set -gx PATH "$VIRTUAL_ENV"'/'__BIN_NAME__ $PATH
 
 if test -n __TCL_LIBRARY__
@@ -129,12 +104,14 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
     functions -c fish_prompt _old_fish_prompt
 
     function fish_prompt
+        set -l old_status $status
         # Run the user's prompt first; it might depend on (pipe)status.
         set -l prompt (_old_fish_prompt)
 
         printf '(%s) ' $VIRTUAL_ENV_PROMPT
 
         string join -- \n $prompt # handle multi-line prompts
+        echo "exit $old_status" | .
     end
 
     set -gx _OLD_FISH_PROMPT_OVERRIDE "$VIRTUAL_ENV"

--- a/src/virtualenv/activation/powershell/activate.ps1
+++ b/src/virtualenv/activation/powershell/activate.ps1
@@ -1,5 +1,92 @@
-$script:THIS_PATH = $myinvocation.mycommand.path
-$script:BASE_DIR = Split-Path (Resolve-Path "$THIS_PATH/..") -Parent
+<#
+.Synopsis
+Activate a Python virtual environment for the current PowerShell session.
+
+.Description
+Pushes the python executable for a virtual environment to the front of the
+$Env:PATH environment variable and sets the prompt to signify that you are
+in a Python virtual environment. Makes use of the command line switches as
+well as the `pyvenv.cfg` file values present in the virtual environment.
+
+.Parameter VenvDir
+Path to the directory that contains the virtual environment to activate. The
+default value for this is the parent of the directory that the activate.ps1
+script is located within.
+
+.Parameter Prompt
+The prompt prefix to display when this virtual environment is activated. By
+default, this prompt is the name of the virtual environment folder (VenvDir)
+surrounded by parentheses and followed by a single space (ie. '(.venv) ').
+
+.Example
+activate.ps1
+Activates the Python virtual environment that contains the activate.ps1 script.
+
+.Example
+activate.ps1 -Verbose
+Activates the Python virtual environment that contains the activate.ps1 script,
+and shows extra information about the activation as it executes.
+
+.Example
+activate.ps1 -VenvDir C:\Users\MyUser\Common\.venv
+Activates the Python virtual environment located in the specified location.
+
+.Example
+activate.ps1 -Prompt "MyPython"
+Activates the Python virtual environment that contains the activate.ps1 script,
+and prefixes the current prompt with the specified string (surrounded in
+parentheses) while the virtual environment is active.
+
+.Notes
+On Windows, it may be required to enable this activate.ps1 script by setting the
+execution policy for the user. You can do this by issuing the following PowerShell
+command:
+
+PS C:\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+For more information on Execution Policies:
+https://go.microsoft.com/fwlink/?LinkID=135170
+
+#>
+Param(
+    [Parameter(Mandatory = $false)]
+    [String]
+    $VenvDir,
+    [Parameter(Mandatory = $false)]
+    [String]
+    $Prompt
+)
+
+function Get-PyVenvConfig(
+    [String]
+    $ConfigDir
+) {
+    Write-Verbose "Given ConfigDir=$ConfigDir, obtain values in pyvenv.cfg"
+
+    $pyvenvConfigPath = Join-Path -Resolve -Path $ConfigDir -ChildPath 'pyvenv.cfg' -ErrorAction Continue
+
+    $pyvenvConfig = @{ }
+
+    if ($pyvenvConfigPath) {
+        Write-Verbose "File exists, parse ``key = value`` lines"
+        $pyvenvConfigContent = Get-Content -Path $pyvenvConfigPath
+
+        $pyvenvConfigContent | ForEach-Object {
+            $keyval = $PSItem -split "\s*=\s*", 2
+            if ($keyval[0] -and $keyval[1]) {
+                $val = $keyval[1]
+
+                if ("'""".Contains($val.Substring(0, 1))) {
+                    $val = $val.Substring(1, $val.Length - 2)
+                }
+
+                $pyvenvConfig[$keyval[0]] = $val
+                Write-Verbose "Adding Key: '$($keyval[0])'='$val'"
+            }
+        }
+    }
+    return $pyvenvConfig
+}
 
 function global:deactivate([switch] $NonDestructive) {
     if (Test-Path variable:_OLD_VIRTUAL_PATH) {
@@ -43,8 +130,11 @@ function global:deactivate([switch] $NonDestructive) {
         Remove-Item env:VIRTUAL_ENV_PROMPT -ErrorAction SilentlyContinue
     }
 
+    if (Get-Variable -Name "_PYTHON_VENV_PROMPT_PREFIX" -ErrorAction SilentlyContinue) {
+        Remove-Variable -Name _PYTHON_VENV_PROMPT_PREFIX -Scope Global -Force
+    }
+
     if (!$NonDestructive) {
-        # Self destruct!
         Remove-Item function:deactivate
         Remove-Item function:pydoc
     }
@@ -54,18 +144,37 @@ function global:pydoc {
     & python -m pydoc $args
 }
 
-# unset irrelevant variables
+$VenvExecPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$VenvExecDir = Get-Item -Path $VenvExecPath
+
+Write-Verbose "Activation script is located in path: '$VenvExecPath'"
+
+if ($VenvDir) {
+    Write-Verbose "VenvDir given as parameter, using '$VenvDir' to determine values"
+} else {
+    $VenvDir = $VenvExecDir.Parent.FullName.TrimEnd("\\/")
+    Write-Verbose "VenvDir=$VenvDir"
+}
+
+$pyvenvCfg = Get-PyVenvConfig -ConfigDir $VenvDir
+
+if ($Prompt) {
+    Write-Verbose "Prompt specified as argument, using '$Prompt'"
+} else {
+    if ($pyvenvCfg -and $pyvenvCfg['prompt']) {
+        Write-Verbose "Setting based on value in pyvenv.cfg='$($pyvenvCfg['prompt'])'"
+        $Prompt = $pyvenvCfg['prompt']
+    } elseif (__VIRTUAL_PROMPT__ -ne "") {
+        $Prompt = __VIRTUAL_PROMPT__
+    } else {
+        $Prompt = Split-Path -Path $VenvDir -Leaf
+    }
+}
+
 deactivate -nondestructive
 
-$VIRTUAL_ENV = $BASE_DIR
-$env:VIRTUAL_ENV = $VIRTUAL_ENV
-
-if (__VIRTUAL_PROMPT__ -ne "") {
-    $env:VIRTUAL_ENV_PROMPT = __VIRTUAL_PROMPT__
-}
-else {
-    $env:VIRTUAL_ENV_PROMPT = $( Split-Path $env:VIRTUAL_ENV -Leaf )
-}
+$env:VIRTUAL_ENV = $VenvDir
+$env:VIRTUAL_ENV_PROMPT = $Prompt
 
 if (__TCL_LIBRARY__ -ne "") {
     if (Test-Path env:TCL_LIBRARY) {
@@ -89,15 +198,16 @@ if (Test-Path env:PKG_CONFIG_PATH) {
 $env:PKG_CONFIG_PATH = "$env:VIRTUAL_ENV\lib\pkgconfig;$env:PKG_CONFIG_PATH"
 
 $env:PATH = "$env:VIRTUAL_ENV/" + __BIN_NAME__ + __PATH_SEP__ + $env:PATH
+
 if (!$env:VIRTUAL_ENV_DISABLE_PROMPT) {
     function global:_old_virtual_prompt {
         ""
     }
     $function:_old_virtual_prompt = $function:prompt
+    New-Variable -Name _PYTHON_VENV_PROMPT_PREFIX -Description "Python virtual environment prompt prefix" -Scope Global -Option ReadOnly -Visibility Public -Value $Prompt
 
     function global:prompt {
-        # Add the custom prefix to the existing prompt
-        $previous_prompt_value = & $function:_old_virtual_prompt
-        ("(" + $env:VIRTUAL_ENV_PROMPT + ") " + $previous_prompt_value)
+        Write-Host -NoNewline -ForegroundColor Green "($($_PYTHON_VENV_PROMPT_PREFIX)) "
+        _old_virtual_prompt
     }
 }

--- a/src/virtualenv/app_data/via_disk_folder.py
+++ b/src/virtualenv/app_data/via_disk_folder.py
@@ -79,7 +79,7 @@ class AppDataDiskFolder(AppData):
 
     @property
     def py_info_at(self):
-        return self.lock / "py_info" / "2"
+        return self.lock / "py_info" / "3"
 
     def py_info(self, path):
         return PyInfoStoreDisk(self.py_info_at, path)

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -47,6 +47,12 @@ class Creator(ABC):
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
         self.app_data = options.app_data
         self.env = options.env
+        self.prompt = getattr(options, "prompt", None)
+
+    if TYPE_CHECKING:
+
+        @property
+        def exe(self) -> Path: ...
 
     if TYPE_CHECKING:
 
@@ -186,7 +192,13 @@ class Creator(ABC):
         self.pyenv_cfg["home"] = os.path.dirname(os.path.abspath(self.interpreter.system_executable))
         self.pyenv_cfg["implementation"] = self.interpreter.implementation
         self.pyenv_cfg["version_info"] = ".".join(str(i) for i in self.interpreter.version_info)
+        self.pyenv_cfg["version"] = ".".join(str(i) for i in self.interpreter.version_info[:3])
+        self.pyenv_cfg["executable"] = os.path.realpath(self.interpreter.system_executable)
+        self.pyenv_cfg["command"] = f"{sys.executable} -m virtualenv {self.dest}"
         self.pyenv_cfg["virtualenv"] = __version__
+        if self.prompt is not None:
+            prompt_value = os.path.basename(os.getcwd()) if self.prompt == "." else self.prompt
+            self.pyenv_cfg["prompt"] = prompt_value
 
     def setup_ignore_vcs(self):
         """Generate ignore instructions for version control systems."""

--- a/src/virtualenv/create/describe.py
+++ b/src/virtualenv/create/describe.py
@@ -60,7 +60,9 @@ class Describe:
 
     def _calc_config_vars(self, to):
         sys_vars = self.interpreter.sysconfig_vars
-        return {k: (to if v is not None and v.startswith(self.interpreter.prefix) else v) for k, v in sys_vars.items()}
+        return {
+            k: (to if isinstance(v, str) and v.startswith(self.interpreter.prefix) else v) for k, v in sys_vars.items()
+        }
 
     @classmethod
     def can_describe(cls, interpreter):  # noqa: ARG003
@@ -85,9 +87,7 @@ class Describe:
 
 
 class Python3Supports(Describe, ABC):
-    @classmethod
-    def can_describe(cls, interpreter):
-        return interpreter.version_info.major == 3 and super().can_describe(interpreter)  # noqa: PLR2004
+    pass
 
 
 class PosixSupports(Describe, ABC):

--- a/src/virtualenv/create/pyenv_cfg.py
+++ b/src/virtualenv/create/pyenv_cfg.py
@@ -28,6 +28,8 @@ class PyEnvCfg:
             equals_at = line.index("=")
             key = line[:equals_at].strip()
             value = line[equals_at + 1 :].strip()
+            if len(value) > 1 and value[0] in {"'", '"'} and value[0] == value[-1]:
+                value = value[1:-1]
             content[key] = value
         return content
 
@@ -37,7 +39,10 @@ class PyEnvCfg:
         for key, value in self.content.items():
             # Use abspath to normalize relative paths but preserve symlinks (match venv behavior)
             # See issue #2770 - realpath resolves symlinks which breaks prefix symlinks
-            normalized_value = os.path.abspath(value) if value and os.path.exists(value) else value
+            if key == "prompt" and value:
+                normalized_value = f'"{value}"'
+            else:
+                normalized_value = os.path.abspath(value) if value and os.path.exists(value) else value
             line = f"{key} = {normalized_value}"
             LOGGER.debug("\t%s", line)
             text += line

--- a/src/virtualenv/create/via_global_ref/builtin/graalpy/__init__.py
+++ b/src/virtualenv/create/via_global_ref/builtin/graalpy/__init__.py
@@ -62,7 +62,7 @@ class GraalPy(ViaGlobalRefVirtualenvBuiltin, ABC):
         super().set_pyenv_cfg()
         # GraalPy 24.0 and older had home without the bin
         version = self.interpreter.version_info
-        if version.major == 3 and version.minor <= 10:  # noqa: PLR2004
+        if version.minor <= 10:  # noqa: PLR2004
             home = Path(self.pyenv_cfg["home"])
             if home.name == "bin":
                 self.pyenv_cfg["home"] = str(home.parent)

--- a/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
+++ b/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
@@ -100,8 +100,15 @@ class ViaGlobalRefVirtualenvBuiltin(ViaGlobalRefApi, VirtualenvBuiltin, ABC):
                 self.enable_system_site_package = true_system_site
         super().create()
 
+    @property
+    def include_dir(self):
+        return self.dest / ("Include" if self.interpreter.os == "nt" else "include")
+
+    def install_venv_shared_libs(self, venv_creator):
+        pass
+
     def ensure_directories(self):
-        return {self.dest, self.bin_dir, self.script_dir, self.stdlib} | set(self.libs)
+        return {self.dest, self.bin_dir, self.script_dir, self.stdlib, self.include_dir} | set(self.libs)
 
     def set_pyenv_cfg(self):
         """

--- a/src/virtualenv/create/via_global_ref/venv.py
+++ b/src/virtualenv/create/via_global_ref/venv.py
@@ -10,6 +10,7 @@ from virtualenv.util.path import ensure_dir
 from virtualenv.util.subprocess import run_cmd
 
 from .api import ViaGlobalRefApi, ViaGlobalRefMeta
+from .builtin.cpython.common import is_mac_os_framework
 from .builtin.cpython.mac_os import CPython3macOsBrew
 from .builtin.pypy.pypy3 import Pypy3Windows
 
@@ -35,6 +36,8 @@ class Venv(ViaGlobalRefApi):
             meta = ViaGlobalRefMeta()
             if interpreter.platform == "win32":
                 meta = handle_store_python(meta, interpreter)
+            if is_mac_os_framework(interpreter):
+                meta.copy_error = "macOS framework builds do not support copy-based virtual environments"
             return meta
         return None
 
@@ -45,6 +48,8 @@ class Venv(ViaGlobalRefApi):
             self.create_via_sub_process()
         for lib in self.libs:
             ensure_dir(lib)
+        if self.describe is not None:
+            self.describe.install_venv_shared_libs(self)
         super().create()
         self.executables_for_win_pypy_less_v37()
 

--- a/src/virtualenv/discovery/py_info.py
+++ b/src/virtualenv/discovery/py_info.py
@@ -120,6 +120,7 @@ class PythonInfo:  # noqa: PLR0904
         for element in self.sysconfig_paths.values():
             config_var_keys.update(k[1:-1] for k in _CONF_VAR_RE.findall(element))
         config_var_keys.add("PYTHONFRAMEWORK")
+        config_var_keys.update(("Py_ENABLE_SHARED", "INSTSONAME", "LIBDIR"))
 
         self.sysconfig_vars = {i: sysconfig.get_config_var(i or "") for i in config_var_keys}
 
@@ -129,7 +130,7 @@ class PythonInfo:  # noqa: PLR0904
             self.tcl_lib, self.tk_lib = None, None
 
         confs = {
-            k: (self.system_prefix if v is not None and v.startswith(self.prefix) else v)
+            k: (self.system_prefix if isinstance(v, str) and v.startswith(self.prefix) else v)
             for k, v in self.sysconfig_vars.items()
         }
         self.system_stdlib = self.sysconfig_path("stdlib", confs)
@@ -323,7 +324,7 @@ class PythonInfo:  # noqa: PLR0904
         path = self.sysconfig_path(
             "include",
             {
-                k: (self.system_prefix if v is not None and v.startswith(self.prefix) else v)
+                k: (self.system_prefix if isinstance(v, str) and v.startswith(self.prefix) else v)
                 for k, v in self.sysconfig_vars.items()
             },
         )

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class _VersionInfo(Protocol):
+    major: int
+    minor: int
+
+
+class Interpreter(Protocol):
+    prefix: str
+    system_prefix: str
+    system_executable: str
+    free_threaded: bool
+    version_info: _VersionInfo
+    sysconfig_vars: dict[str, object]
+
+
+class MakeInterpreter(Protocol):
+    def __call__(
+        self,
+        sysconfig_vars: dict[str, object] | None = ...,
+        prefix: str = ...,
+        free_threaded: bool = ...,
+        version_info: tuple[int, ...] = ...,
+    ) -> Interpreter: ...

--- a/tests/unit/create/via_global_ref/builtin/conftest.py
+++ b/tests/unit/create/via_global_ref/builtin/conftest.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 from testing import path
 from testing.py_info import read_fixture
+
+if TYPE_CHECKING:
+    from tests.types import Interpreter, MakeInterpreter
 
 # Allows to import from `testing` into test submodules.
 sys.path.append(str(Path(__file__).parent))
@@ -24,3 +29,23 @@ def mock_files(mocker):
 @pytest.fixture
 def mock_pypy_libs(mocker):
     return lambda pypy, libs: path.mock_pypy_libs(mocker, pypy, libs)
+
+
+@pytest.fixture
+def make_interpreter() -> MakeInterpreter:
+    def _make(
+        sysconfig_vars: dict[str, object] | None = None,
+        prefix: str = "/usr",
+        free_threaded: bool = False,
+        version_info: tuple[int, ...] = (3, 14, 0),
+    ) -> Interpreter:
+        interpreter = MagicMock()
+        interpreter.prefix = prefix
+        interpreter.system_prefix = prefix
+        interpreter.system_executable = f"{prefix}/bin/python3"
+        interpreter.free_threaded = free_threaded
+        interpreter.version_info = MagicMock(major=version_info[0], minor=version_info[1])
+        interpreter.sysconfig_vars = sysconfig_vars or {}
+        return interpreter
+
+    return _make  # type: ignore[return-value]

--- a/tests/unit/create/via_global_ref/builtin/cpython/conftest.py
+++ b/tests/unit/create/via_global_ref/builtin/cpython/conftest.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from virtualenv.create.via_global_ref.builtin.cpython.cpython3 import CPython3Posix
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+    from tests.types import MakeInterpreter
+    from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest
+
+    CollectSources = Callable[[dict[str, object]], list[PathRefToDest]]
+
+
+@pytest.fixture
+def collect_sources(tmp_path: Path, make_interpreter: MakeInterpreter, mocker: MockerFixture) -> CollectSources:
+    def _collect(sysconfig_vars: dict[str, object]) -> list[PathRefToDest]:
+        interpreter = make_interpreter(
+            sysconfig_vars={**sysconfig_vars, "PYTHONFRAMEWORK": ""},
+            prefix=str(tmp_path),
+        )
+        interpreter.system_executable = str(tmp_path / "bin" / "python3")
+        mocker.patch(
+            "virtualenv.create.via_global_ref.builtin.cpython.cpython3.Path.exists",
+            return_value=True,
+        )
+        return list(CPython3Posix.sources(interpreter))
+
+    return _collect

--- a/tests/unit/create/via_global_ref/builtin/cpython/cpython3_win_free_threaded.json
+++ b/tests/unit/create/via_global_ref/builtin/cpython/cpython3_win_free_threaded.json
@@ -1,0 +1,62 @@
+{
+  "platform": "win32",
+  "implementation": "CPython",
+  "version_info": {
+    "major": 3,
+    "minor": 13,
+    "micro": 0,
+    "releaselevel": "final",
+    "serial": 0
+  },
+  "architecture": 64,
+  "version_nodot": "313",
+  "version": "3.13.0 (main, Oct 07 2024, 00:00:00) [MSC v.1941 64 bit (AMD64)]",
+  "os": "nt",
+  "prefix": "c:\\path\\to\\python",
+  "base_prefix": "c:\\path\\to\\python",
+  "real_prefix": null,
+  "base_exec_prefix": "c:\\path\\to\\python",
+  "exec_prefix": "c:\\path\\to\\python",
+  "executable": "c:\\path\\to\\python\\python3.13t.exe",
+  "original_executable": "c:\\path\\to\\python\\python3.13t.exe",
+  "system_executable": "c:\\path\\to\\python\\python3.13t.exe",
+  "has_venv": false,
+  "path": [
+    "c:\\path\\to\\python\\Scripts\\virtualenv.exe",
+    "c:\\path\\to\\python\\python313.zip",
+    "c:\\path\\to\\python",
+    "c:\\path\\to\\python\\Lib\\site-packages"
+  ],
+  "file_system_encoding": "utf-8",
+  "stdout_encoding": "utf-8",
+  "sysconfig_scheme": null,
+  "sysconfig_paths": {
+    "stdlib": "{installed_base}/Lib",
+    "platstdlib": "{base}/Lib",
+    "purelib": "{base}/Lib/site-packages",
+    "platlib": "{base}/Lib/site-packages",
+    "include": "{installed_base}/Include",
+    "scripts": "{base}/Scripts",
+    "data": "{base}"
+  },
+  "distutils_install": {
+    "purelib": "Lib\\site-packages",
+    "platlib": "Lib\\site-packages",
+    "headers": "Include\\UNKNOWN",
+    "scripts": "Scripts",
+    "data": ""
+  },
+  "sysconfig": {
+    "makefile_filename": "c:\\path\\to\\python\\Lib\\config\\Makefile"
+  },
+  "sysconfig_vars": {
+    "PYTHONFRAMEWORK": "",
+    "installed_base": "c:\\path\\to\\python",
+    "base": "c:\\path\\to\\python"
+  },
+  "system_stdlib": "c:\\path\\to\\python\\Lib",
+  "system_stdlib_platform": "c:\\path\\to\\python\\Lib",
+  "max_size": 9223372036854775807,
+  "_creators": null,
+  "free_threaded": true
+}

--- a/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_posix.py
+++ b/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_posix.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from virtualenv.create.via_global_ref.builtin.cpython.cpython3 import CPython3Posix
+from virtualenv.create.via_global_ref.builtin.ref import PathRefToDest, RefWhen
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conftest import CollectSources
+
+    from tests.types import MakeInterpreter
+
+
+def _shared_lib_copy_refs(sources: list[PathRefToDest]) -> list[PathRefToDest]:
+    return [s for s in sources if isinstance(s, PathRefToDest) and s.when == RefWhen.COPY]
+
+
+def test_shared_lib_included(tmp_path: Path, collect_sources: CollectSources) -> None:
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    (lib_dir / "libpython3.14.so").touch()
+    sources = collect_sources({"Py_ENABLE_SHARED": 1, "INSTSONAME": "libpython3.14.so", "LIBDIR": str(lib_dir)})
+    shared_refs = _shared_lib_copy_refs(sources)
+    assert len(shared_refs) == 1
+    assert shared_refs[0].src.name == "libpython3.14.so"
+
+
+def test_shared_lib_excluded_when_static(collect_sources: CollectSources) -> None:
+    sources = collect_sources({"Py_ENABLE_SHARED": 0})
+    assert _shared_lib_copy_refs(sources) == []
+
+
+def test_shared_lib_excluded_when_no_lib_name(collect_sources: CollectSources) -> None:
+    sources = collect_sources({"Py_ENABLE_SHARED": 1})
+    assert _shared_lib_copy_refs(sources) == []
+
+
+def test_shared_lib_excluded_when_no_lib_dir(collect_sources: CollectSources) -> None:
+    sources = collect_sources({"Py_ENABLE_SHARED": 1, "INSTSONAME": "libpython3.14.so"})
+    assert _shared_lib_copy_refs(sources) == []
+
+
+def test_shared_lib_excluded_when_file_missing(tmp_path: Path, make_interpreter: MakeInterpreter) -> None:
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    interpreter = make_interpreter(
+        sysconfig_vars={
+            "Py_ENABLE_SHARED": 1,
+            "INSTSONAME": "libpython3.14.so",
+            "LIBDIR": str(lib_dir),
+            "PYTHONFRAMEWORK": "",
+        },
+        prefix=str(tmp_path),
+    )
+    interpreter.system_executable = str(tmp_path / "bin" / "python3")
+    sources = list(CPython3Posix.sources(interpreter))
+    assert _shared_lib_copy_refs(sources) == []

--- a/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
+++ b/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from testing.helpers import contains_exe, contains_ref
+from testing.helpers import contains_exe, contains_ref, has_src, is_exe
 from testing.path import join as path
 
 from virtualenv.create.via_global_ref.builtin.cpython.cpython3 import CPython3Windows
@@ -107,6 +107,16 @@ def test_python3_exe_present(py_info, mock_files):
     sources = tuple(CPython3Windows.sources(interpreter=py_info))
     assert contains_exe(sources, py_info.system_executable, "python3.exe")
     assert contains_exe(sources, py_info.system_executable, "python3")
+
+
+@pytest.mark.parametrize("py_info_name", ["cpython3_win_free_threaded"])
+def test_free_threaded_exe_naming(py_info, mock_files):
+    mock_files(CPYTHON3_PATH, [py_info.system_executable])
+    sources = tuple(CPython3Windows.sources(interpreter=py_info))
+    assert contains_exe(sources, py_info.system_executable, "python3.13t.exe")
+    pythonw_refs = [s for s in sources if is_exe(s) and has_src(path(py_info.prefix, "pythonw.exe"))(s)]
+    assert len(pythonw_refs) == 1
+    assert "pythonw3.13t.exe" in pythonw_refs[0].aliases
 
 
 @pytest.mark.parametrize("py_info_name", ["cpython3_win_embed"])

--- a/tests/unit/create/via_global_ref/test_build_c_ext.py
+++ b/tests/unit/create/via_global_ref/test_build_c_ext.py
@@ -10,6 +10,7 @@ import pytest
 
 from virtualenv.discovery.py_info import PythonInfo
 from virtualenv.run import cli_run
+from virtualenv.seed.wheels.embed import BUNDLE_FOLDER as EMBED_WHEEL_DIR
 
 CURRENT = PythonInfo.current_system()
 CREATOR_CLASSES = CURRENT.creators().key_to_class
@@ -42,19 +43,12 @@ def test_can_build_c_extensions(creator, tmp_path, coverage_env):
     shutil.copytree(str(Path(__file__).parent.resolve() / "greet"), greet)
     session = cli_run(["--creator", creator, "--seeder", "app-data", str(env), "-vvv"])
     coverage_env()
-    setuptools_index_args = ()
-    if CURRENT.version_info >= (3, 12):
-        # requires to be able to install setuptools as build dependency
-        setuptools_index_args = (
-            "--find-links",
-            "https://pypi.org/simple/setuptools/",
-        )
-
     cmd = [
         str(session.creator.script("pip")),
         "install",
         "--no-index",
-        *setuptools_index_args,
+        "--find-links",
+        str(EMBED_WHEEL_DIR),
         "--no-deps",
         "--disable-pip-version-check",
         "-vvv",

--- a/tests/unit/discovery/py_info/test_py_info.py
+++ b/tests/unit/discovery/py_info/test_py_info.py
@@ -529,3 +529,8 @@ def test_uses_posix_prefix_on_debian_3_10_without_venv(mocker):
     pyver = f"{pyinfo.version_info.major}.{pyinfo.version_info.minor}"
     assert pyinfo.install_path("scripts") == "bin"
     assert pyinfo.install_path("purelib").replace(os.sep, "/") == f"lib/python{pyver}/site-packages"
+
+
+def test_sysconfig_vars_include_shared_lib_keys() -> None:
+    for key in ("Py_ENABLE_SHARED", "INSTSONAME", "LIBDIR"):
+        assert key in CURRENT.sysconfig_vars

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -43,8 +43,7 @@ def test_logging_setup(caplog, on):
         assert caplog.records
 
 
-def test_invalid_discovery_method_via_env(monkeypatch):
-    """Test that an invalid discovery method via env var raises a helpful error."""
+def test_invalid_discovery_method_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VIRTUALENV_DISCOVERY", "pyenv")
     with pytest.raises(ValueError, match=r"Invalid discovery method 'pyenv'") as exc_info:
         session_via_cli(["env"])


### PR DESCRIPTION
virtualenv's builtin creators replicate what CPython's `Lib/venv/` and PyPy's `lib-python/3/venv/` do, but have drifted since ~2020. This PR brings them back in sync by addressing the most impactful gaps identified from reviewing ~84 upstream CPython commits and PyPy's py3.9-3.11 evolution.

The highest-priority changes focus on correctness: `pyvenv.cfg` now includes the `executable` key (CPython 3.11+) that tools like `uv` and IDEs rely on, the `include` directory is created per PEP 405, and free-threaded Python 3.13+ builds get proper `python3.Xt` / `pythonw3.Xt.exe` executable names plus `venvlaunchert.exe` launcher handling on Windows. PyPy environments also improve — `PYPY_PORTABLE_DEPS.txt` is respected for portable builds, and Windows DLL coverage expands beyond the previous narrow `libpypy*`/`libffi*` globs.

Activation scripts receive targeted fixes: bash now uses `uname`-based detection to catch MinGW/Git Bash (matching upstream), fish preserves `$status` across the prompt function and drops Fish <3 compatibility, and PowerShell gains `Get-PyVenvConfig` with `-VenvDir`/`-Prompt` parameters. All `major == 3` guards are removed since virtualenv requires Python 3.8+, and the single-use `resign` helper is inlined at its call site. The `venv` creator also learns to pass `--without-scm-ignore-files` on 3.13+ to avoid conflicts with virtualenv's own `.gitignore` handling.

Resolves #3021
Resolves #2090