### PR TITLE
Push renamed changelog to PR branch in upgrade workflow

### DIFF
--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -88,10 +88,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin auto/upgrade-embedded-deps
-          git checkout auto/upgrade-embedded-deps
+          git checkout -B auto/upgrade-embedded-deps FETCH_HEAD
           mv docs/changelog/u.bugfix.rst "docs/changelog/${pr_number}.bugfix.rst"
           git add docs/changelog/
           git commit -m "Rename changelog to ${pr_number}.bugfix.rst"
-          git push
+          git push origin HEAD:auto/upgrade-embedded-deps
         env:
           STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
The "Rename changelog with PR number" step in `upgrade.yaml` checks out the local `auto/upgrade-embedded-deps` branch that create-pull-request left behind (no upstream configured) and then runs a bare `git push`, which fails with `fatal: The current branch auto/upgrade-embedded-deps has no upstream branch` (https://github.com/pypa/virtualenv/actions/runs/31094988576, https://github.com/pypa/virtualenv/actions/runs/31307714056); the runs since then are green only because no upgrade was pending. The step now checks out `FETCH_HEAD` from the fetch it already does, so it works on what is actually on the remote for both the created and updated paths, and pushes explicitly with `git push origin HEAD:auto/upgrade-embedded-deps`.