### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,7 @@ release = __version__
 copyright = f"2007-{datetime.now(tz=timezone.utc).year}, {company}, PyPA"  # ruff:ignore[builtin-variable-shadowing]
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.extlinks",
@@ -86,3 +88,6 @@ def setup(app) -> None:
     app.add_css_file("custom.css")
     app.add_directive(CliTable.name, CliTable)
     app.add_role("literal_data", literal_data)
+
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ docs = [
   "sphinx-autodoc-typehints>=3.6.2",
   "sphinx-copybutton>=0.5.2",
   "sphinx-inline-tabs>=2025.12.21.14",
+  "sphinx-llm>=0.4.1",
   "sphinxcontrib-mermaid>=2",
   "sphinxcontrib-towncrier>=0.2.1a0",
   "towncrier>=23.6",


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
