### PR TITLE
🐛 fix(seed): verify sha256 of bundled wheels on load

### DIFF
--- a/docs/changelog/3119.bugfix.rst
+++ b/docs/changelog/3119.bugfix.rst
@@ -1,0 +1,3 @@
+Security hardening: verify the SHA-256 of every bundled seed wheel when it is loaded so a corrupted or tampered file on
+disk fails loud instead of being handed to pip. The hash table is generated alongside ``BUNDLE_SUPPORT`` by
+``tasks/upgrade_wheels.py``.

--- a/src/virtualenv/seed/wheels/embed/__init__.py
+++ b/src/virtualenv/seed/wheels/embed/__init__.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import hashlib
+import zipfile
 from pathlib import Path
 
+from virtualenv.info import IS_ZIPAPP, ROOT
 from virtualenv.seed.wheels.util import Wheel
 
 BUNDLE_FOLDER = Path(__file__).absolute().parent
@@ -42,18 +45,74 @@ BUNDLE_SUPPORT = {
 }
 MAX = "3.8"
 
+# SHA-256 of every bundled wheel. Verified on load so a corrupted or tampered wheel on disk fails loud instead of
+# being handed to pip. Generated together with ``BUNDLE_SUPPORT`` by ``tasks/upgrade_wheels.py``.
+BUNDLE_SHA256 = {
+    "pip-25.0.1-py3-none-any.whl": "c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f",
+    "pip-26.0.1-py3-none-any.whl": "bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b",
+    "setuptools-75.3.4-py3-none-any.whl": "2dd50a7f42dddfa1d02a36f275dbe716f38ed250224f609d35fb60a09593d93e",
+    "setuptools-82.0.1-py3-none-any.whl": "a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb",
+    "wheel-0.45.1-py3-none-any.whl": "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248",
+}
+
+_VERIFIED_WHEELS: set[str] = set()
+
 
 def get_embed_wheel(distribution: str, for_py_version: str) -> Wheel | None:
+    """Return the bundled wheel that ships with virtualenv for a given distribution and Python version.
+
+    :param distribution: project name of the seed package, for example ``pip`` or ``setuptools``.
+    :param for_py_version: major.minor Python version string the environment will be created for.
+
+    :returns: a :class:`Wheel` pointing at the verified bundled file, or ``None`` when no wheel is bundled for the
+        requested combination.
+
+    :raises RuntimeError: if the bundled wheel on disk fails SHA-256 verification.
+
+    """
     mapping = BUNDLE_SUPPORT.get(for_py_version, {}) or BUNDLE_SUPPORT[MAX]
     wheel_file = mapping.get(distribution)
     if wheel_file is None:
         return None
     path = BUNDLE_FOLDER / wheel_file
+    _verify_bundled_wheel(path)
     return Wheel.from_path(path)
