### PR TITLE
👷 ci(brew): add missing Homebrew Python versions and fix discovery

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -105,7 +105,7 @@ jobs:
             nu_version=$(gh release view --repo nushell/nushell --json tagName -q .tagName)
             gh release download "$nu_version" --repo nushell/nushell --pattern "*-x86_64-pc-windows-msvc.zip" --dir "$RUNNER_TEMP"
             7z x "$RUNNER_TEMP/nu-${nu_version#v}-x86_64-pc-windows-msvc.zip" -o"$RUNNER_TEMP/nushell" -y
-            cp "$RUNNER_TEMP/nushell/nu-${nu_version#v}-x86_64-pc-windows-msvc/nu.exe" "/c/ProgramData/chocolatey/bin/nu.exe"
+            cp "$RUNNER_TEMP/nushell/nu.exe" "/c/ProgramData/chocolatey/bin/nu.exe"
           fi
       - name: 🧬 Pick environment to run
         shell: bash

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,6 +42,9 @@ jobs:
           - macos-15
           - windows-2025
         include:
+          - { os: macos-15, py: "brew@3.14" }
+          - { os: macos-15, py: "brew@3.13" }
+          - { os: macos-15, py: "brew@3.12" }
           - { os: macos-15, py: "brew@3.11" }
           - { os: macos-15, py: "brew@3.10" }
           - { os: macos-15, py: "brew@3.9" }
@@ -97,7 +100,10 @@ jobs:
             fi
             brew install fish tcsh nushell || brew upgrade fish tcsh nushell
           elif [ "${{ runner.os }}" = "Windows" ]; then
-            choco install nushell
+            nu_version=$(gh release view --repo nushell/nushell --json tagName -q .tagName)
+            gh release download "$nu_version" --repo nushell/nushell --pattern "*-x86_64-pc-windows-msvc.zip" --dir "$RUNNER_TEMP"
+            7z x "$RUNNER_TEMP/nu-${nu_version#v}-x86_64-pc-windows-msvc.zip" -o"$RUNNER_TEMP/nushell" -y
+            echo "$RUNNER_TEMP/nushell/nu-${nu_version#v}-x86_64-pc-windows-msvc" >> "$GITHUB_PATH"
           fi
       - name: 🧬 Pick environment to run
         shell: bash
@@ -105,7 +111,7 @@ jobs:
           py="${{ matrix.py }}"
           if [[ "$py" == brew@* ]]; then
             brew_version="${py#brew@}"
-            echo "TOX_DISCOVER=/opt/homebrew/bin/python${brew_version}" >> "$GITHUB_ENV"
+            echo "UV_PYTHON=/opt/homebrew/bin/python${brew_version}" >> "$GITHUB_ENV"
             py="$brew_version"
           fi
           [[ "$py" == graalpy-* ]] && py="graalpy"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -83,6 +83,8 @@ jobs:
           python-version: ${{ matrix.py }}
       - name: 🛠️ Install OS dependencies
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ runner.os }}" = "Linux" ]; then
             sudo apt-get install -y software-properties-common

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -105,7 +105,7 @@ jobs:
             nu_version=$(gh release view --repo nushell/nushell --json tagName -q .tagName)
             gh release download "$nu_version" --repo nushell/nushell --pattern "*-x86_64-pc-windows-msvc.zip" --dir "$RUNNER_TEMP"
             7z x "$RUNNER_TEMP/nu-${nu_version#v}-x86_64-pc-windows-msvc.zip" -o"$RUNNER_TEMP/nushell" -y
-            echo "$RUNNER_TEMP/nushell/nu-${nu_version#v}-x86_64-pc-windows-msvc" >> "$GITHUB_PATH"
+            cp "$RUNNER_TEMP/nushell/nu-${nu_version#v}-x86_64-pc-windows-msvc/nu.exe" "/c/ProgramData/chocolatey/bin/nu.exe"
           fi
       - name: 🧬 Pick environment to run
         shell: bash

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -51,11 +51,7 @@ def test_nushell_tkinter_generation(tmp_path):
 def test_nushell(activation_tester_class, activation_tester):
     class Nushell(activation_tester_class):
         def __init__(self, session) -> None:
-            cmd = which("nu")
-            if cmd is None and IS_WIN:
-                cmd = "c:\\program files\\nu\\bin\\nu.exe"
-
-            super().__init__(NushellActivator, session, cmd, "activate.nu", "nu")
+            super().__init__(NushellActivator, session, which("nu"), "activate.nu", "nu")
 
             self.activate_cmd = "overlay use"
             self.unix_line_ending = not IS_WIN


### PR DESCRIPTION
The macOS CI matrix only tested Homebrew-installed Python 3.9 through 3.11, but Homebrew now ships `python@3.12`, `python@3.13`, and `python@3.14`. This gap means virtualenv's Homebrew-specific code path (`CPython3macOsBrew`) wasn't being validated against the versions most users actually install today.

Additionally, the existing brew jobs were broken — they set `TOX_DISCOVER` to point at the brew interpreter, but `tox-uv` ignores that variable entirely. The tox test environments were silently using the `actions/setup-python` interpreter instead of the brew one, defeating the purpose of these matrix entries. 🔧 Switching to `UV_PYTHON` ensures `tox-uv` actually creates the test environment with the Homebrew Python.