### PR TITLE
✨ feat(create): record created environments per PEP 832

### DIFF
--- a/docs/changelog/3193.feature.rst
+++ b/docs/changelog/3193.feature.rst
@@ -1,0 +1,1 @@
+Add the PEP 838 ``python-version`` field to ``pyvenv.cfg``.

--- a/docs/changelog/3193.feature.rst
+++ b/docs/changelog/3193.feature.rst
@@ -1,1 +1,3 @@
-Add the PEP 838 ``python-version`` field to ``pyvenv.cfg``.
+Write the `PEP 838 <https://peps.python.org/pep-0838/>`_ ``python-version`` key into ``pyvenv.cfg``, holding the target
+interpreter's feature release. The new :doc:`reference/files` page covers it alongside every other file a created
+environment holds - by :user:`konstin`.

--- a/docs/changelog/3204.feature.rst
+++ b/docs/changelog/3204.feature.rst
@@ -1,0 +1,3 @@
+Record the created environment as the default one of its parent folder within a ``.python-envs`` file, per `PEP 832
+<https://peps.python.org/pep-0832/>`_, so editors and type checkers can find it. Parallel creations under one folder
+serialize through a ``.python-envs.lock`` file next to it. Skip both with ``--no-python-envs`` - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -147,7 +147,8 @@ virtualenv operates in two distinct phases:
         CreatePython --> SeedPackages[Install seed packages: pip, setuptools, wheel]
         SeedPackages --> ActivationScripts[Install activation scripts]
         ActivationScripts --> VCSIgnore[Create VCS ignore files]
-        VCSIgnore --> Complete([Virtual environment ready])
+        VCSIgnore --> Record[Record in .python-envs]
+        Record --> Complete([Virtual environment ready])
 
         style Start fill:#2563eb,stroke:#1d4ed8,color:#fff
         style Phase1 fill:#6366f1,stroke:#4f46e5,color:#fff
@@ -161,12 +162,14 @@ virtualenv operates in two distinct phases:
     flag to specify a different interpreter.
 
 **Phase 2: Create the virtual environment**
