### PR TITLE
bump python-discovery minimum to 1.2.2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Bugfixes - 21.2.1
 - Upgrade embedded wheels:
 
   - setuptools to ``82.0.1`` from ``82.0.0`` (:issue:`3093`)
+
 - Use terminal width for help formatting instead of hardcoded 240. (:issue:`3110`)
 
 **********************

--- a/docs/changelog/3117.bugfix.rst
+++ b/docs/changelog/3117.bugfix.rst
@@ -1,0 +1,1 @@
+Bump ``python-discovery`` minimum to ``>=1.2.2`` to include ``normalize_isa`` support - by :user:`rahuldevikar`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "filelock>=3.24.2,<4; python_version>='3.10'",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs>=3.9.1,<5",
-  "python-discovery>=1",
+  "python-discovery>=1.2.2",
   "typing-extensions>=4.13.2; python_version<'3.11'",
 ]
 urls.Documentation = "https://virtualenv.pypa.io"


### PR DESCRIPTION
Following a fix for this: https://github.com/python-lz4/python-lz4/actions/runs/24358045293/job/71130129933?pr=337

virtualenv requires python-discovery>=1 which is too loose — it happily accepts 1.2.0. When cibuildwheel's constraints file pins an old version, pip sees no conflict with virtualenv's requirement and downgrades it.

  If virtualenv bumped its minimum to python-discovery>=1.2.2, pip would reject the downgrade to 1.2.0 because it would violate virtualenv's dependency. The constraints file can't override a hard requirement from an installed package.

  This would fix the issue at the root — virtualenv is the package that brings in python-discovery, so it should declare the minimum version it (and its ecosystem) actually needs.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
