### PR TITLE
👷 ci: test against Python 3.15 beta

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -85,6 +85,7 @@ jobs:
         if: ${{ !startsWith(matrix.py, 'brew@') && matrix.py != 'rp' }}
         with:
           python-version: ${{ matrix.py }}
+          allow-prereleases: true
       - name: 🦀 Setup RustPython
         if: matrix.py == 'rp'
         shell: bash

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,6 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.15t"
+          - "3.15"
           - "3.14t"
           - "3.14"
           - "3.13t"
@@ -73,7 +75,7 @@ jobs:
       - name: 📦 Install tox with this virtualenv
         shell: bash
         run: |
-          if [[ "${{ matrix.py }}" == "3.13t" || "${{ matrix.py }}" == "3.14t" || "${{ matrix.py }}" == "rp" ]]; then
+          if [[ "${{ matrix.py }}" == "3.13t" || "${{ matrix.py }}" == "3.14t" || "${{ matrix.py }}" == "3.15t" || "${{ matrix.py }}" == "rp" ]]; then
             uv tool install --no-managed-python --python 3.14 "tox>=4.45" --with .
           else
             uv tool install --no-managed-python --python 3.14 "tox>=4.45" --with tox-uv --with .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries",
@@ -207,7 +208,7 @@ builtin = "clear,usage,en-GB_to_en-US"
 count = true
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.ty]
 rules.unused-ignore-comment = "ignore"  # some ignores are platform/version-specific (e.g., ctypes.windll on Linux)

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,6 @@
 requires = [ "tox>=4.45" ]
 env_list = [
+  "3.15",
   "3.14",
   "3.13",
   "3.12",
@@ -9,6 +10,7 @@ env_list = [
   "pypy3",
   "3.13t",
   "3.14t",
+  "3.15t",
   "coverage",
   "docs",
   "fix",


### PR DESCRIPTION
virtualenv builds environments for whatever interpreter you point it at, so breakage in interpreter discovery and in the seeder shows up on a new CPython feature branch long before that branch ships. 🐍 Python 3.15 reached `3.15.0b3` with no CI job exercising it. Testing it now surfaces bugs while upstream can still fix them for the final release.

I added the version to the places that already enumerate interpreters: the `py` matrix in `check.yaml` (both `3.15` and the free-threaded `3.15t`), `env_list` in `tox.toml`, and the classifiers in `pyproject.toml`. Free-threaded builds skip `tox-uv` and install tox `--with .`, so `3.15t` joins `3.13t` and `3.14t` in that conditional. `max_supported_python` moves to `3.15` so `pyproject-fmt` keeps the new classifier instead of stripping it.

One change goes beyond what declaring `3.14` needed. `actions/setup-python` does not resolve a version with no final release, so my first run died at the interpreter setup step on all three operating systems, twelve seconds in, before a single test ran. Setting `allow-prereleases: true` on that step fixes it, matching what this repo did for `3.13` during its beta in [#2752](https://github.com/pypa/virtualenv/pull/2752). The flag changes resolution only for versions that have no stable release, so the other matrix entries still pick their releases.

This drops no version and leaves `requires-python` alone. For review, the tox `type` environment still checks against `3.14`, and I left out a `brew@3.15` entry because Homebrew has no 3.15 formula yet. All 63 checks pass, including the two `graalpy-24.1` jobs that are red on `main`.
