### PR TITLE
fix(upgrade): emit dash bullets in changelog

### DIFF
--- a/tasks/upgrade_wheels.py
+++ b/tasks/upgrade_wheels.py
@@ -69,7 +69,7 @@ def _sync_dest(new_packages: set[str], remove_packages: set[str], new_batch: dic
 def _write_changelog(added: dict[str, list[str]], removed: dict[str, list[str]]) -> None:
     lines = ["Upgrade embedded wheels:", ""]
     for key, versions in added.items():
-        text = f"* {key} to {fmt_version(versions)}"
+        text = f"- {key} to {fmt_version(versions)}"
         if key in removed:
             rem = ", ".join(f"``{i}``" for i in removed[key])
             text += f" from {rem}"


### PR DESCRIPTION
`_write_changelog` in `tasks/upgrade_wheels.py` rendered upgrade list items with `*`, but the repo's `docstrfmt` pre-commit hook normalizes bullet lists to `-`. Every auto-generated upgrade PR failed docstrfmt until the bullet was fixed by hand (e.g. #3180).

Emit `-` so the generated fragment is clean on the first try.

Task-script-only change, so no changelog fragment (matches #3143).