### PR TITLE
Stop exporting PS1 in bash activator

### DIFF
--- a/docs/changelog/3158.bugfix.rst
+++ b/docs/changelog/3158.bugfix.rst
@@ -1,0 +1,1 @@
+Stop exporting ``PS1`` from the bash activator so child processes do not inherit shell prompt state.

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -45,7 +45,6 @@ deactivate () {
 
     if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
         PS1="$_OLD_VIRTUAL_PS1"
-        export PS1
         unset _OLD_VIRTUAL_PS1
     fi
 
@@ -116,7 +115,6 @@ fi
 if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1-}"
     PS1="(${VIRTUAL_ENV_PROMPT}) ${PS1-}"
-    export PS1
 fi
 
 # Make sure to unalias pydoc if it's already there

--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
+import sys
 from argparse import Namespace
 
 import pytest
@@ -102,6 +104,34 @@ def test_bash_activate_relocation_resolves_virtual_env(tmp_path, current_fastest
 
 
 @pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
+def test_bash_activate_does_not_export_ps1(tmp_path, current_fastest) -> None:
+    dest = tmp_path / "env"
+    cli_run([
+        "--without-pip",
+        str(dest),
+        "--creator",
+        current_fastest,
+        "--no-periodic-update",
+        "--activators",
+        "bash",
+    ])
+    activate_script = dest / "bin" / "activate"
+    print_ps1 = f"{shlex.quote(sys.executable)} -c 'import os; print(os.environ.get(\"PS1\"))'"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            (f"unset PS1; PS1='base$ '; source \"{activate_script}\" && {print_ps1} && deactivate && {print_ps1}"),
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["None", "None"]
+
+
+@pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
 @pytest.mark.parametrize("hashing_enabled", [True, False])
 def test_bash(raise_on_non_source_class, hashing_enabled, activation_tester) -> None:
     class Bash(raise_on_non_source_class):
@@ -121,6 +151,6 @@ def test_bash(raise_on_non_source_class, hashing_enabled, activation_tester) -> 
             return super().activate_call(script) + " || exit 1"
 
         def print_prompt(self):
-            return self.print_os_env_var("PS1")
+            return 'printf "%s\\n" "$PS1"'
 
     activation_tester(Bash)


### PR DESCRIPTION
Closes #3158.

`PS1` is shell-local prompt state. The bash activator now updates it without exporting it, so child processes do not inherit prompt text during activation or after deactivation.

Tests:
- `.tox/3.14/bin/python -m pytest tests/unit/activation/test_bash.py -q`