### PR TITLE
Set git identity in upgrade changelog rename step

### DIFF
--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -87,6 +87,8 @@ jobs:
         if: steps.cpr.outputs.pull-request-number
         run: |
           pr_number="${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin auto/upgrade-embedded-deps
           git checkout auto/upgrade-embedded-deps
           mv docs/changelog/u.bugfix.rst "docs/changelog/${pr_number}.bugfix.rst"


### PR DESCRIPTION
The scheduled `Upgrade embedded dependencies` workflow failed in its "Rename changelog with PR number" step with:

```
fatal: empty ident name (for <runner@...>) not allowed
```

The `peter-evans/create-pull-request` action configures its own committer identity, but the follow-up step runs a bare `git commit` with no identity set on the runner, so it exits 128 (see [run 27464646715](https://github.com/pypa/virtualenv/actions/runs/27464646715)).

Configure the `github-actions[bot]` identity (the same one `create-pull-request` uses) before committing the renamed changelog fragment.