### PR TITLE
👷 ci: fix setup-uv warnings and drop brew@3.9

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -68,6 +68,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
+          cache-suffix: ${{ matrix.py }}
       - name: 🐍 Setup Python for tox
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -153,6 +154,7 @@ jobs:
           PYTEST_ADDOPTS: "-vv --durations=20"
           CI_RUN: "yes"
           DIFF_AGAINST: HEAD
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
   check:
     name: 🔎 check ${{ matrix.tox_env }} - ${{ matrix.os }}
     if: github.event_name != 'schedule' || github.repository_owner == 'pypa'
@@ -193,6 +195,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
+          cache-suffix: ${{ matrix.tox_env }}
       - name: 📦 Install tox
         run: uv tool install --python-preference only-managed --python 3.14 "tox>=4.45" --with tox-uv
       - name: 🏗️ Setup check suite

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -48,15 +48,12 @@ jobs:
           - { os: macos-15, py: "brew@3.12" }
           - { os: macos-15, py: "brew@3.11" }
           - { os: macos-15, py: "brew@3.10" }
-          - { os: macos-15, py: "brew@3.9" }
         exclude:
           - { os: windows-2025, py: "graalpy-24.1" }
           - { os: windows-2025, py: "pypy-3.10" }
           - { os: windows-2025, py: "pypy-3.9" }
           - { os: windows-2025, py: "pypy-3.8" }
     steps:
-      - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - name: 📥 Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -66,6 +63,11 @@ jobs:
         shell: bash
         run: |
           git fetch --force --tags https://github.com/pypa/virtualenv.git
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: 🐍 Setup Python for tox
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -177,10 +179,6 @@ jobs:
           - { os: windows-2025, tox_env: type }
           - { os: windows-2025, tox_env: type-3.8 }
     steps:
-      - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-      - name: 📦 Install tox
-        run: uv tool install --python-preference only-managed --python 3.14 "tox>=4.45" --with tox-uv
       - name: 📥 Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -190,6 +188,13 @@ jobs:
         shell: bash
         run: |
           git fetch --force --tags https://github.com/pypa/virtualenv.git
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - name: 📦 Install tox
+        run: uv tool install --python-preference only-managed --python 3.14 "tox>=4.45" --with tox-uv
       - name: 🏗️ Setup check suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.tox_env }}
       - name: 🏃 Run check for ${{ matrix.tox_env }}


### PR DESCRIPTION
Every CI job emitted "Empty workdir detected" and "No file matched to [...]. The cache will never get invalidated." because `astral-sh/setup-uv` ran before `actions/checkout`. With 50+ parallel jobs sharing the same cache key, jobs also raced to save the cache simultaneously, producing "Unable to reserve cache" warnings on every run.

Checkout now runs first in both jobs so `setup-uv` can find `pyproject.toml` for cache keying. A `cache-suffix` derived from the matrix variable (`matrix.py` / `matrix.tox_env`) gives each job its own cache slot, eliminating the write race entirely. 🔧 `PIP_DISABLE_PIP_VERSION_CHECK=1` suppresses the pip upgrade notice that appeared for Python 3.8, which ships with a stale pip. `brew@3.9` is dropped because Python 3.9 reached EOL in October 2024 and Homebrew emits a deprecation warning when installing it.