### PR TITLE
♻️ refactor(create): remove dead code and document droppable paths

### DIFF
--- a/docs/changelog/3149.feature.rst
+++ b/docs/changelog/3149.feature.rst
@@ -1,0 +1,2 @@
+Remove dead code targeting Python versions below the supported target range (PyPy 3.6, deprecated
+importlib APIs) and simplify the runtime import hook in ``_virtualenv.py`` - by :user:`gaborbernat`.

--- a/docs/changelog/3149.feature.rst
+++ b/docs/changelog/3149.feature.rst
@@ -1,2 +1,2 @@
-Remove dead code targeting Python versions below the supported target range (PyPy 3.6, deprecated
-importlib APIs) and simplify the runtime import hook in ``_virtualenv.py`` - by :user:`gaborbernat`.
+Remove dead code targeting Python versions below the supported target range (PyPy 3.6, deprecated importlib APIs) and
+simplify the runtime import hook in ``_virtualenv.py`` - by :user:`gaborbernat`.

--- a/src/virtualenv/create/debug.py
+++ b/src/virtualenv/create/debug.py
@@ -19,22 +19,15 @@ def encode_list_path(value: list[object]) -> list[str | None]:
     return [encode_path(i) for i in value]
 
 
-def run() -> None:  # noqa: C901,PLR0915
+def run() -> None:
     """Print debug data about the virtual environment."""
