### PR TITLE
Fix Mermaid flowchart rendering

### DIFF
--- a/docs/_static/mermaid-normalize.js
+++ b/docs/_static/mermaid-normalize.js
@@ -1,0 +1,29 @@
+(function () {
+  function dedent(text) {
+    const lines = text.replace(/\s+$/u, "").split("\n");
+    const indents = lines
+      .filter((line) => line.trim())
+      .map((line) => line.match(/^\s*/u)[0].length);
+
+    if (!indents.length) {
+      return text;
+    }
+
+    const indent = Math.min(...indents);
+    return lines.map((line) => line.slice(indent)).join("\n");
+  }
+
+  function normalizeMermaidBlocks() {
+    document.querySelectorAll("pre.mermaid").forEach((block) => {
+      block.textContent = dedent(block.textContent);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", normalizeMermaidBlocks, {
+      once: true,
+    });
+  } else {
+    normalizeMermaidBlocks();
+  }
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ html_title, html_last_updated_fmt = project, datetime.now(tz=timezone.utc).isofo
 pygments_style, pygments_dark_style = "sphinx", "monokai"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
-html_js_files = ["rtd-search.js"]
+html_js_files = ["mermaid-normalize.js", "rtd-search.js"]
 html_favicon = "_static/virtualenv.svg"
 html_theme_options = {
     "light_logo": "virtualenv.png",


### PR DESCRIPTION
Normalizes Mermaid block indentation before the existing renderer runs, so the explanation flowcharts render instead of staying as code blocks.\n\nCloses #3146.\n\nChecks:\n- pre-commit run prettier --files docs/_static/mermaid-normalize.js docs/conf.py\n- pre-commit run ruff-format --files docs/conf.py\n- pre-commit run ruff --files docs/conf.py\n- pre-commit run end-of-file-fixer --files docs/conf.py docs/_static/mermaid-normalize.js\n- pre-commit run trailing-whitespace --files docs/conf.py docs/_static/mermaid-normalize.js\n- sphinx-build -d <tmp>/doctrees docs <tmp>/html --color -b html -W\n- Chrome headless check against the built explanation page