### PR TITLE
🐛 fix(type): stop ty flagging default_source on Action

### DIFF
--- a/src/virtualenv/config/cli/parser.py
+++ b/src/virtualenv/config/cli/parser.py
@@ -113,7 +113,8 @@ class VirtualEnvConfigParser(ArgumentParser):
                     if outcome is not None:
                         break
             if outcome is not None:
-                action.default, action.default_source = outcome
+                action.default, default_source = outcome
+                vars(action)["default_source"] = default_source
             else:
                 outcome = action.default, "default"
             self.options.set_src(action.dest, *outcome)


### PR DESCRIPTION
Running `ty` on `main` fails with `unresolved-attribute` on `action.default_source` in `src/virtualenv/config/cli/parser.py`. The parser attaches `default_source` to `argparse.Action` instances at runtime so the help formatter can render where a default came from, and the tuple-unpacking assignment was making that implicit write look like a static attribute access to the checker.

The assignment is split so `action.default` keeps its regular attribute write, and the dynamic field is stored through `vars(action)`, which populates the instance `__dict__` directly. 🛠 `HelpFormatter._get_help_string` still finds `default_source` via its `%(default_source)s` interpolation because argparse resolves that format spec against `vars(action)`.

Behavior is unchanged; only the write path for the dynamic attribute differs, which lets the type checker pass without a suppression or `# ty: ignore` comment.