### PR TITLE
🐛 fix(seed): add --ignore-installed to pip invoke seeder

### DIFF
--- a/src/virtualenv/seed/embed/pip_invoke.py
+++ b/src/virtualenv/seed/embed/pip_invoke.py
@@ -35,7 +35,17 @@ class PipInvoke(BaseEmbed):
 
     @contextmanager
     def get_pip_install_cmd(self, exe, for_py_version):
-        cmd = [str(exe), "-m", "pip", "-q", "install", "--only-binary", ":all:", "--disable-pip-version-check"]
+        cmd = [
+            str(exe),
+            "-m",
+            "pip",
+            "-q",
+            "install",
+            "--only-binary",
+            ":all:",
+            "--disable-pip-version-check",
+            "--ignore-installed",
+        ]
         if not self.download:
             cmd.append("--no-index")
         folders = set()


### PR DESCRIPTION
On macOS with the system Python from Xcode CommandLineTools, the `PipInvoke` seeder fails with `PermissionError: [Errno 13] Permission denied: 'RECORD'` when creating virtual environments. 🐛 This happens because the venv's `sys.path` leaks the system `site-packages`, causing pip to attempt uninstalling root-owned packages (pip, setuptools, wheel) before installing the seeded versions.

The fix adds `--ignore-installed` to the pip install command used during seeding. Since we're always installing into a freshly created virtual environment, there's no reason for pip to inspect or remove pre-existing packages visible through the inherited `sys.path`. This flag is already commonly used in similar contexts (e.g., `pip install --ignore-installed` inside Docker builds and CI environments) and carries no downside here.

This affects macOS users on both x86 and ARM/M1 when using the system Python, and has been reported by multiple users including JetBrains IDE users who rely on the zipapp. Linux and user-installed Python interpreters are unaffected.

Fixes #2121