### PR TITLE
🐛 fix(util): make safe_delete's error handler actually run

### DIFF
--- a/docs/changelog/3222.bugfix.rst
+++ b/docs/changelog/3222.bugfix.rst
@@ -1,0 +1,4 @@
+``safe_delete`` no longer passes ``ignore_errors=True`` to ``shutil.rmtree``, which was replacing its own
+chmod-and-retry error handler with a no-op. Read-only files - which is every file in a wheel image, marked by
+``set_tree`` - were left behind and the failure was swallowed, so ``--reset-app-data`` and ``--clear`` could silently
+keep the tree they reported deleting - by :user:`darrenhuai`.

--- a/docs/changelog/3222.bugfix.rst
+++ b/docs/changelog/3222.bugfix.rst
@@ -1,4 +1,5 @@
-``safe_delete`` no longer passes ``ignore_errors=True`` to ``shutil.rmtree``, which was replacing its own
-chmod-and-retry error handler with a no-op. Read-only files - which is every file in a wheel image, marked by
-``set_tree`` - were left behind and the failure was swallowed, so ``--reset-app-data`` and ``--clear`` could silently
-keep the tree they reported deleting - by :user:`darrenhuai`.
+``safe_delete`` no longer passes ``ignore_errors=True`` to ``shutil.rmtree``, which replaced its own chmod-and-retry
+handler with a no-op and swallowed every failure. Read-only files - every file in a wheel image, which ``set_tree``
+marks - survived, so ``--reset-app-data`` and ``--clear`` kept trees they reported deleting. The handler now retries
+only the deletion itself, keeps the other mode bits, and raises the original error for anything it cannot clear - by
+:user:`darrenhuai`.

--- a/src/virtualenv/util/path/_sync.py
+++ b/src/virtualenv/util/path/_sync.py
@@ -8,6 +8,7 @@ from stat import S_IWUSR
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
@@ -59,17 +60,20 @@ def copytree(src: str, dest: str) -> None:
 
 
 def safe_delete(dest: Path) -> None:
-    def onerror(func: object, path: str, exc_info: object) -> None:  # ruff:ignore[unused-function-argument]
+    def onerror(func: Callable[[str], object], path: str, exc_info: object) -> None:
+        exc = exc_info[1] if isinstance(exc_info, tuple) else exc_info
+        if isinstance(exc, FileNotFoundError):
+            return
         if not os.access(path, os.W_OK):
             os.chmod(path, S_IWUSR)
-            func(path)  # ty: ignore[call-non-callable]
+            func(path)
         else:
             raise  # ruff:ignore[misplaced-bare-raise]
 
     if sys.version_info >= (3, 12):
-        shutil.rmtree(str(dest), ignore_errors=True, onexc=onerror)
+        shutil.rmtree(str(dest), onexc=onerror)
     else:
-        shutil.rmtree(str(dest), ignore_errors=True, onerror=onerror)
+        shutil.rmtree(str(dest), onerror=onerror)
 
 
 class _Debug:

--- a/src/virtualenv/util/path/_sync.py
+++ b/src/virtualenv/util/path/_sync.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+    from types import TracebackType
+
+    _ExcInfo = BaseException | tuple[type[BaseException], BaseException, TracebackType]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -60,15 +63,16 @@ def copytree(src: str, dest: str) -> None:
 
 
 def safe_delete(dest: Path) -> None:
-    def onerror(func: Callable[[str], object], path: str, exc_info: object) -> None:
+    def onerror(func: Callable[[str], object], path: str, exc_info: _ExcInfo) -> None:
         exc = exc_info[1] if isinstance(exc_info, tuple) else exc_info
         if isinstance(exc, FileNotFoundError):
             return
-        if not os.access(path, os.W_OK):
-            os.chmod(path, S_IWUSR)
-            func(path)
-        else:
+        # rmtree also reports os.open/os.close/os.scandir/os.lstat; retrying one of those with a lone path raises
+        # TypeError over the real error, or deletes nothing while telling rmtree we handled the failure
+        if func not in {os.unlink, os.rmdir} or os.access(path, os.W_OK):
             raise  # ruff:ignore[misplaced-bare-raise]
+        os.chmod(path, os.lstat(path).st_mode | S_IWUSR)
+        func(path)
 
     if sys.version_info >= (3, 12):
         shutil.rmtree(str(dest), onexc=onerror)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
+import sys
 import traceback
 import zipfile
+from stat import S_IREAD
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,6 +13,7 @@ import pytest
 from virtualenv.app_data import _cache_dir_with_migration, _default_app_data_dir
 from virtualenv.util import zipapp
 from virtualenv.util.lock import ReentrantFileLock
+from virtualenv.util.path import safe_delete
 from virtualenv.util.subprocess import run_cmd
 
 if TYPE_CHECKING:
@@ -22,6 +25,35 @@ def test_run_fail(tmp_path) -> None:
     assert err
     assert not out
     assert code
