### PR TITLE
🐛 fix(types): adapt to python-discovery 1.5.2 annotations

### DIFF
--- a/docs/changelog/3211.bugfix.rst
+++ b/docs/changelog/3211.bugfix.rst
@@ -1,0 +1,3 @@
+Fix the type check against ``python-discovery`` 1.5.2, whose annotations allow a ``None`` ``prefix`` and integer
+``sysconfig_vars`` values: config var substitution now skips a missing prefix and locating the shared libpython
+requires string ``INSTSONAME``/``LIBDIR`` values.

--- a/docs/changelog/3211.bugfix.rst
+++ b/docs/changelog/3211.bugfix.rst
@@ -1,3 +1,3 @@
 Fix the type check against ``python-discovery`` 1.5.2, whose annotations allow a ``None`` ``prefix`` and integer
-``sysconfig_vars`` values: config var substitution now skips a missing prefix and locating the shared libpython
-requires string ``INSTSONAME``/``LIBDIR`` values.
+``sysconfig_vars`` values: config var substitution now skips a missing prefix and locating the shared libpython requires
+string ``INSTSONAME``/``LIBDIR`` values.

--- a/src/virtualenv/create/describe.py
+++ b/src/virtualenv/create/describe.py
@@ -66,9 +66,9 @@ class Describe:
 
     def _calc_config_vars(self, to: Path) -> dict[str, Any]:
         sys_vars = self.interpreter.sysconfig_vars
-        return {
-            k: (to if isinstance(v, str) and v.startswith(self.interpreter.prefix) else v) for k, v in sys_vars.items()
-        }
+        if (prefix := self.interpreter.prefix) is None:  # no prefix means no value can live under it
+            return dict(sys_vars)
+        return {k: (to if isinstance(v, str) and v.startswith(prefix) else v) for k, v in sys_vars.items()}
 
     @classmethod
     def can_describe(cls, interpreter: PythonInfo) -> bool:  # ruff:ignore[unused-class-method-argument]

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
@@ -51,9 +51,9 @@ class CPython3Posix(CPythonPosix, CPython3):
     def _shared_libpython(cls, interpreter: PythonInfo) -> Path | None:
         if not interpreter.sysconfig_vars.get("Py_ENABLE_SHARED"):
             return None
-        if not (instsoname := interpreter.sysconfig_vars.get("INSTSONAME")):
+        if not isinstance(instsoname := interpreter.sysconfig_vars.get("INSTSONAME"), str) or not instsoname:
             return None
-        if not (libdir := interpreter.sysconfig_vars.get("LIBDIR")):
+        if not isinstance(libdir := interpreter.sysconfig_vars.get("LIBDIR"), str) or not libdir:
             return None
         if not (lib_path := Path(libdir) / instsoname).exists():
             return None


### PR DESCRIPTION
The type environment fails on every PR since python-discovery 1.5.2 reached PyPI today, for example in [this job](https://github.com/pypa/virtualenv/actions/runs/31618753498/job/94187986986). The release added class-level annotations to `PythonInfo`, widening `prefix` to `str | None` and the `sysconfig_vars` values to `str | int | None`, and ty rejects two call sites that assumed the narrower types.

The annotations match what the collector produces: `prefix` comes from `getattr(sys, "prefix", None)` and `sysconfig_vars` values from `sysconfig.get_config_var`, which returns strings, ints, or None. `Py_ENABLE_SHARED` for instance is an int. `Describe._calc_config_vars` returns the vars unchanged when `prefix` is None, since no value can point inside a prefix that does not exist. `CPython3Posix._shared_libpython` narrows `INSTSONAME` and `LIBDIR` to non-empty strings before joining them into a path; an int in either slot cannot name a shared library, so it bails out the same way it did for missing values.

On a regular CPython host `prefix` is a string and both vars are strings, so runtime behavior stays the same. `tox r -e type` and `tox r -e fix` pass against 1.5.2. So do the describe and cpython3 unit tests.
