### PR TITLE
👷 ci: retry transient apt failures on Linux

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -113,12 +113,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ runner.os }}" = "Linux" ]; then
-            sudo apt-get install -y software-properties-common
-            sudo apt-add-repository ppa:fish-shell/release-4 -y
-            curl -fsSL https://apt.fury.io/nushell/gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/fury-nushell.gpg
+            retry() {
+              local n=1
+              while ! "$@"; do
+                if [ $n -ge 5 ]; then
+                  echo "Command failed after $n attempts: $*" >&2
+                  return 1
+                fi
+                echo "Attempt $n failed for: $*; retrying in 10s" >&2
+                n=$((n + 1))
+                sleep 10
+              done
+            }
+            retry sudo apt-get install -y software-properties-common
+            retry sudo apt-add-repository ppa:fish-shell/release-4 -y
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 https://apt.fury.io/nushell/gpg.key \
+              | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/fury-nushell.gpg
             echo "deb https://apt.fury.io/nushell/ /" | sudo tee /etc/apt/sources.list.d/fury.list
-            sudo apt-get update -y
-            sudo apt-get install snapd fish csh nushell -y
+            retry sudo apt-get update -y
+            retry sudo apt-get install snapd fish csh nushell -y
           elif [ "${{ runner.os }}" = "macOS" ]; then
             brew update
             if [[ "${{ matrix.py }}" == brew@* ]]; then


### PR DESCRIPTION
Linux test jobs have been failing in waves because `ppa.launchpadcontent.net` (the fish-shell PPA used by the `Install OS dependencies` step) intermittently refuses connections during `apt-get install`. When this happens, every Linux matrix entry across CPython 3.8–3.14, free-threaded variants, PyPy, and GraalPy turns red on PRs that touch nothing related to the failure, including the pre-commit autoupdate run on #3137.

Wrap `apt-get install`, `apt-add-repository`, and `apt-get update` in a small bash retry loop, and add `--retry`/`--retry-all-errors` to the `curl` call that fetches the nushell GPG key. Five attempts with a ten-second backoff is enough to absorb single-host blips without blocking forever when the upstream is genuinely down. macOS and Windows steps are untouched because their failures have not been the recurring source of flakes.