### PR TITLE
🐛 fix(create): name Windows venv exes after the interpreter

### DIFF
--- a/docs/changelog/3223.bugfix.rst
+++ b/docs/changelog/3223.bugfix.rst
@@ -1,4 +1,4 @@
-On Windows the CPython 3.13+ ``venvlauncher.exe`` shim is no longer copied into ``Scripts`` under its own name, and the
-interpreter's file name is exposed again when a shim stands in for it. ``_executables`` took its target names from
-``host_python``, which returns the shim rather than the interpreter, so every environment gained a stray copy of the
-launcher and a host such as ``python_d.exe`` lost its alias - by :user:`darrenhuai`.
+On Windows, ``virtualenv`` no longer copies the CPython 3.13+ ``venvlauncher.exe`` shim into ``Scripts`` under the
+shim's own name, and a host such as ``python_d.exe`` gets its alias back. The alias set took its names from the shim
+that stands in for the interpreter, so every environment gained a stray launcher copy and lost the interpreter's own
+file name - by :user:`darrenhuai`.

--- a/docs/changelog/3223.bugfix.rst
+++ b/docs/changelog/3223.bugfix.rst
@@ -1,0 +1,4 @@
+On Windows the CPython 3.13+ ``venvlauncher.exe`` shim is no longer copied into ``Scripts`` under its own name, and the
+interpreter's file name is exposed again when a shim stands in for it. ``_executables`` took its target names from
+``host_python``, which returns the shim rather than the interpreter, so every environment gained a stray copy of the
+launcher and a host such as ``python_d.exe`` lost its alias - by :user:`darrenhuai`.

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
@@ -51,15 +51,13 @@ class CPythonWindows(CPython, WindowsSupports, ABC):
         # - https://bugs.python.org/issue42013
         # - venv
         host = cls.host_python(interpreter)
-        # host may be a launcher shim instead of the interpreter (CPython 3.13+ ships venvlauncher.exe), so the
-        # name we expose has to come from the interpreter, otherwise the shim's own name leaks into the venv
-        exe_name = Path(interpreter.system_executable).name  # ty: ignore[invalid-argument-type]
         minor = interpreter.version_info.minor
         names = {
             "python.exe",
             "python3.exe",
             "python3",
-            exe_name,
+            # host is the venvlauncher shim on CPython 3.13+, so the alias comes from the interpreter, not from host
+            Path(interpreter.system_executable).name,  # ty: ignore[invalid-argument-type]
             *((f"python3.{minor}t.exe",) if interpreter.free_threaded else ()),
         }
         for path in (host.parent / n for n in names):

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
@@ -51,12 +51,15 @@ class CPythonWindows(CPython, WindowsSupports, ABC):
         # - https://bugs.python.org/issue42013
         # - venv
         host = cls.host_python(interpreter)
+        # host may be a launcher shim instead of the interpreter (CPython 3.13+ ships venvlauncher.exe), so the
+        # name we expose has to come from the interpreter, otherwise the shim's own name leaks into the venv
+        exe_name = Path(interpreter.system_executable).name  # ty: ignore[invalid-argument-type]
         minor = interpreter.version_info.minor
         names = {
             "python.exe",
             "python3.exe",
             "python3",
-            host.name,
+            exe_name,
             *((f"python3.{minor}t.exe",) if interpreter.free_threaded else ()),
         }
         for path in (host.parent / n for n in names):

--- a/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
+++ b/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
@@ -138,21 +138,33 @@ def test_debug_build_shim(py_info, mock_files) -> None:
     assert contains_exe(sources, shim)
 
 
-@pytest.mark.parametrize("py_info_name", ["cpython3_win_debug"])
-def test_shim_does_not_copy_itself_under_its_own_name(py_info, mock_files) -> None:
-    shim = path(py_info.system_stdlib, "venv\\scripts\\nt\\venvlauncher_d.exe")
+@pytest.mark.parametrize(
+    ("py_info_name", "shim_name"),
+    [
+        pytest.param("cpython3_win_debug", "venvlauncher_d.exe", id="debug"),
+        pytest.param("cpython3_win_free_threaded", "venvlaunchert.exe", id="free-threaded"),
+    ],
+)
+def test_shim_not_copied_under_its_own_name(py_info, mock_files, shim_name: str) -> None:
+    shim = path(py_info.system_stdlib, f"venv\\scripts\\nt\\{shim_name}")
     mock_files(CPYTHON3_PATH, [shim])
     sources = tuple(CPython3Windows.sources(interpreter=py_info))