+
+
+def _verify_bundled_wheel(path: Path) -> None:
+    name = path.name
+    if name in _VERIFIED_WHEELS:
+        return
+    expected = BUNDLE_SHA256.get(name)
+    if expected is None:
+        msg = f"bundled wheel {name} has no recorded sha256 in BUNDLE_SHA256"
+        raise RuntimeError(msg)
+    actual = _hash_bundled_wheel(path)
+    if actual != expected:
+        msg = f"bundled wheel {name} sha256 mismatch: expected {expected}, got {actual}"
+        raise RuntimeError(msg)
+    _VERIFIED_WHEELS.add(name)
+
+
+def _hash_bundled_wheel(path: Path) -> str:
+    # ``path`` is under the package directory; when virtualenv runs from a zipapp the wheel lives inside the
+    # archive and cannot be opened as a regular file, so read the bytes straight from the zipapp entry.
+    digest = hashlib.sha256()
+    if IS_ZIPAPP:
+        entry = path.resolve().relative_to(Path(ROOT).resolve()).as_posix()
+        with zipfile.ZipFile(ROOT, "r") as archive, archive.open(entry) as stream:
+            for chunk in iter(lambda: stream.read(1 << 20), b""):
+                digest.update(chunk)
+    else:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1 << 20), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
 
 
 __all__ = [
     "BUNDLE_FOLDER",
+    "BUNDLE_SHA256",
     "BUNDLE_SUPPORT",
     "MAX",
     "get_embed_wheel",

--- a/tasks/upgrade_wheels.py
+++ b/tasks/upgrade_wheels.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+import hashlib
 import os
 import shutil
 import subprocess
@@ -20,122 +22,207 @@ SUPPORT = [(3, i) for i in range(8, 16)]
 DEST = Path(__file__).resolve().parents[1] / "src" / "virtualenv" / "seed" / "wheels" / "embed"
 
 
-def download(ver: str, dest: str, package: str) -> None:
-    subprocess.call(
-        [
-            sys.executable,
-            "-W",
-            "ignore::EncodingWarning",
-            "-m",
-            "pip",
-            "--disable-pip-version-check",
-            "download",
-            "--no-cache-dir",
-            "--only-binary=:all:",
-            "--python-version",
-            ver,
-            "-d",
-            dest,
-            package,
-        ],
-    )
-
-
-def run() -> NoReturn:  # noqa: C901, PLR0912
+def run() -> NoReturn:
+    if "--regen" in sys.argv[1:]:
+        render_init()
+        raise SystemExit(0)
     old_batch = {i.name for i in DEST.iterdir() if i.suffix == ".whl"}
     with TemporaryDirectory() as temp:
-        temp_path = Path(temp)
-        folders = {}
-        targets = []
-        for support in SUPPORT:
-            support_ver = ".".join(str(i) for i in support)
-            into = temp_path / support_ver
-            into.mkdir()
-            folders[into] = support_ver
-            for package in BUNDLED:
-                if package == "wheel" and support >= (3, 9):
-                    continue
-                thread = Thread(target=download, args=(support_ver, str(into), package))
-                targets.append(thread)
-                thread.start()
-        for thread in targets:
-            thread.join()
+        folders = _download_all(Path(temp))
         new_batch = {i.name: i for f in folders for i in Path(f).iterdir()}
-
         new_packages = new_batch.keys() - old_batch
         remove_packages = old_batch - new_batch.keys()
-
-        for package in remove_packages:
-            (DEST / package).unlink()
-        for package in new_packages:
-            shutil.copy2(str(new_batch[package]), DEST / package)
-
+        _sync_dest(new_packages, remove_packages, new_batch)
         added = collect_package_versions(new_packages)
         removed = collect_package_versions(remove_packages)
         outcome = (1 if STRICT else 0) if (added or removed) else 0
         print(f"Outcome {outcome} added {added} removed {removed}")  # noqa: T201
-        lines = ["Upgrade embedded wheels:", ""]
-        for key, versions in added.items():
-            text = f"* {key} to {fmt_version(versions)}"
-            if key in removed:
-                rem = ", ".join(f"``{i}``" for i in removed[key])
-                text += f" from {rem}"
-                del removed[key]
-            lines.append(text)
-        for key, versions in removed.items():
-            lines.append(f"Removed {key} of {fmt_version(versions)}")
-        lines.append("")
-        changelog = "\n".join(lines)
-        print(changelog)  # noqa: T201
-        if len(lines) >= 4:  # noqa: PLR2004
-            (Path(__file__).parents[1] / "docs" / "changelog" / "u.bugfix.rst").write_text(changelog, encoding="utf-8")
+        _write_changelog(added, removed)
+        render_init(folders=folders)
+        raise SystemExit(outcome)
+
+
+def _download_all(temp_path: Path) -> dict[Path, str]:
+    folders: dict[Path, str] = {}
+    targets: list[Thread] = []
+    for support in SUPPORT:
+        support_ver = ".".join(str(i) for i in support)
+        into = temp_path / support_ver
+        into.mkdir()
+        folders[into] = support_ver
+        for package in BUNDLED:
+            if package == "wheel" and support >= (3, 9):
+                continue
+            thread = Thread(target=download, args=(support_ver, str(into), package))
+            targets.append(thread)
+            thread.start()
+    for thread in targets:
+        thread.join()
+    return folders
+
+
+def _sync_dest(new_packages: set[str], remove_packages: set[str], new_batch: dict[str, Path]) -> None:
+    for package in remove_packages:
+        (DEST / package).unlink()
+    for package in new_packages:
+        shutil.copy2(str(new_batch[package]), DEST / package)
+
+
+def _write_changelog(added: dict[str, list[str]], removed: dict[str, list[str]]) -> None:
+    lines = ["Upgrade embedded wheels:", ""]
+    for key, versions in added.items():
+        text = f"* {key} to {fmt_version(versions)}"
+        if key in removed:
+            rem = ", ".join(f"``{i}``" for i in removed[key])
+            text += f" from {rem}"
+            del removed[key]
+        lines.append(text)
+    for key, versions in removed.items():
+        lines.append(f"Removed {key} of {fmt_version(versions)}")
+    lines.append("")
+    changelog = "\n".join(lines)
+    print(changelog)  # noqa: T201
+    if len(lines) >= 4:  # noqa: PLR2004
+        (Path(__file__).parents[1] / "docs" / "changelog" / "u.bugfix.rst").write_text(changelog, encoding="utf-8")
+
+
+def render_init(folders: dict[Path, str] | None = None) -> None:
+    """Write ``embed/__init__.py`` from the wheels currently in DEST.
+
+    When called from ``run()`` after a download round, ``folders`` maps each per-python-version temp folder to its
+    version string, which is how support for a wheel is determined. When called with ``--regen`` there are no downloaded
+    folders — the existing ``BUNDLE_SUPPORT`` from the current ``__init__.py`` is used so regeneration is deterministic.
+
+    """
+    if folders is None:
+        support_table = _support_table_from_existing_init()
+    else:
+        present = {i.name: i for f in folders for i in Path(f).iterdir() if i.suffix == ".whl"}
         support_table = OrderedDict((".".join(str(j) for j in i), []) for i in SUPPORT)
-        for package in sorted(new_batch.keys()):
+        for package in sorted(present):
             for folder, version in sorted(folders.items()):
                 if (folder / package).exists():
                     support_table[version].append(package)
-        support_table = {k: OrderedDict((i.split("-")[0], i) for i in v) for k, v in support_table.items()}
-        nl = "\n"
-        bundle = "".join(
-            f"\n        {v!r}: {{{nl}{''.join(f'            {p!r}: {f!r},{nl}' for p, f in line.items())}        }},"
-            for v, line in support_table.items()
-        )
-        msg = dedent(
-            f"""
-        from __future__ import annotations
+        support_table = OrderedDict((k, OrderedDict((i.split("-")[0], i) for i in v)) for k, v in support_table.items())
+    wheel_names = sorted({wheel for mapping in support_table.values() for wheel in mapping.values()})
+    sha_table = OrderedDict((name, _sha256(DEST / name)) for name in wheel_names)
+    nl = "\n"
+    bundle = "".join(
+        f"\n        {v!r}: {{{nl}{''.join(f'            {p!r}: {f!r},{nl}' for p, f in line.items())}        }},"
+        for v, line in support_table.items()
+    )
+    sha_block = "".join(f"\n        {name!r}: {digest!r}," for name, digest in sha_table.items())
+    msg = dedent(
+        f"""
+    from __future__ import annotations
 
-        from pathlib import Path
+    import hashlib
+    import zipfile
+    from pathlib import Path
 
-        from virtualenv.seed.wheels.util import Wheel
+    from virtualenv.info import IS_ZIPAPP, ROOT
+    from virtualenv.seed.wheels.util import Wheel
 
-        BUNDLE_FOLDER = Path(__file__).absolute().parent
-        BUNDLE_SUPPORT = {{ {bundle} }}
-        MAX = {next(iter(support_table.keys()))!r}
+    BUNDLE_FOLDER = Path(__file__).absolute().parent
+    BUNDLE_SUPPORT = {{ {bundle} }}
+    MAX = {next(iter(support_table.keys()))!r}
+
+    # SHA-256 of every bundled wheel. Verified on load so a corrupted or tampered wheel on disk fails loud instead of
+    # being handed to pip. Generated together with ``BUNDLE_SUPPORT`` by ``tasks/upgrade_wheels.py``.
+    BUNDLE_SHA256 = {{ {sha_block} }}
+
+    _VERIFIED_WHEELS: set[str] = set()
 
 
-        def get_embed_wheel(distribution: str, for_py_version: str) -> Wheel | None:
-            mapping = BUNDLE_SUPPORT.get(for_py_version, {{}}) or BUNDLE_SUPPORT[MAX]
-            wheel_file = mapping.get(distribution)
-            if wheel_file is None:
-                return None
-            path = BUNDLE_FOLDER / wheel_file
-            return Wheel.from_path(path)
+    def get_embed_wheel(distribution: str, for_py_version: str) -> Wheel | None:
+        \"\"\"Return the bundled wheel that ships with virtualenv for a given distribution and Python version.
 
-        __all__ = [
-            "BUNDLE_FOLDER",
-            "BUNDLE_SUPPORT",
-            "MAX",
-            "get_embed_wheel",
-        ]
+        :param distribution: project name of the seed package, for example ``pip`` or ``setuptools``.
+        :param for_py_version: major.minor Python version string the environment will be created for.
 
-        """,
-        )
-        dest_target = DEST / "__init__.py"
-        dest_target.write_text(msg, encoding="utf-8")
-        subprocess.run([sys.executable, "-m", "ruff", "check", str(dest_target), "--fix", "--unsafe-fixes"])
-        subprocess.run([sys.executable, "-m", "ruff", "format", str(dest_target), "--preview"])
+        :returns: a :class:`Wheel` pointing at the verified bundled file, or ``None`` when no wheel is bundled for the
+            requested combination.
 
-        raise SystemExit(outcome)
+        :raises RuntimeError: if the bundled wheel on disk fails SHA-256 verification.
+
+        \"\"\"
+        mapping = BUNDLE_SUPPORT.get(for_py_version, {{}}) or BUNDLE_SUPPORT[MAX]
+        wheel_file = mapping.get(distribution)
+        if wheel_file is None:
+            return None
+        path = BUNDLE_FOLDER / wheel_file
+        _verify_bundled_wheel(path)
+        return Wheel.from_path(path)
+
+
+    def _verify_bundled_wheel(path: Path) -> None:
+        name = path.name
+        if name in _VERIFIED_WHEELS:
+            return
+        expected = BUNDLE_SHA256.get(name)
+        if expected is None:
+            msg = f"bundled wheel {{name}} has no recorded sha256 in BUNDLE_SHA256"
+            raise RuntimeError(msg)
+        actual = _hash_bundled_wheel(path)
+        if actual != expected:
+            msg = f"bundled wheel {{name}} sha256 mismatch: expected {{expected}}, got {{actual}}"
+            raise RuntimeError(msg)
+        _VERIFIED_WHEELS.add(name)
+
+
+    def _hash_bundled_wheel(path: Path) -> str:
+        # ``path`` is under the package directory; when virtualenv runs from a zipapp the wheel lives inside the
+        # archive and cannot be opened as a regular file, so read the bytes straight from the zipapp entry.
+        digest = hashlib.sha256()
+        if IS_ZIPAPP:
+            entry = path.resolve().relative_to(Path(ROOT).resolve()).as_posix()
+            with zipfile.ZipFile(ROOT, "r") as archive, archive.open(entry) as stream:
+                for chunk in iter(lambda: stream.read(1 << 20), b""):
+                    digest.update(chunk)
+        else:
+            with path.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1 << 20), b""):
+                    digest.update(chunk)
+        return digest.hexdigest()
+
+
+    __all__ = [
+        "BUNDLE_FOLDER",
+        "BUNDLE_SHA256",
+        "BUNDLE_SUPPORT",
+        "MAX",
+        "get_embed_wheel",
+    ]
+
+    """,
+    )
+    dest_target = DEST / "__init__.py"
+    dest_target.write_text(msg, encoding="utf-8")
+    subprocess.run([sys.executable, "-m", "ruff", "check", str(dest_target), "--fix", "--unsafe-fixes"], check=False)
+    subprocess.run([sys.executable, "-m", "ruff", "format", str(dest_target), "--preview"], check=False)
+
+
+def _support_table_from_existing_init() -> OrderedDict[str, OrderedDict[str, str]]:
+    source = (DEST / "__init__.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "BUNDLE_SUPPORT" for t in node.targets
+        ):
+            bundle_support = ast.literal_eval(node.value)
+            return OrderedDict(
+                (version, OrderedDict(sorted(mapping.items()))) for version, mapping in bundle_support.items()
+            )
+    msg = f"BUNDLE_SUPPORT not found in {DEST / '__init__.py'}"
+    raise RuntimeError(msg)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def fmt_version(versions: list[str]) -> str:
@@ -151,6 +238,27 @@ def collect_package_versions(new_packages: set[str]) -> dict[str, list[str]]:
         key, version = split[0:2]
         result[key].append(version)
     return result
+
+
+def download(python_version: str, dest: str, package: str) -> None:
+    subprocess.call(
+        [
+            sys.executable,
+            "-W",
+            "ignore::EncodingWarning",
+            "-m",
+            "pip",
+            "--disable-pip-version-check",
+            "download",
+            "--no-cache-dir",
+            "--only-binary=:all:",
+            "--python-version",
+            python_version,
+            "-d",
+            dest,
+            package,
+        ],
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/seed/wheels/test_bundle.py
+++ b/tests/unit/seed/wheels/test_bundle.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+import hashlib
 import os
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from virtualenv.app_data import AppDataDiskFolder
+from virtualenv.seed.wheels import embed
 from virtualenv.seed.wheels.bundle import from_bundle
-from virtualenv.seed.wheels.embed import get_embed_wheel
+from virtualenv.seed.wheels.embed import (
+    BUNDLE_FOLDER,
+    BUNDLE_SHA256,
+    BUNDLE_SUPPORT,
+    _verify_bundled_wheel,
+    get_embed_wheel,
+)
 from virtualenv.seed.wheels.periodic_update import dump_datetime
 from virtualenv.seed.wheels.util import Version, Wheel
 
@@ -73,3 +82,57 @@ def test_version_pinned_in_app_data(app_data, for_py_version, next_pip_wheel) ->
     wheel = from_bundle("pip", next_pip_wheel.version, for_py_version, [], app_data, False, os.environ)
     assert wheel is not None
     assert wheel.name == next_pip_wheel.name
+
+
+def test_every_bundled_wheel_has_sha256() -> None:
+    referenced = {wheel for mapping in BUNDLE_SUPPORT.values() for wheel in mapping.values()}
+    missing = referenced - BUNDLE_SHA256.keys()
+    assert not missing, f"bundled wheels missing from BUNDLE_SHA256: {sorted(missing)}"
+
+
+def test_every_wheel_on_disk_has_sha256() -> None:
+    on_disk = {entry.name for entry in BUNDLE_FOLDER.iterdir() if entry.suffix == ".whl"}
+    assert on_disk == BUNDLE_SHA256.keys()
+
+
+def test_get_embed_wheel_verifies_pip(for_py_version: str) -> None:
+    wheel = get_embed_wheel("pip", for_py_version)
+    assert wheel is not None
+
+
+def test_verify_bundled_wheel_rejects_tamper(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_name = "fake-0.0.1-py3-none-any.whl"
+    fake = tmp_path / fake_name
+    fake.write_bytes(b"not the real bytes")
+    monkeypatch.setitem(BUNDLE_SHA256, fake_name, "0" * 64)
+    monkeypatch.setattr("virtualenv.seed.wheels.embed._VERIFIED_WHEELS", set())
+
+    with pytest.raises(RuntimeError, match="sha256 mismatch"):
+        _verify_bundled_wheel(fake)
+
+
+def test_verify_bundled_wheel_rejects_unknown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stray = tmp_path / "stray-0.0.1-py3-none-any.whl"
+    stray.write_bytes(b"payload")
+    monkeypatch.setattr("virtualenv.seed.wheels.embed._VERIFIED_WHEELS", set())
+
+    with pytest.raises(RuntimeError, match="no recorded sha256"):
+        _verify_bundled_wheel(stray)
+
+
+def test_verify_bundled_wheel_reads_from_zipapp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate the layout we get when virtualenv runs out of a ``.pyz``: the wheel lives inside the zipapp rather
+    # than on disk, so the hash check has to read it through ``zipfile`` rather than ``path.open``.
+    wheel_name = "fakepkg-0.0.1-py3-none-any.whl"
+    wheel_payload = b"pretend-wheel-bytes"
+    fake_root = tmp_path / "virtualenv.pyz"
+    entry = f"virtualenv/seed/wheels/embed/{wheel_name}"
+    with zipfile.ZipFile(str(fake_root), "w") as archive:
+        archive.writestr(entry, wheel_payload)
+
+    monkeypatch.setattr(embed, "IS_ZIPAPP", True)
+    monkeypatch.setattr(embed, "ROOT", str(fake_root))
+    monkeypatch.setitem(BUNDLE_SHA256, wheel_name, hashlib.sha256(wheel_payload).hexdigest())
+    monkeypatch.setattr(embed, "_VERIFIED_WHEELS", set())
+
+    _verify_bundled_wheel(fake_root / entry)


### PR DESCRIPTION
Security hardening. Bundled seed wheels were loaded straight off disk and handed to pip without any integrity check. A corrupted or tampered wheel sitting next to `embed/__init__.py` — whether from a botched upgrade, a filesystem error, or a supply-chain compromise — would have been silently installed into every new environment. 🔒

The fix records the SHA-256 of every bundled wheel alongside `BUNDLE_SUPPORT` in the generated `embed/__init__.py`, and verifies each wheel the first time it is requested. Hashes are cached per wheel name so the happy path keeps a single file read per interpreter run, and a mismatch aborts with a clear `RuntimeError`. When virtualenv runs from a zipapp the bytes are read straight from the archive entry, so the check applies to both on-disk and zipapp layouts.

The hash table is produced by `tasks/upgrade_wheels.py` so future wheel bumps stay in sync without manual bookkeeping. A new `--regen` mode lets the generator rewrite the module from the wheels currently on disk without re-downloading anything, which is how this PR produced the initial table.