### PR TITLE
🐛 fix(bash): use BASH_SOURCE in activate relocation

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -192,3 +192,5 @@ jobs:
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.tox_env }}
       - name: 🏃 Run check for ${{ matrix.tox_env }}
         run: tox run --skip-pkg-install -e ${{ matrix.tox_env }}
+        env:
+          UPGRADE_ADVISORY: ${{ matrix.tox_env == 'upgrade' && '1' || '' }}

--- a/docs/changelog/3090.bugfix.rst
+++ b/docs/changelog/3090.bugfix.rst
@@ -1,2 +1,2 @@
-Use ``BASH_SOURCE[0]`` instead of ``$0`` in the bash activate script relocation fallback, fixing incorrect ``PATH``
-when sourcing the activate script from a different directory - by :user:`gaborbernat`.
+Use ``BASH_SOURCE[0]`` instead of ``$0`` in the bash activate script relocation fallback, fixing incorrect ``PATH`` when
+sourcing the activate script from a different directory - by :user:`gaborbernat`.

--- a/docs/changelog/3090.bugfix.rst
+++ b/docs/changelog/3090.bugfix.rst
@@ -1,0 +1,2 @@
+Use ``BASH_SOURCE[0]`` instead of ``$0`` in the bash activate script relocation fallback, fixing incorrect ``PATH``
+when sourcing the activate script from a different directory - by :user:`gaborbernat`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ lint.per-file-ignores."tests/**/*.py" = [
   "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
   "S101",    # asserts allowed in tests
   "S603",    # `subprocess` call: check for execution of untrusted input
+  "S607",    # partial executable path is fine in tests
 ]
 lint.isort = { known-first-party = [
   "virtualenv",

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -62,7 +62,7 @@ deactivate nondestructive
 
 if [ ! -d __VIRTUAL_ENV__ ]; then
     echo "Virtual environment directory __VIRTUAL_ENV__ does not exist!" >&2
-    CURRENT_PATH=$(realpath "${0}")
+    CURRENT_PATH=$(realpath "${BASH_SOURCE[0]}")
     CURRENT_DIR=$(dirname "${CURRENT_PATH}")
     VIRTUAL_ENV="$(realpath "${CURRENT_DIR}/../")"
 else

--- a/src/virtualenv/run/__init__.py
+++ b/src/virtualenv/run/__init__.py
@@ -106,7 +106,7 @@ def build_parser(
     if interpreter is None:
         msg = f"failed to find interpreter for {discover}"
         raise RuntimeError(msg)
-    elements = [
+    elements: list[ComponentBuilder] = [
         CreatorSelector(interpreter, parser),
         SeederSelector(interpreter, parser),
         ActivationSelector(interpreter, parser),

--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -76,7 +76,15 @@ def test_bash_tkinter_generation(tmp_path, tcl_lib, tk_lib, present) -> None:
 @pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
 def test_bash_activate_relocation_resolves_virtual_env(tmp_path, current_fastest) -> None:
     original = tmp_path / "original"
-    cli_run(["--without-pip", str(original), "--creator", current_fastest, "--no-periodic-update", "--activators", "bash"])
+    cli_run([
+        "--without-pip",
+        str(original),
+        "--creator",
+        current_fastest,
+        "--no-periodic-update",
+        "--activators",
+        "bash",
+    ])
     relocated = tmp_path / "relocated"
     shutil.move(original, relocated)
 

--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import shutil
+import subprocess
 from argparse import Namespace
 
 import pytest
 
 from virtualenv.activation import BashActivator
 from virtualenv.info import IS_WIN
+from virtualenv.run import cli_run
 
 
 @pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
@@ -68,6 +71,26 @@ def test_bash_tkinter_generation(tmp_path, tcl_lib, tk_lib, present) -> None:
         assert "TCL_LIBRARY=''" in content
         # The export is inside the if, so this is fine
         assert "export TCL_LIBRARY" in content
+
+
+@pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
+def test_bash_activate_relocation_resolves_virtual_env(tmp_path, current_fastest) -> None:
+    original = tmp_path / "original"
+    cli_run(["--without-pip", str(original), "--creator", current_fastest, "--no-periodic-update", "--activators", "bash"])
+    relocated = tmp_path / "relocated"
+    shutil.move(original, relocated)
+
+    work_dir = tmp_path / "workdir"
+    work_dir.mkdir()
+    activate_script = relocated / "bin" / "activate"
+    result = subprocess.run(
+        ["bash", "-c", f'source "{activate_script}" 2>/dev/null && echo "$VIRTUAL_ENV"'],
+        capture_output=True,
+        text=True,
+        cwd=str(work_dir),
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(relocated)
 
 
 @pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")


### PR DESCRIPTION
When a virtualenv is moved and the original `__VIRTUAL_ENV__` path no longer exists, the bash activate script falls back to computing `VIRTUAL_ENV` from the script's own location. 🐛 This fallback used `$0` to find the script path, but since activate is **sourced** (not executed), `$0` evaluates to the shell binary (e.g. `/bin/bash`) rather than the script path. This caused `VIRTUAL_ENV` and `PATH` to point to incorrect directories derived from the shell's location or the user's working directory.

Replacing `$0` with `BASH_SOURCE[0]` resolves this, as `BASH_SOURCE[0]` correctly refers to the sourced script's path regardless of how bash was invoked. This is consistent with the guard at the top of the script (line 5) which already uses `BASH_SOURCE` to detect direct execution.

Fixes #3090