-    try:
-        from collections import OrderedDict  # noqa: PLC0415
-
-        DictType = OrderedDict  # noqa: N806
-    except ImportError:  # pragma: no cover
-        DictType = dict  # pragma: no cover  # noqa: N806
-    sys_info: dict[str, str | list[str | None] | None] = DictType()
-    result: dict[str, str | dict[str, str | list[str | None] | None] | None] = DictType([("sys", sys_info)])
+    sys_info: dict[str, str | list[str | None] | None] = {}
+    result: dict[str, str | dict[str, str | list[str | None] | None] | None] = {"sys": sys_info}
     path_keys = (
         "executable",
         "_base_executable",
         "prefix",
         "base_prefix",
-        "real_prefix",
         "exec_prefix",
         "base_exec_prefix",
         "path",
@@ -51,10 +44,7 @@ def run() -> None:  # noqa: C901,PLR0915
     try:
         import sysconfig  # noqa: PLC0415
 
-        # https://bugs.python.org/issue22199
-        makefile = getattr(sysconfig, "get_makefile_filename", getattr(sysconfig, "_get_makefile_filename", None))
-        if makefile is not None:
-            result["makefile_filename"] = encode_path(makefile())
+        result["makefile_filename"] = encode_path(sysconfig.get_makefile_filename())
     except ImportError:
         pass
 

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -91,16 +91,12 @@ class _Finder:
         return None
 
     def _patch_spec(self, spec: ModuleSpec, partial: Callable[..., object]) -> ModuleSpec:
-        # https://www.python.org/dev/peps/pep-0451/#how-loading-will-work
-        is_new_api = hasattr(spec.loader, "exec_module")
-        func_name = "exec_module" if is_new_api else "load_module"
-        old = getattr(spec.loader, func_name)
-        func = self.exec_module if is_new_api else self.load_module
-        if old is not func:
+        old = getattr(spec.loader, "exec_module", None)
+        if old is not None and old is not self.exec_module:
             try:  # noqa: SIM105
-                setattr(spec.loader, func_name, partial(func, old))
+                setattr(spec.loader, "exec_module", partial(self.exec_module, old))  # ty: ignore[invalid-assignment]
             except AttributeError:
-                pass  # C-Extension loaders are r/o such as zipimporter with <3.7
+                pass
         return spec
 
     @staticmethod
@@ -111,22 +107,8 @@ class _Finder:
         except NameError:
             return
         if module.__name__ in distutils_patch:
-            # patch_dist or its dependencies may not be defined during file rewrite
             with contextlib.suppress(NameError):
                 patch_dist(module)
-
-    @staticmethod
-    def load_module(old: Callable[..., types.ModuleType], name: str) -> types.ModuleType:
-        module = old(name)
-        try:
-            distutils_patch = _DISTUTILS_PATCH
-        except NameError:
-            return module
-        if module.__name__ in distutils_patch:
-            # patch_dist or its dependencies may not be defined during file rewrite
-            with contextlib.suppress(NameError):
-                patch_dist(module)
-        return module
 
 
 sys.meta_path.insert(0, _Finder())

--- a/src/virtualenv/create/via_global_ref/_virtualenv.py
+++ b/src/virtualenv/create/via_global_ref/_virtualenv.py
@@ -94,7 +94,7 @@ class _Finder:
         old = getattr(spec.loader, "exec_module", None)
         if old is not None and old is not self.exec_module:
             try:  # noqa: SIM105
-                setattr(spec.loader, "exec_module", partial(self.exec_module, old))  # ty: ignore[invalid-assignment]
+                spec.loader.exec_module = partial(self.exec_module, old)  # ty: ignore[invalid-assignment]
             except AttributeError:
                 pass
         return spec

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
@@ -83,7 +83,7 @@ class CPython3Posix(CPythonPosix, CPython3):
         return text
 
     @classmethod
-    def pyvenv_launch_patch_active(cls, interpreter: PythonInfo) -> bool:
+    def pyvenv_launch_patch_active(cls, interpreter: PythonInfo) -> bool:  # drop when Python 3.8 support is dropped
         ver = interpreter.version_info
         return interpreter.platform == "darwin" and ((3, 7, 8) > ver >= (3, 7) or (3, 8, 3) > ver >= (3, 8))
 

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py
@@ -66,10 +66,6 @@ class PyPy3Posix(PyPy3, PosixSupports):
 class Pypy3Windows(PyPy3, WindowsSupports):
     """PyPy 3 on Windows."""
 
-    @property
-    def less_v37(self) -> bool:
-        return self.interpreter.version_info.minor < 7  # noqa: PLR2004
-
     @classmethod
     def _shared_libs(cls, python_dir: Path) -> Iterator[Path]:
         # PyPy does not use a PEP 397 launcher, so all DLLs from the interpreter directory are needed for the venv

--- a/src/virtualenv/create/via_global_ref/venv.py
+++ b/src/virtualenv/create/via_global_ref/venv.py
@@ -14,7 +14,6 @@ from virtualenv.util.subprocess import run_cmd
 from .api import ViaGlobalRefApi, ViaGlobalRefMeta
 from .builtin.cpython.common import is_mac_os_framework
 from .builtin.cpython.mac_os import CPython3macOsBrew
-from .builtin.pypy.pypy3 import Pypy3Windows
 
 if TYPE_CHECKING:
     from typing import Any
@@ -58,14 +57,6 @@ class Venv(ViaGlobalRefApi):
         if self.describe is not None:
             self.describe.install_venv_shared_libs(self)
         super().create()
-        self.executables_for_win_pypy_less_v37()
-
-    def executables_for_win_pypy_less_v37(self) -> None:
-        """PyPy <= 3.6 (v7.3.3) for Windows contains only pypy3.exe and pypy3w.exe Venv does not handle non-existing exe sources, e.g. python.exe, so this patch does it."""
-        creator = self.describe
-        if isinstance(creator, Pypy3Windows) and creator.less_v37:
-            for exe in creator.executables(self.interpreter):
-                exe.run(creator, self.symlinks)
 
     def create_inline(self) -> None:
         from venv import EnvBuilder  # noqa: PLC0415

--- a/src/virtualenv/run/plugin/base.py
+++ b/src/virtualenv/run/plugin/base.py
@@ -12,8 +12,6 @@ if TYPE_CHECKING:
 
     from virtualenv.config.cli.parser import VirtualEnvConfigParser, VirtualEnvOptions
 
-importlib_metadata_version = ()
-
 
 class PluginLoader:
     _OPTIONS = None
@@ -21,7 +19,7 @@ class PluginLoader:
 
     @classmethod
     def entry_points_for(cls, key: str) -> OrderedDict[str, type]:
-        if sys.version_info >= (3, 10) or importlib_metadata_version >= (3, 6):
+        if sys.version_info >= (3, 10):
             selected = list(cls.entry_points().select(group=key))  # ty: ignore[unresolved-attribute]
         else:
             selected = list(cls.entry_points().get(key, []))  # ty: ignore[unresolved-attribute]

--- a/tests/unit/create/via_global_ref/_test_race_condition_helper.py
+++ b/tests/unit/create/via_global_ref/_test_race_condition_helper.py
@@ -27,16 +27,5 @@ class _Finder:
         if module.__name__ in distutils_patch:
             pass  # Would call patch_dist(module)
 
-    @staticmethod
-    def load_module(old, name):
-        module = old(name)
-        try:
-            distutils_patch = _DISTUTILS_PATCH
-        except NameError:
-            return module
-        if module.__name__ in distutils_patch:
-            pass  # Would call patch_dist(module)
-        return module
-
 
 finder = _Finder()

--- a/tests/unit/create/via_global_ref/test_race_condition.py
+++ b/tests/unit/create/via_global_ref/test_race_condition.py
@@ -20,12 +20,6 @@ def _test_finder_behavior() -> None:
 
     finder.exec_module(mock_old_exec, MockModule())
 
-    def mock_old_load(_name):
-        return MockModule()
-
-    result = finder.load_module(mock_old_load, "distutils.dist")
-    assert result.__name__ == "distutils.dist"
-
 
 def test_virtualenv_py_race_condition_find_spec(tmp_path) -> None:
     """Test that _Finder.find_spec handles NameError gracefully when _DISTUTILS_PATCH is not defined."""


### PR DESCRIPTION
Several code paths can never execute given the project's supported target range (BUNDLE_SUPPORT starts at 3.8, bundled pip/setuptools require >= 3.8). This removes them and adds a drop-when comment to one remaining path that targets EOL micro-versions still technically within range.

`executables_for_win_pypy_less_v37` and `less_v37` targeted PyPy 3.6 on Windows, which is below the BUNDLE_SUPPORT minimum — a venv created for that target would get non-functional seed packages anyway. The `load_module` fallback in `_virtualenv.py` handled loaders without `exec_module`, but `distutils.dist` and `setuptools.dist` always use standard SourceFileLoader on Python 3.8+ which has had `exec_module` since Python 3.4. In `debug.py`, the `OrderedDict` import fallback guarded against an `ImportError` impossible since Python 2.7, the `_get_makefile_filename` fallback targeted a private API that's been public since 3.2, and probing `sys.real_prefix` checked an attribute only set by virtualenv 1.x (no modern Python sets it). The `importlib_metadata_version` variable in `plugin/base.py` was hardcoded to `()` and never populated.

`pyvenv_launch_patch_active` targets CPython 3.8.0-3.8.2 on macOS — still within the "3.8" BUNDLE_SUPPORT entry so kept with a drop-when comment for the eventual 3.8 removal.