### PR TITLE
🐛 fix(seed): validate distribution and version before pip download

### DIFF
--- a/docs/changelog/3120.bugfix.rst
+++ b/docs/changelog/3120.bugfix.rst
@@ -1,0 +1,2 @@
+Security hardening: validate the distribution name and version specifier passed to ``pip download`` when acquiring a
+seed wheel so extras, pip flags, or shell metacharacters cannot be smuggled into the subprocess command line.

--- a/src/virtualenv/seed/wheels/acquire.py
+++ b/src/virtualenv/seed/wheels/acquire.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from operator import eq, lt
 from pathlib import Path
@@ -17,6 +18,34 @@ if TYPE_CHECKING:
     from virtualenv.app_data.base import AppData
 
 LOGGER = logging.getLogger(__name__)
+
+# PEP 503 normalized distribution name. Anything outside this character set on the way to ``pip download`` means
+# somebody is smuggling pip options or extras, so reject it before we build the command line.
+_DISTRIBUTION_RE = re.compile(
+    r"""
+    ^
+    (?P<name>
+        [A-Za-z0-9]                 # must start with an alnum
+        (?:[A-Za-z0-9._-]*           # inner chars: alnum plus . _ -
+           [A-Za-z0-9])?             # must also end with an alnum (unless length is 1)
+    )
+    $
+    """,
+    re.VERBOSE,
+)
+
+# Version specifier that matches what ``Version.as_version_spec`` emits: either empty, ``==<ver>`` or ``<<ver>`` where
+# ``<ver>`` is a subset of PEP 440 public versions. Kept deliberately strict so a crafted version cannot inject pip
+# flags.
+_VERSION_SPEC_RE = re.compile(
+    r"""
+    ^
+    (?P<operator>==|<)              # only the operators Version.as_version_spec can emit
+    (?P<version>[A-Za-z0-9._+!-]+)  # PEP 440 public-version character set, no whitespace
+    $
+    """,
+    re.VERBOSE,
+)
 
 
 def get_wheel(  # noqa: PLR0913
@@ -63,6 +92,26 @@ def download_wheel(  # noqa: PLR0913
     to_folder: Path,
     env: dict[str, str],
 ) -> Wheel:
+    """Invoke ``pip download`` in a subprocess to fetch a seed wheel.
+
+    :param distribution: PEP 503 normalized project name; rejected if it contains anything other than
+        ``[A-Za-z0-9._-]``.
+    :param version_spec: optional version specifier of the form ``==<ver>`` or ``<<ver>`` as emitted by
+        :func:`Version.as_version_spec`, or ``None``/empty for the latest compatible release.
+    :param for_py_version: major.minor Python version to pass through to ``pip --python-version``.
+    :param search_dirs: additional directories to treat as a local wheel index when bootstrapping pip.
+    :param app_data: application data store used to locate the embedded pip wheel.
+    :param to_folder: directory the downloaded wheel is written into.
+    :param env: environment mapping passed through to the subprocess.
+
+    :returns: the downloaded :class:`Wheel`.
+
+    :raises ValueError: if ``distribution`` or ``version_spec`` fail the strict allow-list check.
+    :raises CalledProcessError: if ``pip download`` exits with a non-zero status.
+
+    """
+    _check_distribution(distribution)
+    _check_version_spec(version_spec)
     to_download = f"{distribution}{version_spec or ''}"
     LOGGER.debug("download wheel %s %s to %s", to_download, for_py_version, to_folder)
     cmd = [
@@ -141,6 +190,20 @@ def pip_wheel_env_run(search_dirs: list[Path], app_data: AppData, env: dict[str,
         raise RuntimeError(msg)
     env["PYTHONPATH"] = str(wheel.path)
     return env
+
+
+def _check_distribution(distribution: str) -> None:
+    if not _DISTRIBUTION_RE.fullmatch(distribution):
+        msg = f"refusing to download wheel for suspicious distribution name: {distribution!r}"
+        raise ValueError(msg)
+
+
+def _check_version_spec(version_spec: str | None) -> None:
+    if not version_spec:
+        return
+    if not _VERSION_SPEC_RE.fullmatch(version_spec):
+        msg = f"refusing to download wheel with suspicious version spec: {version_spec!r}"
+        raise ValueError(msg)
 
 
 __all__ = [

--- a/tests/unit/seed/wheels/test_acquire.py
+++ b/tests/unit/seed/wheels/test_acquire.py
@@ -200,9 +200,7 @@ def test_download_wheel_rejects_bad_distribution(distribution: str, session_app_
         "==1.0;echo",
     ],
 )
-def test_download_wheel_rejects_bad_version_spec(
-    version_spec: str, session_app_data, mocker: MockerFixture
-) -> None:
+def test_download_wheel_rejects_bad_version_spec(version_spec: str, session_app_data, mocker: MockerFixture) -> None:
     mocker.patch("virtualenv.seed.wheels.acquire.Popen")
     with pytest.raises(ValueError, match="suspicious version spec"):
         download_wheel("pip", version_spec, "3.14", [], session_app_data, "folder", os.environ)

--- a/tests/unit/seed/wheels/test_acquire.py
+++ b/tests/unit/seed/wheels/test_acquire.py
@@ -171,3 +171,38 @@ def test_get_wheel_download_cached(
             },
         ],
     }
+
+
+@pytest.mark.parametrize(
+    "distribution",
+    [
+        "pip space",
+        "pip[extra]",
+        "pip;os.system('x')",
+        "--index-url=http://evil",
+        "-r requirements.txt",
+        "",
+        ".pip",
+        "pip-",
+    ],
+)
+def test_download_wheel_rejects_bad_distribution(distribution: str, session_app_data) -> None:
+    with pytest.raises(ValueError, match="suspicious distribution name"):
+        download_wheel(distribution, None, "3.14", [], session_app_data, "folder", os.environ)
+
+
+@pytest.mark.parametrize(
+    "version_spec",
+    [
+        "==1.0 --index-url=http://evil",
+        ">=1.0",
+        "== 1.0",
+        "==1.0;echo",
+    ],
+)
+def test_download_wheel_rejects_bad_version_spec(
+    version_spec: str, session_app_data, mocker: MockerFixture
+) -> None:
+    mocker.patch("virtualenv.seed.wheels.acquire.Popen")
+    with pytest.raises(ValueError, match="suspicious version spec"):
+        download_wheel("pip", version_spec, "3.14", [], session_app_data, "folder", os.environ)


### PR DESCRIPTION
Security hardening. The distribution name and version specifier handed to `pip download` in `download_wheel` were interpolated straight into the subprocess argument list with an f-string. Internal callers always pass sensible values today, but the function is a small function call away from turning a distribution string like `pip --index-url=http://evil` or `pip[extra]` into extra pip flags or a different package entirely. 🔒 Defense in depth is cheap here and the check runs before the subprocess is ever spawned.

The fix rejects any distribution name that does not match the PEP 503 normalised form, and any non-empty version spec that does not match what `Version.as_version_spec` can emit. The regexes are written in verbose mode with named groups so the allow-list is readable at a glance. Anything outside those shapes raises a `ValueError` with the offending string quoted for debugging. Happy-path callers see no behavioural change.