### PR TITLE
🐛 fix(create): add pythonw3.exe to Windows venvs

### DIFF
--- a/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
@@ -59,7 +59,7 @@ class CPythonWindows(CPython, WindowsSupports, ABC):
         python_w = host.parent / "pythonw.exe"
         yield (
             python_w,
-            [python_w.name, *((f"pythonw3.{minor}t.exe",) if interpreter.free_threaded else ())],
+            [python_w.name, "pythonw3.exe", *((f"pythonw3.{minor}t.exe",) if interpreter.free_threaded else ())],
             RefMust.COPY,
             RefWhen.ANY,
         )

--- a/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
+++ b/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
@@ -109,6 +109,15 @@ def test_python3_exe_present(py_info, mock_files):
     assert contains_exe(sources, py_info.system_executable, "python3")
 
 
+@pytest.mark.parametrize("py_info_name", ["cpython3_win_embed"])
+def test_pythonw3_exe_present(py_info, mock_files):
+    mock_files(CPYTHON3_PATH, [py_info.system_executable])
+    sources = tuple(CPython3Windows.sources(interpreter=py_info))
+    pythonw_refs = [s for s in sources if is_exe(s) and has_src(path(py_info.prefix, "pythonw.exe"))(s)]
+    assert len(pythonw_refs) == 1
+    assert "pythonw3.exe" in pythonw_refs[0].aliases
+
+
 @pytest.mark.parametrize("py_info_name", ["cpython3_win_free_threaded"])
 def test_free_threaded_exe_naming(py_info, mock_files):
     mock_files(CPYTHON3_PATH, [py_info.system_executable])
@@ -116,6 +125,7 @@ def test_free_threaded_exe_naming(py_info, mock_files):
     assert contains_exe(sources, py_info.system_executable, "python3.13t.exe")
     pythonw_refs = [s for s in sources if is_exe(s) and has_src(path(py_info.prefix, "pythonw.exe"))(s)]
     assert len(pythonw_refs) == 1
+    assert "pythonw3.exe" in pythonw_refs[0].aliases
     assert "pythonw3.13t.exe" in pythonw_refs[0].aliases
 
 


### PR DESCRIPTION
When users install GUI packages via `python3 -m pip install` inside a virtualenv on Windows, the generated script wrapper references `pythonw3.exe` — because `distlib` derives the windowed executable name by replacing `python` with `pythonw` in the current interpreter's filename. 🐛 Since virtualenv creates `python3.exe` but not the corresponding `pythonw3.exe`, these GUI scripts fail to launch.

The fix adds `pythonw3.exe` as an alias of `pythonw.exe` in the CPython Windows creator, mirroring how `python3.exe` is already unconditionally created alongside `python.exe`. This is consistent with the existing pattern where every `python` variant has a matching `pythonw` counterpart.

Fixes #3072.