### PR TITLE
🐛 fix(fish): harden prompt against shadowed builtins

### DIFF
--- a/docs/changelog/3185.bugfix.rst
+++ b/docs/changelog/3185.bugfix.rst
@@ -1,0 +1,4 @@
+Harden the fish activator prompt against user functions that shadow builtins. Routing ``functions``, ``printf``,
+``string``, ``echo`` and ``source``/``.`` through ``builtin`` stops a shadowing function (such as a dot-style directory
+navigator that redefines ``.``) from hijacking the prompt and dropping the previous command's exit status, matching the
+CPython fix in `gh-140006 <https://github.com/python/cpython/issues/140006>`_.

--- a/src/virtualenv/activation/fish/activate.fish
+++ b/src/virtualenv/activation/fish/activate.fish
@@ -36,14 +36,14 @@ function deactivate -d 'Exit virtualenv mode and return to the normal environmen
     end
 
     if test -n "$_OLD_FISH_PROMPT_OVERRIDE"
-       and functions -q _old_fish_prompt
+       and builtin functions -q _old_fish_prompt
         # Set an empty local `$fish_function_path` to allow the removal of `fish_prompt` using `functions -e`.
         set -l fish_function_path
 
         # Erase virtualenv's `fish_prompt` and restore the original.
-        functions -e fish_prompt
-        functions -c _old_fish_prompt fish_prompt
-        functions -e _old_fish_prompt
+        builtin functions -e fish_prompt
+        builtin functions -c _old_fish_prompt fish_prompt
+        builtin functions -e _old_fish_prompt
         set -e _OLD_FISH_PROMPT_OVERRIDE
     end
 
@@ -52,8 +52,8 @@ function deactivate -d 'Exit virtualenv mode and return to the normal environmen
 
     if test "$argv[1]" != 'nondestructive'
         # Self-destruct!
-        functions -e pydoc
-        functions -e deactivate
+        builtin functions -e pydoc
+        builtin functions -e deactivate
     end
 end
 
@@ -104,17 +104,20 @@ end
 
 if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
     # Copy the current `fish_prompt` function as `_old_fish_prompt`.
-    functions -c fish_prompt _old_fish_prompt
+    builtin functions -c fish_prompt _old_fish_prompt
 
+    # Route every builtin the prompt path uses through `builtin` so a user function that shadows
+    # `printf`, `string`, `echo`, or `source`/`.` cannot hijack the prompt (Issue #93858 follow-up,
+    # CPython gh-140006). A dot-style directory navigator redefining `.` is the common trigger.
     function fish_prompt
         set -l old_status $status
         # Run the user's prompt first; it might depend on (pipe)status.
         set -l prompt (_old_fish_prompt)
 
-        printf '(%s) ' $VIRTUAL_ENV_PROMPT
+        builtin printf '(%s) ' $VIRTUAL_ENV_PROMPT
 
-        string join -- \n $prompt # handle multi-line prompts
-        echo "exit $old_status" | .
+        builtin string join -- \n $prompt # handle multi-line prompts
+        builtin echo "exit $old_status" | builtin source -
     end
 
     set -gx _OLD_FISH_PROMPT_OVERRIDE "$VIRTUAL_ENV"

--- a/tests/unit/activation/test_fish.py
+++ b/tests/unit/activation/test_fish.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import sys
 from argparse import Namespace
 
@@ -8,6 +10,8 @@ import pytest
 
 from virtualenv.activation import FishActivator
 from virtualenv.info import IS_WIN
+
+FISH = shutil.which("fish")
 
 
 @pytest.mark.parametrize(
@@ -55,6 +59,26 @@ def test_fish_tkinter_generation(tmp_path, tcl_lib, tk_lib, present) -> None:
     else:
         assert "if test -n ''\n  if set -q TCL_LIBRARY;" in content
         assert "if test -n ''\n  if set -q TK_LIBRARY;" in content
+
+
+@pytest.mark.skipif(IS_WIN, reason="fish is not available on Windows")
+@pytest.mark.skipif(FISH is None, reason="fish is not installed")
+def test_fish_prompt_survives_shadowed_source(activation_python, tmp_path) -> None:
+    # A user function shadowing `.`/`source` must not hijack the prompt's exit-status restore. Source a copy of the
+    # rendered script from an ASCII path so the driver avoids the venv path's special characters.
+    script = tmp_path / "activate.fish"
+    rendered = activation_python.creator.bin_dir / "activate.fish"
+    script.write_text(rendered.read_text(encoding="utf-8"), encoding="utf-8")
+    start, trap = tmp_path / "start", tmp_path / "trap"
+    start.mkdir()
+    trap.mkdir()
+    driver = tmp_path / "driver.fish"
+    driver.write_text(
+        f"cd '{start}'\nfunction . ; cd '{trap}' ; end\nsource '{script}'\nfish_prompt\necho \"PWD=$PWD\"\n",
+        encoding="utf-8",
+    )
+    out = subprocess.run([FISH, str(driver)], capture_output=True, text=True, timeout=60, check=True).stdout
+    assert f"PWD={start}\n" in out, out
 
 
 @pytest.mark.skipif(IS_WIN, reason="we have not setup fish in CI yet")


### PR DESCRIPTION
The fish activator installs a `fish_prompt` wrapper that restores the previous command's exit status with `echo "exit $old_status" | .`. fish resolves functions ahead of builtins, so a user function that shadows `.`/`source` intercepts that pipe instead of sourcing it. The common trigger is a dot-style directory navigator that redefines `.`, which turns every prompt render into a `cd`, loses the exit status the original prompt depends on, and can move the shell around under the user's feet.

This routes the builtins the prompt and `deactivate` paths rely on (`functions`, `printf`, `string`, `echo`, and `source`/`.`) through `builtin`, so no user function can hijack them. All of these have been fish builtins with a stable interface since 2.0.0, well below the version the activator already requires, so the minimum supported fish version does not move.

CPython shipped the same fix for its own `activate.fish` in [gh-140006](https://github.com/python/cpython/issues/140006). This brings virtualenv's activator in line. I reproduced it against the rendered script: with `.` shadowed by a `cd` function the old prompt changed the working directory on every render, while the hardened prompt leaves it untouched and still shows the `(env)` prefix.