-    Once the target interpreter is identified, virtualenv creates the environment in four steps:
+    Once the target interpreter is identified, virtualenv creates the environment in five steps:
 
     1. Create a Python executable matching the target interpreter
     2. Install seed packages (pip, setuptools, wheel) to enable package installation
     3. Install activation scripts for various shells
     4. Create VCS ignore files (currently Git's ``.gitignore``, skip with ``--no-vcs-ignore``)
+    5. Record the environment in a ``.python-envs`` file so editors and type checkers can find it (`PEP 832
+       <https://peps.python.org/pep-0832/>`_, skip with ``--no-python-envs``)
 
 An important design principle: virtual environments are not self-contained. A complete Python installation consists of
 thousands of files, and copying all of them into every virtual environment would be wasteful. Instead, virtual
@@ -569,6 +572,54 @@ Remember: activation is optional. The following commands are equivalent:
 For a deeper dive into how activation works under the hood, see Allison Kaptur's blog post `There's no magic: virtualenv
 edition <https://www.recurse.com/blog/14-there-is-no-magic-virtualenv-edition>`_, which explains how virtualenv uses
 ``PATH`` and ``PYTHONHOME`` to isolate virtual environments.
+
+***********************
+ Environment discovery
+***********************
+
+Editors, type checkers and task runners need to find a project's environments, and they cannot count on an activated
+shell to tell them where those are. Launching an editor on a fresh checkout leaves it guessing. Each tool has answered
+that by hard-coding a search per environment manager it wants to support, which is why editor support for any new tool
+lags behind the tool itself.
+
+`PEP 832 <https://peps.python.org/pep-0832/>`_ replaces the guessing with a file. A project may carry a ``.python-envs``
+file listing one environment per line, and the tools that create environments keep it current. virtualenv creates
+environments, so it writes the file; reading it belongs to the tools consuming it.
+
+After creating ``<root>/<name>``, virtualenv records ``<name>`` in ``<root>/.python-envs``:
+
+.. code-block:: console
+
+    $ virtualenv env
+    $ virtualenv other
+    $ cat .python-envs
+    env
+    other
+
+**The last line is the default**
+    A tool asking "which environment should I use" takes the final entry, so the environment created last wins. An entry
+    pointing at the same destination moves to the end instead of being repeated.
+
+**A ``.venv`` folder needs no line**
+    PEP 832 counts a ``.venv`` folder beside the file as its implicit last line. Creating ``.venv`` therefore writes
+    nothing, and where a ``.venv`` folder exists it stays the default whatever ``.python-envs`` lists. virtualenv logs a
+    debug message when it records an environment that a sibling ``.venv`` outranks.
+
+**Recording never breaks creation**
+    A read or write failure logs a warning and leaves you with a working environment. Discovery is a convenience for
+    other tools, so it does not get to fail the job you asked for.
+
+Why a lock file
+===============
+
+Recording rewrites the whole file, which loses entries when several environments land in one folder at once. A task
+runner building a matrix does that. virtualenv serializes the read-modify-write through a ``.python-envs.lock`` file,
+which is why a second file appears next to ``.python-envs`` on every platform except Windows, where the lock file goes
+away as the lock releases.
+
+The lock sits beside the file it guards rather than in the app data folder for two reasons. It keeps working when the
+app data is read-only or disabled, and it gives any other PEP 832 writer a location to agree on, which a path private to
+virtualenv could not.
 
 **********
  See also

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -173,6 +173,14 @@ thousands of files, and copying all of them into every virtual environment would
 environments are lightweight shells that borrow most content from the system Python. They contain only what's needed to
 redirect Python's behavior.
 
+``pyvenv.cfg`` is what makes that redirection work. The interpreter reads it at startup to find its base installation,
+so the file is the environment rather than a description of it. That also makes it the cheapest place for other tools to
+learn about the environment, which is why it accumulated three keys carrying the same version at different precisions.
+`PEP 838 <https://peps.python.org/pep-0838/>`_ settles which one to read by requiring ``python-version``, holding the
+feature release and nothing more, since a wheel tag and a type-checker target both stop at the minor version.
+``version`` and ``version_info`` stay for the callers that need a patch level or a release level, and
+:doc:`reference/files` sets out the difference.
+
 This design has two implications:
 
 - Environment creation is fast because only a small number of files need to be created.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -336,6 +336,25 @@ For distribution maintainers
 Patch the ``virtualenv.seed.wheels.embed`` module and set ``PERIODIC_UPDATE_ON_BY_DEFAULT`` to ``False`` to disable
 periodic updates by default. See :doc:`../explanation` for implementation details.
 
+*******************************************
+ Find out which Python an environment uses
+*******************************************
+
+Read ``python-version`` out of ``pyvenv.cfg`` rather than running the environment's interpreter, which costs a
+subprocess and fails when the base Python has been removed:
+
+.. code-block:: python
+
+    from configparser import ConfigParser
+    from pathlib import Path
+
+    parser = ConfigParser()
+    parser.read_string("[cfg]\n" + Path("env/pyvenv.cfg").read_text(encoding="utf-8"))
+    parser["cfg"]["python-version"]  # '3.14'
+
+``pyvenv.cfg`` has no section header, hence the prefix. The key holds the feature release only; reach for ``version``
+when you need the patch level too.
+
 **********************
  Use from Python code
 **********************

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -290,6 +290,66 @@ Options are resolved in this order (highest to lowest priority):
         style C fill:#d97706,stroke:#b45309,color:#fff
         style D fill:#6366f1,stroke:#4f46e5,color:#fff
 
+********************************
+ Make environments discoverable
+********************************
+
+virtualenv records every environment it creates in a ``.python-envs`` file next to it, so editors and type checkers can
+find them without an activated shell. See `PEP 832 <https://peps.python.org/pep-0832/>`_ for the format and
+:ref:`explanation:Environment discovery` for the reasoning.
+
+Point a tool at the right environment
+=====================================
+
+The last line of ``.python-envs`` is the default environment, and the environment you create last takes that spot:
+
+.. code-block:: console
+
+    $ virtualenv py313 --python 3.13
+    $ virtualenv py314 --python 3.14
+    $ cat .python-envs
+    py313
+    py314
+
+To promote ``py313`` back to the default, create it again over the existing folder. Its entry moves to the end rather
+than repeating:
+
+.. code-block:: console
+
+    $ virtualenv py313 --python 3.13
+    $ cat .python-envs
+    py314
+    py313
+
+A ``.venv`` folder outranks every line in the file, so delete or rename it if you want another environment to win.
+
+Skip recording
+==============
+
+Pass ``--no-python-envs`` when you do not want the ``.python-envs`` and ``.python-envs.lock`` files:
+
+.. code-block:: console
+
+    $ virtualenv env --no-python-envs
+
+Set it once for every environment you create through the configuration file or an environment variable:
+
+.. code-block:: ini
+
+    [virtualenv]
+    no_python_envs = true
+
+.. code-block:: console
+
+    $ export VIRTUALENV_NO_PYTHON_ENVS=1
+
+Commit the file or ignore it
+============================
+
+Commit ``.python-envs`` when the environment locations are the same for everyone on the project, such as a containerized
+setup or a fixed tox layout. Add it to ``.gitignore`` when developers pick their own paths. Always ignore
+``.python-envs.lock``, which is a local lock file rather than project configuration.
+
 ***********************
  Control seed packages
 ***********************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,7 @@ into the standard library under the ``venv`` module. For how ``virtualenv`` comp
 - :doc:`reference/compatibility` — Supported Python versions and operating systems
 - :doc:`reference/cli` — Command line options and flags
 - :doc:`reference/environment-layout` — Names the interpreter answers to inside an environment
-- :doc:`reference/files` — Files a created environment holds
+- :doc:`reference/files` — Files written inside and beside a created environment
 - :doc:`reference/api` — Programmatic Python API reference
 
 **Explanation** - Understand the concepts

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,8 @@ into the standard library under the ``venv`` module. For how ``virtualenv`` comp
 
 - :doc:`reference/compatibility` — Supported Python versions and operating systems
 - :doc:`reference/cli` — Command line options and flags
+- :doc:`reference/environment-layout` — Names the interpreter answers to inside an environment
+- :doc:`reference/files` — Files a created environment holds
 - :doc:`reference/api` — Programmatic Python API reference
 
 **Explanation** - Understand the concepts
@@ -116,6 +118,7 @@ Learn more about virtualenv from these community resources:
     reference/compatibility
     reference/cli
     reference/environment-layout
+    reference/files
     reference/api
 
 .. toctree::

--- a/docs/plugin/tutorial.rst
+++ b/docs/plugin/tutorial.rst
@@ -112,7 +112,7 @@ The output should list ``pyenv`` as an available discovery mechanism. You can no
 
     $ virtualenv --discovery=pyenv myenv
     created virtual environment CPython3.11.0.final.0-64 in 234ms
-      creator CPython3Posix(dest=/path/to/myenv, clear=False, no_vcs_ignore=False, global=False)
+      creator CPython3Posix(dest=/path/to/myenv, clear=False, no_vcs_ignore=False, no_python_envs=False, global=False)
       seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/path)
         added seed packages: pip==23.0, setuptools==65.5.0, wheel==0.38.4
       activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

