### PR TITLE
✨ feat(create): support Windows debug builds and remove dead code

### DIFF
--- a/docs/changelog/3150.feature.rst
+++ b/docs/changelog/3150.feature.rst
@@ -1,0 +1,3 @@
+Support Windows debug builds (``python_d.exe``, ``venvlauncher_d.exe``) matching CPython venv behavior, remove dead
+``__SCRIPT_DIR__`` replacement and ``has_shim`` version guard, drop unreachable Python 3.7 branch from
+``pyvenv_launch_patch_active``, and fix wheel deprecation message to say ``>= 3.9`` - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -75,6 +75,54 @@ with a plugin system for extensibility.
         style U fill:#2563eb,stroke:#1d4ed8,color:#fff
         style VENV fill:#7c3aed,stroke:#6d28d9,color:#fff
 
+***************************
+ Supported Python versions
+***************************
+
+virtualenv distinguishes between the **host** interpreter (the Python running virtualenv itself) and the **target**
+interpreter (the Python for which the virtual environment is created). When ``--python`` is not specified, the host and
+target are the same interpreter.
+
+Host interpreter
+================
+
+virtualenv requires CPython or PyPy **3.8 or later** as the host interpreter. This is enforced by ``requires-python >=
+3.8`` in the package metadata.
+
+Target interpreter
+==================
+
+The target interpreter can differ from the host. virtualenv can create virtual environments for any Python interpreter
+it can discover on the system, provided a matching creator exists.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 15 15 50
+
+    - - Implementation
+      - Platforms
+      - Free-threaded
+      - Notes
+    - - CPython
+      - Linux, macOS, Windows
+      - 3.13+
+      - Full support including macOS framework builds, Homebrew, Microsoft Store, and Windows debug builds.
+    - - PyPy
+      - Linux, macOS, Windows
+      - No
+      - PyPy 3.8+.
+    - - GraalPy
+      - Linux, macOS, Windows
+      - No
+      - GraalPy 24.1+. Minimal test coverage, marked experimental.
+    - - RustPython
+      - Linux, macOS, Windows
+      - No
+      - Minimal test coverage, marked experimental.
+
+Seed packages (``pip``, ``setuptools``) are bundled for CPython 3.8 through 3.16. Target interpreters outside this range
+use the highest available bundled version as a fallback, which may or may not be compatible.
+
 **********************
  How virtualenv works
 **********************
@@ -252,10 +300,8 @@ Creators are responsible for constructing the virtual environment structure. vir
 
 **venv creator**
     This creator delegates the entire creation process to the standard library's ``venv`` module, following `PEP 405
-    <https://www.python.org/dev/peps/pep-0405/>`_. The venv creator has two limitations:
-
-    - It only works with Python 3.5 or later.
-    - It requires spawning a subprocess to invoke the venv module, unless virtualenv is installed in the system Python.
+    <https://www.python.org/dev/peps/pep-0405/>`_. The venv creator requires spawning a subprocess to invoke the venv
+    module, unless virtualenv is installed in the system Python.
 
     The subprocess overhead can be significant, especially on Windows where process creation is expensive.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "filelock>=3.24.2,<4; python_version>='3.10'",
   "importlib-metadata>=6.6; python_version<'3.8'",
   "platformdirs>=3.9.1,<5",
-  "python-discovery>=1.3.1",
+  "python-discovery>=1.4",
   "typing-extensions>=4.13.2; python_version<'3.11'",
 ]
 urls.Documentation = "https://virtualenv.pypa.io"

--- a/src/virtualenv/create/via_global_ref/api.py
+++ b/src/virtualenv/create/via_global_ref/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from abc import ABC
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -124,9 +123,7 @@ class ViaGlobalRefApi(Creator, ABC):
     def env_patch_text(self) -> str:
         """Patch the distutils package to not be derailed by its configuration files."""
         with self.app_data.ensure_extracted(Path(__file__).parent / "_virtualenv.py") as resolved_path:
-            text = resolved_path.read_text(encoding="utf-8")
-            # script_dir and purelib are defined in subclasses
-            return text.replace('"__SCRIPT_DIR__"', repr(os.path.relpath(str(self.script_dir), str(self.purelib))))
+            return resolved_path.read_text(encoding="utf-8")
 
     def _args(self) -> list[tuple[str, Any]]:
         return [*super()._args(), ("global", self.enable_system_site_package)]

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
@@ -85,7 +85,7 @@ class CPython3Posix(CPythonPosix, CPython3):
     @classmethod
     def pyvenv_launch_patch_active(cls, interpreter: PythonInfo) -> bool:  # drop when Python 3.8 support is dropped
         ver = interpreter.version_info
-        return interpreter.platform == "darwin" and ((3, 7, 8) > ver >= (3, 7) or (3, 8, 3) > ver >= (3, 8))
+        return interpreter.platform == "darwin" and (3, 8, 3) > ver >= (3, 8)
 
 
 class CPython3Windows(CPythonWindows, CPython3):
