### PR TITLE
fix(type): silence ty unresolved-attribute on default_source

### DIFF
--- a/src/virtualenv/config/cli/parser.py
+++ b/src/virtualenv/config/cli/parser.py
@@ -113,7 +113,7 @@ class VirtualEnvConfigParser(ArgumentParser):
                     if outcome is not None:
                         break
             if outcome is not None:
-                action.default, action.default_source = outcome
+                action.default, action.default_source = outcome  # ty: ignore[unresolved-attribute]
             else:
                 outcome = action.default, "default"
             self.options.set_src(action.dest, *outcome)


### PR DESCRIPTION
## Summary
- `ty` on `main` flags `action.default_source` in `parser.py:116` because `Action` has no such attribute statically; it is added at runtime.
- Add `# ty: ignore[unresolved-attribute]` to silence the diagnostic, matching the rest of the codebase's suppression style.

## Test plan
- [x] `tox run -e type` passes
- [x] `ruff format` / `ruff check` clean