### PR TITLE
📝 docs(branding): clarify official logo vs favicon

### DIFF
--- a/docs/changelog/3199.doc.rst
+++ b/docs/changelog/3199.doc.rst
@@ -1,0 +1,2 @@
+Document that ``virtualenv.png`` is the official logo and ``virtualenv.svg`` is a simplified favicon-only mark - by
+:user:`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ pygments_style, pygments_dark_style = "sphinx", "monokai"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 html_js_files = ["mermaid-normalize.js", "rtd-search.js"]
+# favicon is a simplified mark, not a vector copy of the logo PNG; see development.rst "Logo and branding"
 html_favicon = "_static/virtualenv.svg"
 html_theme_options = {
     "light_logo": "virtualenv.png",

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -136,6 +136,16 @@ locally, run:
 The built documentation can be found in the ``.tox/docs_out`` folder and may be viewed by opening ``index.html`` within
 that folder.
 
+Logo and branding
+=================
+
+Two logo files live in ``docs/_static`` and serve different roles, so both are kept on purpose:
+
+- ``virtualenv.png`` is the official logo — the snakes wrapped around a terminal, with the wordmark. It is the site logo
+  (``light_logo``/``dark_logo`` in ``docs/conf.py``) and the one to use wherever a virtualenv logo is needed.
+- ``virtualenv.svg`` is a simplified mark used only as the browser favicon (``html_favicon``), where the detailed PNG
+  would be illegible at 16×16. It is not a vector copy of the PNG.
+
 Release
 =======
 


### PR DESCRIPTION
The `docs/_static` folder ships two logo files, `virtualenv.png` and `virtualenv.svg`, and a contributor in [#3199](https://github.com/pypa/virtualenv/issues/3199) read them as two formats of one asset and asked which is canonical. They are separate designs. The PNG is the detailed logo (snakes around a terminal with the wordmark). The SVG is a stripped-down mark used only for the favicon, where the detailed logo would be illegible at 16×16.

A new "Logo and branding" section in the development guide states that the PNG is the official logo and the SVG is a favicon-only mark. The `html_favicon` line in `docs/conf.py` now carries a comment pointing at that note, so a later cleanup does not "correct" the mismatch. No assets change.