--- a/docs/reference/files.rst
+++ b/docs/reference/files.rst
@@ -1,0 +1,72 @@
+#################
+ Generated files
+#################
+
+Creating an environment writes several files into the destination folder. This page lists each one and what it holds.
+
+****************
+ ``pyvenv.cfg``
+****************
+
+Marks the folder as a virtual environment and points the interpreter at the Python it was built from, per `PEP 405
+<https://peps.python.org/pep-0405/>`_. Deleting it breaks the environment.
+
+.. code-block:: ini
+
+    home = /usr/local/python-3.14/bin
+    implementation = CPython
+    python-version = 3.14
+    version_info = 3.14.6.final.0
+    version = 3.14.6
+    executable = /usr/local/python-3.14/bin/python3.14
+    command = /usr/bin/python3 -m virtualenv /home/user/env
+    virtualenv = 21.7.6
+    include-system-site-packages = false
+    base-prefix = /usr/local/python-3.14
+    base-exec-prefix = /usr/local/python-3.14
+    base-executable = /usr/local/python-3.14/bin/python3.14
+
+Three keys carry the version, and they differ in precision and in who should read them:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 25 30 45
+
+    - - Key
+      - Example
+      - Read it when
+    - - ``python-version``
+      - ``3.14``
+      - You want the feature release, which is what selects a wheel tag or a type-checker target. `PEP 838
+        <https://peps.python.org/pep-0838/>`_ defines it and every tool creating an environment must write it.
+    - - ``version``
+      - ``3.14.6``
+      - You need the patch level as well. PEP 838 discourages reading it in favor of ``python-version``.
+    - - ``version_info``
+      - ``3.14.6.final.0``
+      - You need the release level and serial. Written by virtualenv rather than by any specification.
+
+``prompt`` appears as an extra key when you pass ``--prompt``. The ``base-*`` keys come from the creator and vary by
+creation method.
+
+******************
+ ``CACHEDIR.TAG``
+******************
+
+Marks the environment as regenerable cache content, following the `cache directory tagging specification
+<https://bford.info/cachedir/>`_, so backup tools skip it. virtualenv leaves an existing file untouched.
+
+****************
+ ``.gitignore``
+****************
+
+Holds ``*``, keeping the environment out of Git. Skip it with ``--no-vcs-ignore``. virtualenv leaves an existing file
+untouched, and writes nothing for Mercurial, Bazaar or Subversion, none of which honor ignore files in a subdirectory.
+
+***********************
+ ``bin`` / ``Scripts``
+***********************
+
+The interpreter, the console scripts of any seeded package, and the activation scripts for each shell.
+:doc:`environment-layout` lists the names the interpreter answers to, and :ref:`explanation:Activators` covers the
+shells.