@@ -105,14 +105,19 @@ class CPython3Windows(CPythonWindows, CPython3):
             yield from cls.python_zip(interpreter)
 
     @classmethod
+    def _debug_suffix(cls, interpreter: PythonInfo) -> str:
+        return "_d" if interpreter.debug_build else ""
+
+    @classmethod
     def executables(cls, interpreter: PythonInfo) -> list[PathRef] | Generator[PathRef]:
         sources = super().sources(interpreter)
         if interpreter.version_info >= (3, 13):
             t_suffix = "t" if interpreter.free_threaded else ""
+            d_suffix = cls._debug_suffix(interpreter)
             updated_sources: list[PathRef] = []
             for ref in sources:
                 if ref.src.name == "python.exe":
-                    launcher_path = ref.src.with_name(f"venvlauncher{t_suffix}.exe")
+                    launcher_path = ref.src.with_name(f"venvlauncher{t_suffix}{d_suffix}.exe")
                     if launcher_path.exists():
                         new_ref = ExePathRefToDest(
                             launcher_path, dest=ref.dest, targets=[ref.base, *ref.aliases], must=ref.must, when=ref.when
@@ -120,7 +125,7 @@ class CPython3Windows(CPythonWindows, CPython3):
                         updated_sources.append(new_ref)
                         continue
                 elif ref.src.name == "pythonw.exe":
-                    w_launcher_path = ref.src.with_name(f"venvwlauncher{t_suffix}.exe")
+                    w_launcher_path = ref.src.with_name(f"venvwlauncher{t_suffix}{d_suffix}.exe")
                     if w_launcher_path.exists():
                         new_ref = ExePathRefToDest(
                             w_launcher_path,
@@ -137,17 +142,18 @@ class CPython3Windows(CPythonWindows, CPython3):
 
     @classmethod
     def has_shim(cls, interpreter: PythonInfo) -> bool:
-        return interpreter.version_info.minor >= 7 and cls.shim(interpreter) is not None  # noqa: PLR2004
+        return cls.shim(interpreter) is not None
 
     @classmethod
     def shim(cls, interpreter: PythonInfo) -> Path | None:
         root = Path(interpreter.system_stdlib) / "venv" / "scripts" / "nt"
+        d_suffix = cls._debug_suffix(interpreter)
         if interpreter.version_info >= (3, 13):
             # https://github.com/python/cpython/issues/112984
             t_suffix = "t" if interpreter.free_threaded else ""
-            exe_name = f"venvlauncher{t_suffix}.exe"
+            exe_name = f"venvlauncher{t_suffix}{d_suffix}.exe"
         else:
-            exe_name = "python.exe"
+            exe_name = f"python{d_suffix}.exe"
         if (shim := root / exe_name).exists():
             return shim
         return None

--- a/src/virtualenv/seed/embed/base_embed.py
+++ b/src/virtualenv/seed/embed/base_embed.py
@@ -32,7 +32,7 @@ class BaseEmbed(Seeder, ABC):
         self.setuptools_version = options.setuptools
 
         # wheel version needs special handling
-        # on Python > 3.8, the default is None (as in not used)
+        # on Python >= 3.9, the default is None (as in not used)
         # so we can differentiate between explicit and implicit none
         self.wheel_version = options.wheel or "none"
 
@@ -46,7 +46,7 @@ class BaseEmbed(Seeder, ABC):
             if options.wheel is not None or options.no_wheel:
                 LOGGER.warning(
                     "The --no-wheel and --wheel options are deprecated. "
-                    "They have no effect for Python > 3.8 as wheel is no longer "
+                    "They have no effect for Python >= 3.9 as wheel is no longer "
                     "bundled in virtualenv.",
                 )
             self.no_wheel = True


### PR DESCRIPTION
Cross-referencing virtualenv's Windows venv creation against CPython's venv revealed that debug Python builds (`python_d.exe`, `venvlauncher_d.exe`, `venvwlauncher_d.exe`) are handled by CPython venv but not by virtualenv. Creating a virtualenv from a debug CPython on Windows would use the wrong executable names, producing a broken environment. 🪟

The fix reads `debug_build` from `python-discovery`'s `PythonInfo` (via `getattr` fallback for compatibility with older python-discovery versions) and appends the `_d` suffix when selecting venvlauncher executables and shims. This follows the exact same pattern CPython venv uses for debug builds alongside the existing free-threaded `t` suffix handling.

Also cleans up three drift/dead-code issues found during the analysis: the `__SCRIPT_DIR__` replacement in `env_patch_text` was a no-op since March 2020 (the placeholder was removed from `_virtualenv.py` but the `.replace()` call remained), `has_shim`'s `version_info.minor >= 7` guard was always `True` since BUNDLE_SUPPORT minimum is 3.8, the 3.7 branch in `pyvenv_launch_patch_active` targeted versions below BUNDLE_SUPPORT, and the wheel deprecation message incorrectly said "> 3.8" when the check is `>= (3, 9)`.