### PR TITLE
Version bump filelock to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ dynamic = [
 ]
 dependencies = [
   "distlib>=0.3.7,<1",
-  "filelock>=3.24.2,<4; python_version>='3.10'",
   "filelock>=3.16.1,<=3.19.1; python_version<'3.10'",
+  "filelock>=3.24.2,<4; python_version>='3.10'",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs>=3.9.1,<5",
   "typing-extensions>=4.13.2; python_version<'3.11'",


### PR DESCRIPTION
Companion PR to #3038 (a focused fix for Python `3.9`) to also update dependency for Python `3.10`+

Refs:
* as discussed in pypa/virtualenv#3038 updates post python 3.10 to use latest filelock (now 3.24.2)
