### PR TITLE
fix(ci): check out repo in publish job for gh release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,11 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
`gh release create --generate-notes` runs git to locate the previous tag when building auto-generated release notes. The publish job had no checkout, so it failed with `fatal: not a git repository`. This broke the 21.2.1 release after PyPI publish had already succeeded.

A minimal `fetch-depth: 0` checkout is added before the artifact downloads. `persist-credentials: false` is set since the publish job only reads the repo — it does not push.