### PR TITLE
Accept GraalPy implementation name.

### DIFF
--- a/docs/changelog/3144.bugfix.rst
+++ b/docs/changelog/3144.bugfix.rst
@@ -1,0 +1,1 @@
+recognize GraalPy interpreters using the normalized ``GraalPy`` name - by :user:`timfel`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "filelock>=3.24.2,<4; python_version>='3.10'",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs>=3.9.1,<5",
-  "python-discovery>=1.2.2",
+  "python-discovery>=1.3.1",
   "typing-extensions>=4.13.2; python_version<'3.11'",
 ]
 urls.Documentation = "https://virtualenv.pypa.io"

--- a/src/virtualenv/create/via_global_ref/builtin/graalpy/__init__.py
+++ b/src/virtualenv/create/via_global_ref/builtin/graalpy/__init__.py
@@ -23,7 +23,7 @@ class GraalPy(ViaGlobalRefVirtualenvBuiltin, ABC):
 
     @classmethod
     def can_describe(cls, interpreter: PythonInfo) -> bool:
-        return interpreter.implementation == "GraalVM" and super().can_describe(interpreter)
+        return interpreter.implementation == "GraalPy" and super().can_describe(interpreter)
 
     @classmethod
     def exe_stem(cls) -> str:

--- a/tests/integration/test_zipapp.py
+++ b/tests/integration/test_zipapp.py
@@ -18,7 +18,7 @@ CURRENT = PythonInfo.current_system()
 @pytest.fixture(scope="session")
 def zipapp_build_env(tmp_path_factory):
     create_env_path = None
-    if CURRENT.implementation not in {"PyPy", "GraalVM"}:
+    if CURRENT.implementation not in {"PyPy", "GraalPy"}:
         exe = CURRENT.executable  # guaranteed to contain a recent enough pip (tox.ini)
     else:
         create_env_path = tmp_path_factory.mktemp("zipapp-create-env")


### PR DESCRIPTION
With the latest python-discover release, GraalPy names are normalized to GraalPy, instead of GraalVM, so virtualenv needs to be adapted.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder 
- [x] updated/extended the documentation (not needed)
