### PR TITLE
🐛 fix(zipapp): enforce ROOT containment with Path.relative_to

### DIFF
--- a/docs/changelog/3121.bugfix.rst
+++ b/docs/changelog/3121.bugfix.rst
@@ -1,0 +1,2 @@
+Security hardening: replace the string-prefix containment check in ``virtualenv.util.zipapp`` with ``Path.relative_to``
+so the zipapp extraction helpers refuse any path that does not resolve under the archive root.

--- a/src/virtualenv/util/zipapp.py
+++ b/src/virtualenv/util/zipapp.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import logging
-import os
 import zipfile
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-from virtualenv.info import IS_WIN, ROOT
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from virtualenv.info import ROOT
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,16 +25,18 @@ def extract(full_path: str | Path, dest: Path) -> None:
 
 
 def _get_path_within_zip(full_path: str | Path) -> str:
-    full_path = os.path.realpath(os.path.abspath(str(full_path)))
-    prefix = f"{ROOT}{os.sep}"
-    if not full_path.startswith(prefix):
-        msg = f"full_path={full_path} should start with prefix={prefix}."
-        raise RuntimeError(msg)
-    sub_file = full_path[len(prefix) :]
-    if IS_WIN:
-        # paths are always UNIX separators, even on Windows, though __file__ still follows platform default
-        sub_file = sub_file.replace(os.sep, "/")
-    return sub_file
+    # Use Path.relative_to so symlinks and ``..`` segments cannot slip through a string ``startswith`` check. The zipapp
+    # root is a real file we own so ``resolve`` is safe; anything that does not resolve under ROOT is a bug or an
+    # attempt to escape the archive and we refuse it.
+    resolved = Path(full_path).resolve()
+    root = Path(ROOT).resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        msg = f"full_path={resolved} should be within ROOT={root}"
+        raise RuntimeError(msg) from exc
+    # Zip entries always use forward slashes regardless of platform.
+    return relative.as_posix()
 
 
 __all__ = [

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import traceback
+import zipfile
 from typing import TYPE_CHECKING
 
 import pytest
 
 from virtualenv.app_data import _cache_dir_with_migration, _default_app_data_dir
+from virtualenv.util import zipapp
 from virtualenv.util.lock import ReentrantFileLock
 from virtualenv.util.subprocess import run_cmd
 
@@ -148,3 +150,29 @@ class TestCacheDirMigration:
         result = _cache_dir_with_migration()
         assert result == new_dir
         assert (tmp_path / "new-cache" / "wheel" / "3.12" / "image" / "pip" / "pip.dist-info" / "METADATA").exists()
+
+
+@pytest.fixture
+def fake_zipapp_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_root = tmp_path / "virtualenv.pyz"
+    with zipfile.ZipFile(str(fake_root), "w") as zip_file:
+        zip_file.writestr("virtualenv/payload.txt", "hello zipapp")
+    monkeypatch.setattr(zipapp, "ROOT", str(fake_root))
+    return fake_root
+
+
+def test_zipapp_read_returns_payload_from_entry_inside_root(fake_zipapp_root: Path) -> None:
+    entry = fake_zipapp_root / "virtualenv" / "payload.txt"
+    assert zipapp.read(entry) == "hello zipapp"
+
+
+def test_zipapp_read_rejects_path_escaping_via_parent(fake_zipapp_root: Path) -> None:
+    escape = fake_zipapp_root / ".." / "escape.txt"
+    with pytest.raises(RuntimeError, match="should be within ROOT"):
+        zipapp.read(escape)
+
+
+def test_zipapp_read_rejects_unrelated_absolute_path(fake_zipapp_root: Path, tmp_path: Path) -> None:  # noqa: ARG001
+    unrelated = tmp_path / "other" / "file.txt"
+    with pytest.raises(RuntimeError, match="should be within ROOT"):
+        zipapp.read(unrelated)


### PR DESCRIPTION
Security hardening. When running from a zipapp, `virtualenv.util.zipapp._get_path_within_zip` guards against paths that resolve outside the archive. The previous implementation called `os.path.realpath`, then decided containment by building a separator-prefixed string and comparing with `startswith`. That is fragile on Windows path separators, brittle around the trailing separator, and hard to reason about when symlinks are involved. 🔒

The fix resolves both the candidate path and `ROOT` through `pathlib` and uses `Path.relative_to` to decide containment — anything that does not resolve inside `ROOT` is rejected with a `RuntimeError` before any zipfile work happens. The returned entry name is always forward-slashed via `as_posix`, so the Windows-specific replacement is no longer needed.

Behaviour is unchanged for well-formed paths; only previously-accepted escape attempts become errors.