### PR TITLE
✨ feat(create): skip distutils hook on Python 3.10+

### DIFF
--- a/docs/changelog/3181.feature.rst
+++ b/docs/changelog/3181.feature.rst
@@ -1,0 +1,3 @@
+Stop installing the ``_virtualenv.{py,pth}`` distutils import hook for Python 3.10 and later, where pip,
+setuptools and CPython already ignore the install config keys it guards against; this removes the hook's startup
+import cost. The hook is still installed for Python 3.9 - :issue:`3181`.

--- a/docs/changelog/3181.feature.rst
+++ b/docs/changelog/3181.feature.rst
@@ -1,3 +1,3 @@
-Stop installing the ``_virtualenv.{py,pth}`` distutils import hook for Python 3.10 and later, where pip,
-setuptools and CPython already ignore the install config keys it guards against; this removes the hook's startup
-import cost. The hook is still installed for Python 3.9 - :issue:`3181`.
+Stop installing the ``_virtualenv.{py,pth}`` distutils import hook for Python 3.10 and later, where pip, setuptools and
+CPython already ignore the install config keys it guards against; this removes the hook's startup import cost. The hook
+is still installed for Python 3.9 - :issue:`3181`.

--- a/src/virtualenv/create/via_global_ref/api.py
+++ b/src/virtualenv/create/via_global_ref/api.py
@@ -111,6 +111,11 @@ class ViaGlobalRefApi(Creator, ABC):
         self.install_patch()
 
     def install_patch(self) -> None:
+        # Python 3.10+ ignores the distutils install config keys this patch guards against (pip does so by default,
+        # setuptools and CPython's vendored distutils drop them too), so the runtime import hook only earns its
+        # startup cost on 3.9. See https://github.com/pypa/virtualenv/issues/3181.
+        if self.interpreter.version_info >= (3, 10):
+            return
         text = self.env_patch_text()
         if text:
             pth = self.purelib / "_virtualenv.pth"

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -496,6 +496,23 @@ def test_create_distutils_cfg(creator, tmp_path, monkeypatch) -> None:
     assert package_folder.exists(), list_files(str(tmp_path))
 
 
+def test_install_patch_skipped_on_py310(tmp_path, mocker) -> None:
+    creator = mocker.MagicMock(purelib=tmp_path, interpreter=mocker.MagicMock(version_info=(3, 10, 0)))
+    creator.env_patch_text.return_value = "import _virtualenv"
+    api.ViaGlobalRefApi.install_patch(creator)
+    assert not (tmp_path / "_virtualenv.pth").exists()
+    assert not (tmp_path / "_virtualenv.py").exists()
+    creator.env_patch_text.assert_not_called()
+
+
+def test_install_patch_written_on_py39(tmp_path, mocker) -> None:
+    creator = mocker.MagicMock(purelib=tmp_path, interpreter=mocker.MagicMock(version_info=(3, 9, 21)))
+    creator.env_patch_text.return_value = "import _virtualenv"
+    api.ViaGlobalRefApi.install_patch(creator)
+    assert (tmp_path / "_virtualenv.pth").read_text(encoding="utf-8") == "import _virtualenv"
+    assert (tmp_path / "_virtualenv.py").read_text(encoding="utf-8") == "import _virtualenv"
+
+
 def list_files(path):
     result = ""
     for root, _, files in os.walk(path):


### PR DESCRIPTION
virtualenv installs a `_virtualenv.{py,pth}` import hook into every environment to stop distutils install config keys (`prefix`, `install_purelib`, and friends from `~/.pydistutils.cfg` or a project `setup.cfg`) from redirecting package installs outside the environment. As #3181 tracks, that guard no longer earns its keep on modern Python. Since 3.10 pip ignores those keys by default, and both setuptools and CPython's vendored distutils drop them too. What survives is cost. The `.pth` runs `import _virtualenv` on every interpreter startup, which imports `contextlib` and adds about 2ms (measured in the issue).

This gates hook installation on the target interpreter version, so environments for Python 3.10 and later skip the hook and its startup import. The cutoff avoids a blanket removal for one reason: the last pip release supporting Python 3.9 still needs the workaround below 3.10, so 3.9 environments keep the hook. Once virtualenv drops 3.9, `install_patch` and `_virtualenv.py` can go for good.

Nothing changes for 3.9 or for the escape-prevention guarantee itself, since pip on 3.10+ keeps installs inside the environment without our hook. Closes #3181.
