### PR TITLE
🐛 fix(periodic-update): refuse unverified HTTPS to PyPI by default

### DIFF
--- a/docs/changelog/3122.bugfix.rst
+++ b/docs/changelog/3122.bugfix.rst
@@ -1,0 +1,4 @@
+Security hardening: do not silently fall back to an unverified HTTPS context when the periodic update request to PyPI
+fails TLS verification. The returned metadata drives which wheel version virtualenv considers "up to date", so accepting
+an unverified response lets a network-level attacker suppress security updates. Set
+``VIRTUALENV_PERIODIC_UPDATE_INSECURE=1`` to restore the previous behavior on hosts with broken trust stores.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -252,6 +252,15 @@ Override app-data location
 
 Set the ``VIRTUALENV_OVERRIDE_APP_DATA`` environment variable to override the default app-data cache directory location.
 
+Allow unverified HTTPS for periodic updates
+===========================================
+
+The periodic update checks for newer seed wheels by fetching ``https://pypi.org/pypi/<distribution>/json``. The request
+is made with full TLS verification and, if the verified request fails, virtualenv now skips the update rather than
+downgrading the connection. Set ``VIRTUALENV_PERIODIC_UPDATE_INSECURE=1`` to restore the previous behavior and retry
+with an unverified SSL context. This is an escape hatch for hosts with broken trust stores; do not set it on hosts you
+do not control.
+
 Configuration priority
 ======================
 

--- a/src/virtualenv/seed/wheels/periodic_update.py
+++ b/src/virtualenv/seed/wheels/periodic_update.py
@@ -360,10 +360,20 @@ def release_date_for_wheel_path(dest: Path) -> datetime | None:
     return None
 
 
+#: Opt-in escape hatch to restore the pre-2026 behavior of falling back to an unverified HTTPS context when the
+#: verified request fails. Off by default: a failed TLS handshake on the PyPI metadata lookup now aborts the update
+#: instead of silently downgrading, because the response drives which wheel version virtualenv thinks is up to date.
+_INSECURE_FALLBACK_ENV = "VIRTUALENV_PERIODIC_UPDATE_INSECURE"
+
+
 def _request_context() -> Generator[ssl.SSLContext | None, None, None]:
     yield None
-    # fallback to non verified HTTPS (the information we request is not sensitive, so fallback)
-    yield ssl._create_unverified_context()  # noqa: S323, SLF001
+    if os.environ.get(_INSECURE_FALLBACK_ENV):
+        LOGGER.warning(
+            "falling back to unverified HTTPS for PyPI metadata because %s is set",
+            _INSECURE_FALLBACK_ENV,
+        )
+        yield ssl._create_unverified_context()  # noqa: S323, SLF001
 
 
 _PYPI_CACHE = {}

--- a/tests/unit/seed/wheels/test_periodic_update.py
+++ b/tests/unit/seed/wheels/test_periodic_update.py
@@ -501,7 +501,9 @@ def test_new_version_ne() -> None:
     )
 
 
-def test_get_release_unsecure(mocker, caplog) -> None:
+def test_get_release_unsecure(mocker, caplog, monkeypatch) -> None:
+    monkeypatch.setenv("VIRTUALENV_PERIODIC_UPDATE_INSECURE", "1")
+
     @contextmanager
     def _release(of, context):
         assert of == "https://pypi.org/pypi/pip/json"
@@ -519,6 +521,17 @@ def test_get_release_unsecure(mocker, caplog) -> None:
     assert url_o.call_count == 2
     assert "insecure" in caplog.text
     assert " failed " in caplog.text
+
+
+def test_get_release_verified_failure_does_not_fallback(mocker, monkeypatch) -> None:
+    monkeypatch.delenv("VIRTUALENV_PERIODIC_UPDATE_INSECURE", raising=False)
+    url_o = mocker.patch("virtualenv.seed.wheels.periodic_update.urlopen", side_effect=URLError("insecure"))
+
+    result = release_date_for_wheel_path(Path("pip-20.1.whl"))
+
+    assert result is None
+    assert url_o.call_count == 1
+    assert url_o.call_args.kwargs["context"] is None
 
 
 def test_get_release_fails(mocker, caplog) -> None:
@@ -564,7 +577,7 @@ def test_download_stop_with_embed(tmp_path, mocker, time_freeze) -> None:
     do_update("pip", "3.9", str(wheel.path), str(app_data_outer), [], True)
 
     assert download_wheel.call_count == 3
-    assert url_o.call_count == 2
+    assert url_o.call_count == 1
 
     assert read_dict.call_count == 1
     assert write.call_count == 1
@@ -587,7 +600,7 @@ def test_download_manual_stop_after_one_download(tmp_path, mocker, time_freeze) 
     do_update("pip", "3.9", str(wheel.path), str(app_data_outer), [], False)
 
     assert download_wheel.call_count == 1
-    assert url_o.call_count == 2
+    assert url_o.call_count == 1
     assert read_dict.call_count == 1
     assert write.call_count == 1
 
@@ -610,7 +623,7 @@ def test_download_manual_ignores_pre_release(tmp_path, mocker, time_freeze) -> N
     do_update("pip", "3.9", str(wheel.path), str(app_data_outer), [], False)
 
     assert download_wheel.call_count == 1
-    assert url_o.call_count == 2
+    assert url_o.call_count == 1
     assert read_dict.call_count == 1
     assert write.call_count == 1
     wrote_json = write.call_args[0][0]


### PR DESCRIPTION
Security hardening. When the verified HTTPS request to `https://pypi.org/pypi/<dist>/json` failed, the periodic update retried the request with an unverified SSL context and used whatever came back. The original comment justified this with 'the information we request is not sensitive', but the metadata drives the decision about which wheel version virtualenv considers 'up to date'. 🔒 A network-level attacker that can break the handshake can then pin virtualenv to an older seed wheel and silently suppress security updates.

The fallback is now skipped by default. A failed verified request logs the error and returns `None`, which the periodic update path already handles gracefully — no wheel bump happens and the run continues. Hosts with genuinely broken trust stores can opt back in by setting `VIRTUALENV_PERIODIC_UPDATE_INSECURE=1`, which is logged at WARNING so it shows up in CI output. The env var is documented in `docs/how-to/usage.rst` next to the existing override knobs.