### PR TITLE
🐛 fix(create): use commonpath for correct path validation

### DIFF
--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -148,7 +148,7 @@ class Creator(ABC):
         """No path separator in the path, valid chars and must be write-able."""
 
         def non_write_able(dest: Path, value: Path) -> NoReturn:
-            common = Path(*os.path.commonprefix([value.parts, dest.parts]))
+            common = Path(os.path.commonpath([str(value), str(dest)]))
             msg = f"the destination {dest.relative_to(common)} is not write-able at {common}"
             raise ArgumentTypeError(msg)
 


### PR DESCRIPTION
## Summary
Replace `os.path.commonprefix` with `os.path.commonpath` in destination path validation.

## Problem
`os.path.commonprefix` operates on strings character-by-character and when given path component tuples (from `.parts`), returns a tuple that may not represent a valid common path.

`os.path.commonpath` properly understands path semantics and returns the longest common sub-path as a string.

## Changes
- Changed from `Path(*os.path.commonprefix([value.parts, dest.parts]))` to `Path(os.path.commonpath([str(value), str(dest)]))`
- Ensures correct path comparison when validating write permissions for virtual environment destinations

## Test Plan
- [x] Existing test `test_destination_not_write_able` passes
- [x] Type check passes with Python 3.8+
- [x] Ruff formatting and linting pass