--- a/docs/reference/files.rst
+++ b/docs/reference/files.rst
@@ -2,11 +2,15 @@
  Generated files
 #################
 
-Creating an environment writes several files into the destination folder. This page lists each one and what it holds.
+Creating an environment writes files inside the destination folder and beside it. This page lists each one, what it
+holds, and how to suppress it.
 
-****************
- ``pyvenv.cfg``
-****************
+*******************************
+ Inside the environment folder
+*******************************
+
+``pyvenv.cfg``
+==============
 
 Marks the folder as a virtual environment and points the interpreter at the Python it was built from, per `PEP 405
 <https://peps.python.org/pep-0405/>`_. Deleting it breaks the environment.
@@ -49,24 +53,66 @@ Three keys carry the version, and they differ in precision and in who should rea
 ``prompt`` appears as an extra key when you pass ``--prompt``. The ``base-*`` keys come from the creator and vary by
 creation method.
 
-******************
- ``CACHEDIR.TAG``
-******************
+``CACHEDIR.TAG``
+================
 
 Marks the environment as regenerable cache content, following the `cache directory tagging specification
 <https://bford.info/cachedir/>`_, so backup tools skip it. virtualenv leaves an existing file untouched.
 
-****************
- ``.gitignore``
-****************
+``.gitignore``
+==============
 
 Holds ``*``, keeping the environment out of Git. Skip it with ``--no-vcs-ignore``. virtualenv leaves an existing file
 untouched, and writes nothing for Mercurial, Bazaar or Subversion, none of which honor ignore files in a subdirectory.
 
-***********************
- ``bin`` / ``Scripts``
-***********************
+``bin`` / ``Scripts``
+=====================
 
 The interpreter, the console scripts of any seeded package, and the activation scripts for each shell.
 :doc:`environment-layout` lists the names the interpreter answers to, and :ref:`explanation:Activators` covers the
 shells.
