### PR TITLE
Align dependency versions across projects

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,4 +5,4 @@ build:
   commands:
     - curl -LsSf https://astral.sh/uv/install.sh | sh
     - ~/.local/bin/uv tool install tox --with tox-uv -p 3.14 --managed-python
-    - ~/.local/bin/tox run -e docs -- $READTHEDOCS_OUTPUT/html
+    - ~/.local/bin/tox run -e docs --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 build-backend = "hatchling.build"
 requires = [
-  "hatch-vcs>=0.3",
-  "hatchling>=1.17.1",
+  "hatch-vcs>=0.4",
+  "hatchling>=1.27",
 ]
 
 [project]
@@ -104,12 +104,12 @@ test = [
   "time-machine>=2.10; platform_python_implementation=='CPython'",
 ]
 type = [
-  "ty>=0.0.15",
+  "ty>=0.0.17",
   { include-group = "test" },
 ]
 docs = [
   "furo>=2023.7.26",
-  "pre-commit-uv>=4.1.4",
+  "pre-commit-uv>=4.2",
   "proselint>=0.13",
   "sphinx>=7.1.2,!=7.3",
   "sphinx-argparse>=0.4",
@@ -121,12 +121,12 @@ docs = [
   "towncrier>=23.6",
 ]
 lint = [
-  "pre-commit-uv>=4.1.4",
+  "pre-commit-uv>=4.2",
 ]
 pkg-meta = [
-  "check-wheel-contents>=0.6.2",
-  "twine>=6.1",
-  "uv>=0.8",
+  "check-wheel-contents>=0.6.3",
+  "twine>=6.2",
+  "uv>=0.10.2",
 ]
 
 [tool.hatch]

--- a/tox.toml
+++ b/tox.toml
@@ -1,4 +1,4 @@
-requires = [ "tox>=4.28" ]
+requires = [ "tox>=4.34.1" ]
 env_list = [
   "3.14",
   "3.13",
@@ -74,10 +74,11 @@ commands = [
     "-d",
     "{env_tmp_dir}{/}doctree",
     "docs",
+    "{env:READTHEDOCS_OUTPUT:{env_tmp_dir}{/}docs_out}/html",
     "--color",
     "-b",
     "html",
-    { replace = "posargs", extend = true, default = [ "-W", "{work_dir}{/}docs_out" ] },
+    "-W",
   ],
   [
     "python",


### PR DESCRIPTION
## Summary
- Bump hatchling, hatch-vcs, tox, ty, pre-commit-uv, check-wheel-contents, twine, uv, pytest-mock to latest versions used across the project fleet
- Fix RTD docs build to use env var fallback pattern for output directory