-    assert CPython3Windows.has_shim(interpreter=py_info)
-    assert not contains_exe(sources, shim, "venvlauncher_d.exe")
+    assert not contains_exe(sources, shim, shim_name)
 
 
-@pytest.mark.parametrize("py_info_name", ["cpython3_win_debug"])
-def test_shim_still_exposes_the_host_exe_name(py_info, mock_files) -> None:
-    shim = path(py_info.system_stdlib, "venv\\scripts\\nt\\venvlauncher_d.exe")
+@pytest.mark.parametrize(
+    ("py_info_name", "shim_name", "exe_name"),
+    [
+        pytest.param("cpython3_win_debug", "venvlauncher_d.exe", "python_d.exe", id="3.13 debug build"),
+        pytest.param("cpython3_win_embed", "python.exe", "python666.exe", id="pre-3.13 renamed host"),
+    ],
+)
+def test_shim_exposes_the_interpreter_exe_name(py_info, mock_files, shim_name: str, exe_name: str) -> None:
+    py_info.system_executable = path(py_info.prefix, exe_name)
+    shim = path(py_info.system_stdlib, f"venv\\scripts\\nt\\{shim_name}")
     mock_files(CPYTHON3_PATH, [shim])
     sources = tuple(CPython3Windows.sources(interpreter=py_info))
-    assert contains_exe(sources, shim, "python_d.exe")
+    assert contains_exe(sources, shim, exe_name)
 
 
 @pytest.mark.parametrize("py_info_name", ["cpython3_win_debug"])

--- a/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
+++ b/tests/unit/create/via_global_ref/builtin/cpython/test_cpython3_win.py
@@ -139,6 +139,23 @@ def test_debug_build_shim(py_info, mock_files) -> None:
 
 
 @pytest.mark.parametrize("py_info_name", ["cpython3_win_debug"])
+def test_shim_does_not_copy_itself_under_its_own_name(py_info, mock_files) -> None:
+    shim = path(py_info.system_stdlib, "venv\\scripts\\nt\\venvlauncher_d.exe")
+    mock_files(CPYTHON3_PATH, [shim])
+    sources = tuple(CPython3Windows.sources(interpreter=py_info))
+    assert CPython3Windows.has_shim(interpreter=py_info)
+    assert not contains_exe(sources, shim, "venvlauncher_d.exe")
+
+
+@pytest.mark.parametrize("py_info_name", ["cpython3_win_debug"])
+def test_shim_still_exposes_the_host_exe_name(py_info, mock_files) -> None:
+    shim = path(py_info.system_stdlib, "venv\\scripts\\nt\\venvlauncher_d.exe")
+    mock_files(CPYTHON3_PATH, [shim])
+    sources = tuple(CPython3Windows.sources(interpreter=py_info))
+    assert contains_exe(sources, shim, "python_d.exe")
+
+
+@pytest.mark.parametrize("py_info_name", ["cpython3_win_debug"])
 def test_debug_build_uses_venvlauncher(py_info, mock_files) -> None:
     launcher = path(py_info.prefix, "venvlauncher_d.exe")
     w_launcher = path(py_info.prefix, "venvwlauncher_d.exe")


### PR DESCRIPTION
On Windows with CPython 3.13+, `CPython3Windows.host_python()` returns the `venvlauncher.exe` shim rather than the
interpreter, and `CPythonWindows._executables()` builds its set of target names from `host.name`. Two things follow.

Every environment gets a stray `venvlauncher.exe` in `Scripts`.

```
virtualenv:   python.exe  python3  python3.exe  pythonw.exe  pythonw3.exe  venvlauncher.exe
stdlib venv:  python.exe  pythonw.exe
```

It is a copy of the shim carrying a name CPython treats as an implementation detail, and it lands on `PATH` once the
environment is activated. Stdlib `venv` writes no such file. Its `setup_python()` copies `venvlauncher{_d}.exe` to
`python.exe` and `python{_d}.exe`, and that is the whole destination list.

The second effect changes behavior. `test_3_exe_on_not_default_py_host` asserts that a `python666.exe` host resolves
under that name, which holds only while no shim is present. Once there is one, `host.name` describes the shim, so a
debug build loses its `python_d.exe` alias, an alias stdlib `venv` does write.

Taking the name from `interpreter.system_executable` fixes both, since that path describes the interpreter rather than
whatever stands in for it. A copy's file name is cosmetic here: `venvlauncher.c` resolves its target from the
compile-time `EXENAME` (`python$(PyDebugExt).exe`) rather than from its own name, so the copy named `python_d.exe`
still reaches `python_d.exe` in the base prefix.

One behavior change reaches older hosts. A pre-3.13 interpreter not called `python.exe` now also gains an alias under
its own name when a shim is present, which is what the no-shim path already does. Both cases are covered by
`test_shim_exposes_the_interpreter_exe_name`.

Verified on Windows 11 / CPython 3.13.7. `venvlauncher.exe` is gone from `Scripts`, and the created environment still
resolves `sys.prefix` through both `python.exe` and `python3.exe`. Full suite passes with and without `--int`, and `ty`
is clean against 3.14 and 3.9.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
