### PR TITLE
📝 docs(changelog): add removal entry for python-discovery extraction

### DIFF
--- a/docs/changelog/3070.removal.rst
+++ b/docs/changelog/3070.removal.rst
@@ -1,6 +1,6 @@
-The Python discovery logic has been extracted into a standalone ``python-discovery`` package on PyPI
-(`documentation <https://python-discovery.readthedocs.io/>`_) and is now consumed as a dependency. If you
-previously imported discovery internals directly (e.g. ``from virtualenv.discovery.py_info import PythonInfo``),
-switch to ``from python_discovery import PythonInfo``. Backward-compatibility re-export shims are provided at
-``virtualenv.discovery.py_info``, ``virtualenv.discovery.py_spec``, and ``virtualenv.discovery.cached_py_info``,
-however these are considered unsupported and may be removed in a future release - by :user:`gaborbernat`.
+The Python discovery logic has been extracted into a standalone ``python-discovery`` package on PyPI (`documentation
+<https://python-discovery.readthedocs.io/>`_) and is now consumed as a dependency. If you previously imported discovery
+internals directly (e.g. ``from virtualenv.discovery.py_info import PythonInfo``), switch to ``from python_discovery
+import PythonInfo``. Backward-compatibility re-export shims are provided at ``virtualenv.discovery.py_info``,
+``virtualenv.discovery.py_spec``, and ``virtualenv.discovery.cached_py_info``, however these are considered unsupported
+and may be removed in a future release - by :user:`gaborbernat`.

--- a/docs/changelog/3070.removal.rst
+++ b/docs/changelog/3070.removal.rst
@@ -1,0 +1,6 @@
+The Python discovery logic has been extracted into a standalone ``python-discovery`` package on PyPI
+(`documentation <https://python-discovery.readthedocs.io/>`_) and is now consumed as a dependency. If you
+previously imported discovery internals directly (e.g. ``from virtualenv.discovery.py_info import PythonInfo``),
+switch to ``from python_discovery import PythonInfo``. Backward-compatibility re-export shims are provided at
+``virtualenv.discovery.py_info``, ``virtualenv.discovery.py_spec``, and ``virtualenv.discovery.cached_py_info``,
+however these are considered unsupported and may be removed in a future release - by :user:`gaborbernat`.


### PR DESCRIPTION
PR #3070 extracted the Python discovery logic into the standalone `python-discovery` package but was merged without a towncrier changelog fragment. This adds the missing `removal` fragment documenting the breaking change for the upcoming 21.0.0 release.

The entry explains the migration path from `virtualenv.discovery.py_info` to `python_discovery` and notes that the backward-compatibility re-export shims at `virtualenv.discovery.py_info`, `virtualenv.discovery.py_spec`, and `virtualenv.discovery.cached_py_info` are unsupported and may be removed in a future release.