### PR TITLE
🐛 fix(seed): validate wheel zip entries before extraction

### DIFF
--- a/docs/changelog/3118.bugfix.rst
+++ b/docs/changelog/3118.bugfix.rst
@@ -1,0 +1,2 @@
+Security hardening: validate each entry of a seed wheel archive before extracting it so a tampered wheel cannot escape
+the app-data image directory via an absolute path or ``..`` traversal.

--- a/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
+++ b/src/virtualenv/seed/embed/via_app_data/pip_install/base.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+import ntpath
 import os
+import posixpath
 import re
 import zipfile
 from abc import ABC, abstractmethod
@@ -19,6 +21,24 @@ if TYPE_CHECKING:
     from virtualenv.create.creator import Creator
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _safe_extract_zip(zip_ref: zipfile.ZipFile, target_dir: Path) -> None:
+    # Guard against zip slip: a wheel is a zip and a tampered entry name (absolute path or one containing ``..``)
+    # could escape ``target_dir``.
+    base = target_dir.resolve()
+    for info in zip_ref.infolist():
+        name = info.filename
+        if name.startswith(("/", "\\")) or ntpath.isabs(name) or posixpath.isabs(name):
+            msg = f"refusing to extract absolute path entry from wheel: {name!r}"
+            raise RuntimeError(msg)
+        candidate = (base / name).resolve()
+        try:
+            candidate.relative_to(base)
+        except ValueError as exc:
+            msg = f"refusing to extract entry escaping target directory: {name!r}"
+            raise RuntimeError(msg) from exc
+    zip_ref.extractall(str(target_dir))
 
 
 class PipInstall(ABC):
@@ -49,11 +69,19 @@ class PipInstall(ABC):
         LOGGER.debug("generated console scripts %s", " ".join(i.name for i in consoles))
 
     def build_image(self) -> None:
+        """Extract the seed wheel into the image directory and fix up its RECORD file.
+
+        Each archive entry is validated before extraction so a tampered wheel cannot escape the image directory via an
+        absolute path or ``..`` traversal.
+
+        :raises RuntimeError: if the wheel contains an entry that would land outside the image directory.
+
+        """
         # 1. first extract the wheel
         LOGGER.debug("build install image for %s to %s", self._wheel.name, self._image_dir)
         with zipfile.ZipFile(str(self._wheel)) as zip_ref:
             self._shorten_path_if_needed(zip_ref)
-            zip_ref.extractall(str(self._image_dir))
+            _safe_extract_zip(zip_ref, self._image_dir)
             self._extracted = True
         # 2. now add additional files not present in the distribution
         new_files = self._generate_new_files()

--- a/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
+++ b/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
+import zipfile
 from stat import S_IWGRP, S_IWOTH, S_IWUSR
 from subprocess import Popen, check_call
 from threading import Thread
@@ -14,6 +15,7 @@ from python_discovery import _cached_py_info as cached_py_info
 
 from virtualenv.info import fs_supports_symlink
 from virtualenv.run import cli_run
+from virtualenv.seed.embed.via_app_data.pip_install.base import _safe_extract_zip
 from virtualenv.seed.wheels.embed import BUNDLE_FOLDER, BUNDLE_SUPPORT
 from virtualenv.util.path import safe_delete
 
@@ -262,3 +264,52 @@ def _run_parallel_threads(tmp_path):
     for thread in threads:
         thread.join()
     return exceptions
+
+
+def _write_zip_with_entry(zip_path: Path, entry_name: str) -> None:
+    with zipfile.ZipFile(str(zip_path), "w") as archive:
+        archive.writestr(entry_name, "payload")
+
+
+def test_safe_extract_zip_allows_normal_entry(tmp_path: Path) -> None:
+    archive = tmp_path / "ok.zip"
+    _write_zip_with_entry(archive, "pkg/inner.txt")
+    target = tmp_path / "out"
+    target.mkdir()
+
+    with zipfile.ZipFile(str(archive)) as zip_ref:
+        _safe_extract_zip(zip_ref, target)
+
+    assert (target / "pkg" / "inner.txt").read_text() == "payload"
+
+
+def test_safe_extract_zip_rejects_parent_traversal(tmp_path: Path) -> None:
+    archive = tmp_path / "evil.zip"
+    _write_zip_with_entry(archive, "../escape.txt")
+    target = tmp_path / "out"
+    target.mkdir()
+
+    with zipfile.ZipFile(str(archive)) as zip_ref, pytest.raises(RuntimeError, match="escaping target directory"):
+        _safe_extract_zip(zip_ref, target)
+
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_safe_extract_zip_rejects_absolute_posix_entry(tmp_path: Path) -> None:
+    archive = tmp_path / "abs.zip"
+    _write_zip_with_entry(archive, "/tmp/evil.txt")  # noqa: S108
+    target = tmp_path / "out"
+    target.mkdir()
+
+    with zipfile.ZipFile(str(archive)) as zip_ref, pytest.raises(RuntimeError, match="absolute path"):
+        _safe_extract_zip(zip_ref, target)
+
+
+def test_safe_extract_zip_rejects_absolute_windows_entry(tmp_path: Path) -> None:
+    archive = tmp_path / "win.zip"
+    _write_zip_with_entry(archive, "C:/Windows/System32/evil.txt")
+    target = tmp_path / "out"
+    target.mkdir()
+
+    with zipfile.ZipFile(str(archive)) as zip_ref, pytest.raises(RuntimeError, match="absolute path"):
+        _safe_extract_zip(zip_ref, target)


### PR DESCRIPTION
Security hardening. The app-data seeder extracts seed wheels with `zipfile.ZipFile.extractall` without validating entry names first. Wheels are not a strongly trusted input — they live on disk, they can be replaced by anyone with write access to the app-data cache, and in the ``--download`` path they come from pip's cache — so a tampered wheel with an entry named `../evil.py` or an absolute path would land outside the image directory. 🔒

The fix wraps extraction in a helper that refuses any entry whose name is absolute or resolves outside the target image directory, then delegates to `extractall` for the happy path. Absolute-path checks cover both POSIX and Windows forms so the same guard is effective on any platform.

Nothing changes for well-formed wheels; only malformed archives are rejected, with a clear `RuntimeError` that names the offending entry.