### PR TITLE
🐛 fix(seed): sync wheel regen script with seeder guard

### DIFF
--- a/tasks/upgrade_wheels.py
+++ b/tasks/upgrade_wheels.py
@@ -124,6 +124,15 @@ def render_init(folders: dict[Path, str] | None = None) -> None:
     BUNDLE_FOLDER = Path(__file__).absolute().parent
     BUNDLE_SUPPORT = {{ {bundle} }}
     MAX = next(reversed(BUNDLE_SUPPORT))
+    MIN = next(iter(BUNDLE_SUPPORT))
+
+
+    def _release_tuple(version: str) -> tuple[int, ...]:
+        return tuple(int(part) for part in version.split("."))
+
+
+    # oldest target Python version virtualenv still bundles seed wheels for; anything below this has no embedded pip
+    OLDEST_SUPPORTED = _release_tuple(MIN)
 
     # SHA-256 of every bundled wheel. Verified on load so a corrupted or tampered wheel on disk fails loud instead of
     # being handed to pip. Generated together with ``BUNDLE_SUPPORT`` by ``tasks/upgrade_wheels.py``.
@@ -132,19 +141,26 @@ def render_init(folders: dict[Path, str] | None = None) -> None:
     _VERIFIED_WHEELS: set[str] = set()
 
 
-    def get_embed_wheel(distribution: str, for_py_version: str) -> Wheel | None:
+    def get_embed_wheel(distribution: str, for_py_version: str | None) -> Wheel | None:
         \"\"\"Return the bundled wheel that ships with virtualenv for a given distribution and Python version.
 
         :param distribution: project name of the seed package, for example ``pip`` or ``setuptools``.
-        :param for_py_version: major.minor Python version string the environment will be created for.
+        :param for_py_version: major.minor Python version string the environment will be created for, or ``None`` to use the
+            newest bundle.
 
         :returns: a :class:`Wheel` pointing at the verified bundled file, or ``None`` when no wheel is bundled for the
-            requested combination.
+            requested combination, including target versions below the oldest bundled one.
 
         :raises RuntimeError: if the bundled wheel on disk fails SHA-256 verification.
 
         \"\"\"
-        mapping = BUNDLE_SUPPORT.get(for_py_version, {{}}) or BUNDLE_SUPPORT[MAX]
+        if for_py_version is None or _release_tuple(for_py_version) > _release_tuple(MAX):
+            # no specific target, or a Python newer than anything bundled: reuse the newest bundle
+            mapping = BUNDLE_SUPPORT[MAX]
+        else:  # versions below the oldest bundled one fall through to None instead of an incompatible newer wheel
+            mapping = BUNDLE_SUPPORT.get(for_py_version)
+        if not mapping:
+            return None
         wheel_file = mapping.get(distribution)
         if wheel_file is None:
             return None
@@ -189,6 +205,8 @@ def render_init(folders: dict[Path, str] | None = None) -> None:
         "BUNDLE_SHA256",
         "BUNDLE_SUPPORT",
         "MAX",
+        "MIN",
+        "OLDEST_SUPPORTED",
         "get_embed_wheel",
     ]
 


### PR DESCRIPTION
The unsupported-target refusal in `#3173` taught the bundled seeder to decline Pythons below the oldest bundle, and that policy lives in `src/virtualenv/seed/wheels/embed/__init__.py` through `MIN`, `OLDEST_SUPPORTED`, the `_release_tuple` helper, and a `get_embed_wheel` that returns `None` instead of substituting the newest wheel. 🐛 That module is generated, though: `tasks/upgrade_wheels.py` rewrites it from a template on every wheel bump, and the template still emitted the old `get_embed_wheel`. The next routine wheel upgrade would have regenerated the file and silently reverted the guard, letting virtualenv seed dropped Python versions again.

This brings the `render_init` template in line with the committed module, so `MIN`, `OLDEST_SUPPORTED`, `_release_tuple`, and the below-oldest fallback removal survive regeneration. ✨ Running `tasks/upgrade_wheels.py --regen` now reproduces the current `__init__.py` byte-for-byte.

Reviewers can confirm by running `python tasks/upgrade_wheels.py --regen` against a clean tree and checking that `src/virtualenv/seed/wheels/embed/__init__.py` is unchanged.