+
+*******************************
+ Beside the environment folder
+*******************************
+
+``.python-envs``
+================
+
+Lists the environments of the parent folder, one per line, with the last line naming the default one, per `PEP 832
+<https://peps.python.org/pep-0832/>`_. Skip it with ``--no-python-envs``.
+
+.. code-block:: text
+
+    py313
+    py314
+
+Format rules virtualenv follows when it rewrites the file:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 70
+
+    - - Rule
+      - Behavior
+    - - Encoding
+      - UTF-8.
+    - - Entry
+      - The destination folder name, since the file sits in the destination's parent. Absolute entries written by other
+        tools are read and preserved.
+    - - Default
+      - The last line. A new environment goes last, and an entry already pointing at it moves there rather than
+        repeating.
+    - - ``.venv``
+      - Never written, because PEP 832 counts a ``.venv`` folder beside the file as its implicit last line.
+    - - Blank lines
+      - Dropped on rewrite.
+    - - Failure
+      - Logged as a warning; the environment is still created.
+
+``.python-envs.lock``
+=====================
+
+An empty lock file serializing concurrent rewrites of ``.python-envs``. It carries no content. On Windows it disappears
+as the lock releases; on other platforms it stays behind, and you can delete it while no virtualenv is running.
+Suppressed by ``--no-python-envs`` along with the file it guards, and worth adding to your VCS ignore list.

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -33,6 +33,16 @@ Let's create a virtual environment called ``myproject``:
 This creates a new directory called ``myproject`` containing a complete, isolated Python environment with its own copy
 of Python, pip, and other tools.
 
+``pyvenv.cfg`` inside it records which Python the environment came from:
+
+.. code-block:: console
+
+    $ grep python-version myproject/pyvenv.cfg
+    python-version = 3.13
+
+That key tells an editor or a type checker which language version your code targets, and :doc:`../reference/files`
+covers the rest of the file.
+
 The interpreter answers to several names, so a script expecting any of them keeps working inside the environment:
 
 .. code-block:: console

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -26,7 +26,7 @@ Let's create a virtual environment called ``myproject``:
 
     $ virtualenv myproject
     created virtual environment CPython3.13.2.final.0-64 in 200ms
-      creator CPython3Posix(dest=/home/user/myproject, clear=False, no_vcs_ignore=False, global=False)
+      creator CPython3Posix(dest=/home/user/myproject, clear=False, no_vcs_ignore=False, no_python_envs=False, global=False)
       seeder FromAppData(download=False, pip=bundle, setuptools=bundle, via=copy, app_data_dir=/home/user/.cache/virtualenv)
       activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
 
@@ -40,8 +40,7 @@ of Python, pip, and other tools.
     $ grep python-version myproject/pyvenv.cfg
     python-version = 3.13
 
-That key tells an editor or a type checker which language version your code targets, and :doc:`../reference/files`
-covers the rest of the file.
+That key tells an editor or a type checker which language version your code targets.
 
 The interpreter answers to several names, so a script expecting any of them keeps working inside the environment:
 
@@ -50,7 +49,17 @@ The interpreter answers to several names, so a script expecting any of them keep
     $ ls myproject/bin/python*
     myproject/bin/python  myproject/bin/python3  myproject/bin/python3.13
 
-:doc:`../reference/environment-layout` lists the full set, which differs on Windows.
+Alongside the folder you get a ``.python-envs`` file naming the environment you just made:
+
+.. code-block:: console
+
+    $ cat .python-envs
+    myproject
+
+The same tools read that file to find the environment, so they can offer the right interpreter before you activate
+anything. Create a second environment here and its name joins the list, with the newest one last. Pass
+``--no-python-envs`` if you would rather virtualenv left no trace outside the environment folder.
+:doc:`../reference/environment-layout` lists every interpreter name, and :doc:`../reference/files` covers every file.
 
 **************************
  Activate the environment
@@ -251,6 +260,7 @@ In this tutorial, you learned how to:
 - Install packages in isolation from your system Python.
 - Save project dependencies with ``pip freeze``.
 - Reproduce environments using ``requirements.txt``.
+- Let editors find your environments through the ``.python-envs`` file.
 
 ************
  Next steps
@@ -261,3 +271,4 @@ Now that you understand the basics, explore these topics:
 - :doc:`../how-to/usage` for selecting specific Python versions, configuring defaults, and advanced usage patterns.
 - :doc:`../explanation` for understanding how virtualenv works under the hood and how it compares to ``venv``.
 - :doc:`../reference/cli` for all available command line options and flags.