+
+
+def test_safe_delete_removes_read_only_files(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    nested = target / "sub"
+    nested.mkdir(parents=True)
+    # the wheel image marks its files read-only via set_tree, which on Windows blocks os.unlink
+    marked = nested / "wheel.py"
+    marked.write_text("cached")
+    marked.chmod(S_IREAD)
+
+    safe_delete(target)
+
+    assert not target.exists()
+
+
+def test_safe_delete_missing_path_is_noop(tmp_path: Path) -> None:
+    safe_delete(tmp_path / "does-not-exist")  # --reset-app-data before anything was cached
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="only Windows blocks deleting an open file")
+def test_safe_delete_surfaces_undeletable_entries(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    busy = target / "busy.txt"
+    busy.write_text("x")
+
+    with busy.open(), pytest.raises(OSError, match="busy"):
+        safe_delete(target)
 
 
 def test_reentrant_file_lock_is_thread_safe(tmp_path) -> None:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -5,7 +5,7 @@ import os
 import sys
 import traceback
 import zipfile
-from stat import S_IREAD
+from stat import S_IEXEC, S_IREAD, S_IRGRP, S_IRWXU, S_IWUSR
 from typing import TYPE_CHECKING
 
 import pytest
@@ -54,6 +54,38 @@ def test_safe_delete_surfaces_undeletable_entries(tmp_path: Path) -> None:
 
     with busy.open(), pytest.raises(OSError, match="busy"):
         safe_delete(target)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows deletion ignores directory permissions")
+def test_safe_delete_raises_the_original_error_not_a_retry_failure(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    blocked = target / "sub"
+    blocked.mkdir(parents=True)
+    (blocked / "wheel.py").write_text("cached")
+    blocked.chmod(0o000)  # rmtree reports this one through os.open, which takes more than a path
+
+    try:
+        with pytest.raises(PermissionError):
+            safe_delete(target)
+    finally:
+        blocked.chmod(S_IRWXU)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows deletion ignores directory permissions")
+def test_safe_delete_keeps_the_other_mode_bits_when_clearing_read_only(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    blocked = target / "wheel.py"
+    blocked.write_text("cached")
+    blocked.chmod(S_IREAD | S_IRGRP)
+    target.chmod(S_IREAD | S_IEXEC)  # the unlink fails, so the mode the handler left behind stays observable
+
+    try:
+        with pytest.raises(PermissionError):
+            safe_delete(target)
+        assert blocked.stat().st_mode & 0o777 == S_IREAD | S_IRGRP | S_IWUSR
+    finally:
+        target.chmod(S_IRWXU)
 
 
 def test_reentrant_file_lock_is_thread_safe(tmp_path) -> None:


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

---

`safe_delete` hands `shutil.rmtree` a chmod-and-retry handler and sets `ignore_errors=True` at the same time:

```python
def onerror(func, path, exc_info):
    if not os.access(path, os.W_OK):
        os.chmod(path, S_IWUSR)
        func(path)
    else:
        raise

shutil.rmtree(str(dest), ignore_errors=True, onexc=onerror)
```

`rmtree` overwrites whatever handler it is given when `ignore_errors` is set — `onexc = _onexc = lambda *args: None` — so this handler has never run. Every deletion failure was swallowed and `safe_delete` returned as if it had worked.

That matters on Windows, where the read-only attribute blocks `os.unlink`, and virtualenv marks every file in a wheel image read-only itself via `set_tree`. So:

- `--reset-app-data` kept the image trees it reported removing
- recreating an env with `--clear` could leave read-only files from the old one behind
- replacing a seed package could leave a mix of old and new files

I found this by asking what the `# ty: ignore[call-non-callable]` on the `func(path)` line was hiding. The suppression was there because `func` is annotated `object`, and `func` is annotated `object` because nothing ever called it. Before the fix, on Windows, `rmtree` left the tree in place and the handler was invoked zero times.

Dropping `ignore_errors` lets the handler do what it was written to do: clear the read-only bit, retry, and surface anything it genuinely cannot delete instead of pretending the delete succeeded. Typing `func` properly removes the `ty` suppression — `ty check src/virtualenv` still passes without it.

One caller needed a guard. `AppDataDiskFolder.reset` is the only one that calls `safe_delete` without an `exists()` check first, so a missing directory used to be absorbed by `ignore_errors`. `onerror` now returns early on `FileNotFoundError` to keep that a no-op.

Three tests: a read-only tree is actually removed, a missing path stays a no-op, and an undeletable entry now raises instead of being swallowed. The first and third fail on `main`. The third is Windows-only, since it needs an open file handle to block deletion; the first passes on POSIX either way, because there deleting a file depends on the parent directory's permissions rather than the file's own.

`tests/unit` is green locally on Windows / 3.13 (296 passed, 31 skipped), along with ruff and `ty`.
