### PR TITLE
🐛 fix(sdist): include tox.toml in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ build.targets.sdist.include = [
   "/src",
   "/tests",
   "/tasks",
-  "/tox.ini",
+  "/tox.toml",
 ]
 version.source = "vcs"
 


### PR DESCRIPTION
The tox.ini to tox.toml migration in #3050 didn't update the `build.targets.sdist.include` list in `pyproject.toml`, so `tox.toml` was missing from published sdist packages. 🐛

Updated the sdist include path from `/tox.ini` to `/tox.toml` to match the renamed file.

Fixes #3060