+- :doc:`../reference/files` for every file virtualenv writes inside and beside an environment.

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -223,11 +223,10 @@ class Creator(ABC):
         assert system_executable is not None  # ruff:ignore[assert]
         self.pyenv_cfg["home"] = os.path.dirname(os.path.abspath(system_executable))
         self.pyenv_cfg["implementation"] = self.interpreter.implementation
-        self.pyenv_cfg["python-version"] = (
-            f"{self.interpreter.version_info.major}.{self.interpreter.version_info.minor}"
-        )
-        self.pyenv_cfg["version_info"] = ".".join(str(i) for i in self.interpreter.version_info)
-        self.pyenv_cfg["version"] = ".".join(str(i) for i in self.interpreter.version_info[:3])
+        version_info = self.interpreter.version_info
+        self.pyenv_cfg["python-version"] = f"{version_info.major}.{version_info.minor}"
+        self.pyenv_cfg["version_info"] = ".".join(str(i) for i in version_info)
+        self.pyenv_cfg["version"] = ".".join(str(i) for i in version_info[:3])
         self.pyenv_cfg["executable"] = os.path.realpath(system_executable)
         self.pyenv_cfg["command"] = f"{sys.executable} -m virtualenv {self.dest}"
         self.pyenv_cfg["virtualenv"] = __version__

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -223,6 +223,9 @@ class Creator(ABC):
         assert system_executable is not None  # ruff:ignore[assert]
         self.pyenv_cfg["home"] = os.path.dirname(os.path.abspath(system_executable))
         self.pyenv_cfg["implementation"] = self.interpreter.implementation
+        self.pyenv_cfg["python-version"] = (
+            f"{self.interpreter.version_info.major}.{self.interpreter.version_info.minor}"
+        )
         self.pyenv_cfg["version_info"] = ".".join(str(i) for i in self.interpreter.version_info)
         self.pyenv_cfg["version"] = ".".join(str(i) for i in self.interpreter.version_info[:3])
         self.pyenv_cfg["executable"] = os.path.realpath(system_executable)

--- a/src/virtualenv/create/creator.py
+++ b/src/virtualenv/create/creator.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 from os.path import commonpath
 
+from virtualenv.util.lock import ReentrantFileLock
 from virtualenv.util.path import safe_delete
 from virtualenv.util.subprocess import LogCmd, run_cmd
 from virtualenv.version import __version__
@@ -54,6 +55,7 @@ class Creator(ABC):
         self.dest = Path(options.dest)
         self.clear = options.clear
         self.no_vcs_ignore = options.no_vcs_ignore
+        self.no_python_envs = options.no_python_envs
         self.pyenv_cfg = PyEnvCfg.from_folder(self.dest)
         self.app_data = options.app_data
         self.env = options.env
@@ -90,6 +92,7 @@ class Creator(ABC):
             ("dest", str(self.dest)),
             ("clear", self.clear),
             ("no_vcs_ignore", self.no_vcs_ignore),
+            ("no_python_envs", self.no_python_envs),
         ]
 
     @classmethod
@@ -137,6 +140,13 @@ class Creator(ABC):
             dest="no_vcs_ignore",
             action="store_true",
             help="don't create VCS ignore directive in the destination directory",
+            default=False,
+        )
+        parser.add_argument(
+            "--no-python-envs",
+            dest="no_python_envs",
+            action="store_true",
+            help="don't record the created environment within a PEP-832 .python-envs file next to the destination",
             default=False,
         )
 
@@ -204,6 +214,8 @@ class Creator(ABC):
         self.set_pyenv_cfg()
         if not self.no_vcs_ignore:
             self.setup_ignore_vcs()
+        if not self.no_python_envs:
+            self.record_python_envs()
 
     def add_cachedir_tag(self) -> None:
         """Generate a file indicating that this is not meant to be backed up."""
