### PR TITLE
🐛 fix(upgrade): regen embedded init with correct MAX and 3.16

### DIFF
--- a/tasks/upgrade_wheels.py
+++ b/tasks/upgrade_wheels.py
@@ -18,7 +18,7 @@ from typing import NoReturn
 STRICT = "UPGRADE_ADVISORY" not in os.environ
 
 BUNDLED = ["pip", "setuptools", "wheel"]
-SUPPORT = [(3, i) for i in range(8, 16)]
+SUPPORT = [(3, i) for i in range(8, 17)]
 DEST = Path(__file__).resolve().parents[1] / "src" / "virtualenv" / "seed" / "wheels" / "embed"
 
 
@@ -125,7 +125,7 @@ def render_init(folders: dict[Path, str] | None = None) -> None:
 
     BUNDLE_FOLDER = Path(__file__).absolute().parent
     BUNDLE_SUPPORT = {{ {bundle} }}
-    MAX = {next(iter(support_table.keys()))!r}
+    MAX = next(reversed(BUNDLE_SUPPORT))
 
     # SHA-256 of every bundled wheel. Verified on load so a corrupted or tampered wheel on disk fails loud instead of
     # being handed to pip. Generated together with ``BUNDLE_SUPPORT`` by ``tasks/upgrade_wheels.py``.


### PR DESCRIPTION
The daily `Upgrade embedded dependencies` workflow keeps regenerating `src/virtualenv/seed/wheels/embed/__init__.py` with `MAX = "3.8"` and dropping the `3.16` entry — both of which had to be hand-patched in #3140 on top of the auto-PR. The script is the source of the regression, so patching the generated file alone leaves the next cron run free to undo the fix again. 🔁

The `MAX` substitution in `render_init` was reading the first key of the ordered support table, which is always the lowest Python version, so it baked `MAX = '3.8'` into the rendered module on every regen. Emit the runtime expression `next(reversed(BUNDLE_SUPPORT))` as literal text in the template instead, so the rendered module evaluates it at import time and always points at the highest supported version regardless of what the table contains.

The `SUPPORT` range stopped at `3.15`, which is why each regen also dropped the `3.16` entry. Extend the range through `3.16` so the generated table covers the versions we already ship wheels for.

No runtime behavior changes for users — this only affects what the regen task writes, so no changelog fragment is needed.