### PR TITLE
🐛 fix(activation): silence deactivate hash -r under set -e

### DIFF
--- a/docs/changelog/3152.bugfix.rst
+++ b/docs/changelog/3152.bugfix.rst
@@ -1,3 +1,3 @@
-Stop ``deactivate`` in the bash/zsh activation script from aborting under ``set -e`` when ``hash -r`` fails (for
-example with shell hashing disabled) by appending ``|| true``, matching CPython ``venv`` (gh-149701) and the existing
+Stop ``deactivate`` in the bash/zsh activation script from aborting under ``set -e`` when ``hash -r`` fails (for example
+with shell hashing disabled) by appending ``|| true``, matching CPython ``venv`` (gh-149701) and the existing
 non-deactivate call - by :user:`gaborbernat`.

--- a/docs/changelog/3152.bugfix.rst
+++ b/docs/changelog/3152.bugfix.rst
@@ -1,0 +1,3 @@
+Stop ``deactivate`` in the bash/zsh activation script from aborting under ``set -e`` when ``hash -r`` fails (for
+example with shell hashing disabled) by appending ``|| true``, matching CPython ``venv`` (gh-149701) and the existing
+non-deactivate call - by :user:`gaborbernat`.

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -41,7 +41,7 @@ deactivate () {
     # The hash command must be called to get it to forget past
     # commands. Without forgetting past commands the $PATH changes
     # we made may not be respected
-    hash -r 2>/dev/null
+    hash -r 2>/dev/null || true
 
     if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
         PS1="$_OLD_VIRTUAL_PS1"


### PR DESCRIPTION
Sourcing the bash/zsh activation script and later running `deactivate` could abort the shell when strict mode is on. 🐚 Under `set -euo pipefail` with shell command hashing disabled (`set +h`), the `hash -r` call inside `deactivate()` returns non-zero, and `2>/dev/null` only hides its stderr, not its exit status, so the failing command tears down the session.

The `deactivate()` call now appends `|| true`, the same guard the trailing activation-time `hash -r` already carried. This brings the two `hash -r` sites into line and mirrors the equivalent CPython `venv` change in gh-149701.

The fix is confined to the bash/zsh activator; behavior under non-strict shells is unchanged since `hash -r` already succeeded there.