@@ -245,6 +257,28 @@ class Creator(ABC):
         # https://www.selenic.com/mercurial/hgignore.5.html for more details
         # Bazaar - does not support ignore files in sub-directories, only at root level via .bzrignore
         # Subversion - does not support ignore files, requires direct manipulation with the svn tool
+
+    def record_python_envs(self) -> None:
+        """Register the environment as the default one of its parent folder, per PEP-832."""
+        if self.dest.name == ".venv":  # implicitly the last line of .python-envs, no need to record it
+            return
+        root = self.dest.parent
+        if (root / ".venv" / "pyvenv.cfg").exists():
+            LOGGER.debug(".venv keeps being the default environment of %s", root)
+        envs_file = root / ".python-envs"
+        target = os.path.normcase(os.path.normpath(str(self.dest)))
+        try:
+            # concurrent creations under one folder rewrite the same file, so serialize them across processes
+            with ReentrantFileLock(root).lock_for_key(envs_file.name):
+                # the last entry is the default environment, so an entry already pointing at us must move to the end
+                keep = [
+                    i
+                    for i in (envs_file.read_text(encoding="utf-8") if envs_file.exists() else "").splitlines()
+                    if i.strip() and os.path.normcase(os.path.normpath(os.path.join(str(root), i))) != target
+                ]
+                envs_file.write_text("".join(f"{i}\n" for i in [*keep, self.dest.name]), encoding="utf-8")
+        except OSError as exc:
+            LOGGER.warning("could not record %s within %s - %s", self.dest, envs_file, exc)
 
     @property
     def debug(self) -> dict[str, Any] | None:

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -326,9 +326,11 @@ def test_prompt_set(tmp_path: Path, creator: str, prompt: str | None, monkeypatc
 
 
 @pytest.mark.parametrize("creator", CURRENT_CREATORS)
-def test_version_key_in_pyenv_cfg(tmp_path: Path, creator: str) -> None:
+def test_version_keys_in_pyenv_cfg(tmp_path: Path, creator: str) -> None:
     result = cli_run([str(tmp_path), "--seeder", "app-data", "--without-pip", "--creator", creator])
     cfg = PyEnvCfg.from_file(result.creator.pyenv_cfg.path)
+    version_info = result.creator.interpreter.version_info
+    assert cfg["python-version"] == f"{version_info.major}.{version_info.minor}"
     assert "version" in cfg
     parts = cfg["version"].split(".")
     assert len(parts) == 3

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -329,8 +329,7 @@ def test_prompt_set(tmp_path: Path, creator: str, prompt: str | None, monkeypatc
 def test_version_keys_in_pyenv_cfg(tmp_path: Path, creator: str) -> None:
     result = cli_run([str(tmp_path), "--seeder", "app-data", "--without-pip", "--creator", creator])
     cfg = PyEnvCfg.from_file(result.creator.pyenv_cfg.path)
-    version_info = result.creator.interpreter.version_info
-    assert cfg["python-version"] == f"{version_info.major}.{version_info.minor}"
+    assert cfg["python-version"] == f"{sys.version_info.major}.{sys.version_info.minor}"
     assert "version" in cfg
     parts = cfg["version"].split(".")
     assert len(parts) == 3

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -329,7 +329,8 @@ def test_prompt_set(tmp_path: Path, creator: str, prompt: str | None, monkeypatc
 def test_version_keys_in_pyenv_cfg(tmp_path: Path, creator: str) -> None:
     result = cli_run([str(tmp_path), "--seeder", "app-data", "--without-pip", "--creator", creator])
     cfg = PyEnvCfg.from_file(result.creator.pyenv_cfg.path)
-    assert cfg["python-version"] == f"{sys.version_info.major}.{sys.version_info.minor}"
+    version_info = result.creator.interpreter.version_info
+    assert cfg["python-version"] == f"{version_info.major}.{version_info.minor}"
     assert "version" in cfg
     parts = cfg["version"].split(".")
     assert len(parts) == 3

--- a/tests/unit/create/test_python_envs.py
+++ b/tests/unit/create/test_python_envs.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+import os
+from stat import S_IREAD, S_IWRITE
+from threading import Thread
+from typing import TYPE_CHECKING
+
+import pytest
+
+from virtualenv.run import cli_run
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def envs_file(tmp_path: Path) -> Path:
+    return tmp_path / ".python-envs"
+
+
+@pytest.mark.parametrize(
+    ("before", "after"),
+    [
+        pytest.param(None, "env\n", id="no-file-yet"),
+        pytest.param("other\n/opt/elsewhere\n", "other\n/opt/elsewhere\nenv\n", id="appended-last"),
+        pytest.param("env\nother\n", "other\nenv\n", id="relative-entry-moved-last"),
+        pytest.param("{dest}\nother\n", "other\nenv\n", id="absolute-entry-moved-last"),
+        pytest.param("other\r\n\r\n   \r\n", "other\nenv\n", id="blank-lines-dropped"),
+    ],
+)
+def test_python_envs_recorded(tmp_path: Path, envs_file: Path, before: str | None, after: str) -> None:
+    dest = tmp_path / "env"
+    if before is not None:
+        envs_file.write_bytes(before.format(dest=dest.resolve()).encode("utf-8"))
+    _create(dest)
+    assert envs_file.read_text(encoding="utf-8") == after
+
+
+def _create(dest: Path, *args: str) -> None:
+    cli_run([str(dest), "--without-pip", "--activators", "", *args], setup_logging=False)
+
+
+@pytest.mark.parametrize(
+    ("name", "args"),
+    [
+        pytest.param("env", ("--no-python-envs",), id="opted-out"),
+        pytest.param(".venv", (), id="dot-venv-is-implicit"),
+    ],
+)
+def test_python_envs_not_recorded(tmp_path: Path, envs_file: Path, name: str, args: tuple[str, ...]) -> None:
+    _create(tmp_path / name, *args)
+    assert not envs_file.exists()
+
+
+def test_python_envs_records_parallel_creations(tmp_path: Path, envs_file: Path) -> None:
+    names = [f"env-{i}" for i in range(8)]
+    threads = [Thread(target=_create, args=(tmp_path / i,)) for i in names]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert sorted(envs_file.read_text(encoding="utf-8").splitlines()) == names
+
+
+def test_python_envs_dot_venv_keeps_precedence(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _create(tmp_path / ".venv")
+    with caplog.at_level(logging.DEBUG):
+        _create(tmp_path / "env")
+    assert ".venv keeps being the default environment" in caplog.text
+
+
+def test_python_envs_not_write_able(tmp_path: Path, envs_file: Path, caplog: pytest.LogCaptureFixture) -> None:
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root may write read-only files")
+
+    envs_file.write_text("other\n", encoding="utf-8")
+    envs_file.chmod(S_IREAD)
+    try:
+        with caplog.at_level(logging.WARNING):
+            _create(tmp_path / "env")
+    finally:
+        envs_file.chmod(S_IREAD | S_IWRITE)
+    assert f"could not record {(tmp_path / 'env').resolve()} within {envs_file.resolve()}" in caplog.text
+    assert (tmp_path / "env" / "pyvenv.cfg").exists()


### PR DESCRIPTION
Editors and type checkers have no standard way to find a project's environments without an activated shell, so each one hard-codes a search per tool that creates environments. [PEP 832](https://peps.python.org/pep-0832/) addresses that with a `.python-envs` file listing one environment per line, where the last line names the default environment and a `.venv` folder alongside counts as the implicit last line.

virtualenv creates environments, so this covers the write half. After creation it records the destination in the `.python-envs` file of the parent folder and moves any existing entry for it to the end, making the fresh environment the default. It leaves a destination named `.venv` alone, since the PEP treats it as the implicit last line. A read or write failure warns and leaves the environment usable. Pass `--no-python-envs` to opt out.

Rewriting the whole file loses entries when several environments land in one folder at once. Eight concurrent creations dropped between one and four of them on every attempt, so the read-modify-write runs under a `.python-envs.lock` file next to the recorded one. 🔒 Locking beside the resource rather than inside the app data folder holds the guarantee when the app data is read-only or disabled, and gives any other PEP 832 writer a location to agree on.
