### PR TITLE
🧪 test(discovery): fix test_py_info_cache_clear outside venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ build.targets.sdist.include = [
   "/src",
   "/tests",
   "/tasks",
-  "/tox.ini",
+  "/tox.toml",
 ]
 version.source = "vcs"
 


### PR DESCRIPTION
`test_py_info_cache_clear` fails when tests run outside a virtual environment (e.g. Fedora RPM
builds, reported in #2939). The test tracked cumulative `_run_subprocess` spy counts across two
`from_exe` calls and assumed a `2 * count` relationship, which breaks when `_resolve_to_system`
doesn't trigger additional subprocess calls — the case when `system_executable == executable`.

Restructured to follow the same pattern as the already-fixed sibling
`test_py_info_cache_invalidation_on_py_info_change`: set up the spy only after clearing the cache,
and account for the venv vs non-venv difference using `native_difference`. This makes the assertion
independent of how many subprocess calls the initial cache-warming `from_exe` triggers. 🐛

Fixes #2939