### PR TITLE
🎨 refactor(create): read the system exe without narrowing

### DIFF
--- a/docs/changelog/3224.bugfix.rst
+++ b/docs/changelog/3224.bugfix.rst
@@ -1,3 +1,2 @@
-Read the system interpreter through ``PythonInfo.system_exe``, which python-discovery narrows to ``str``, in place of
-the nullable ``system_executable``. That drops the twelve type-checker suppressions the creators carried for it - by
-:user:`gaborbernat`.
+Bump the ``python-discovery`` minimum to ``>=1.6`` for ``PythonInfo.system_exe``, which reports the system interpreter
+without the nullable typing of ``system_executable`` - by :user:`gaborbernat`.

--- a/docs/changelog/3224.bugfix.rst
+++ b/docs/changelog/3224.bugfix.rst
@@ -1,0 +1,3 @@
+Read the system interpreter through ``PythonInfo.system_exe``, which python-discovery narrows to ``str``, in place of
+the nullable ``system_executable``. That drops the twelve type-checker suppressions the creators carried for it - by
+:user:`gaborbernat`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "filelock>=3.16.1,<=3.19.1; python_version<'3.10'",
   "filelock>=3.24.2,<4; python_version>='3.10'",
   "platformdirs>=3.9.1,<5",
-  "python-discovery>=1.4.2",
+  "python-discovery>=1.6.0",
   "typing-extensions>=4.13.2; python_version<'3.11'",
 ]
 urls.Documentation = "https://virtualenv.pypa.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "filelock>=3.16.1,<=3.19.1; python_version<'3.10'",
   "filelock>=3.24.2,<4; python_version>='3.10'",
   "platformdirs>=3.9.1,<5",
-  "python-discovery>=1.6.0",
+  "python-discovery>=1.6",
   "typing-extensions>=4.13.2; python_version<'3.11'",
 ]
 urls.Documentation = "https://virtualenv.pypa.io"

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/common.py
@@ -31,7 +31,7 @@ class CPythonPosix(CPython, PosixSupports, ABC):
 
     @classmethod
     def _executables(cls, interpreter: PythonInfo) -> Generator[tuple[Path, list[str], str, str]]:
-        host_exe = Path(interpreter.system_executable)  # ty: ignore[invalid-argument-type]
+        host_exe = Path(interpreter.system_exe)
         minor = interpreter.version_info.minor
         names = [
             "python",
@@ -57,7 +57,7 @@ class CPythonWindows(CPython, WindowsSupports, ABC):
             "python3.exe",
             "python3",
             # host is the venvlauncher shim on CPython 3.13+, so the alias comes from the interpreter, not from host
-            Path(interpreter.system_executable).name,  # ty: ignore[invalid-argument-type]
+            Path(interpreter.system_exe).name,
             *((f"python3.{minor}t.exe",) if interpreter.free_threaded else ()),
         }
         for path in (host.parent / n for n in names):
@@ -73,7 +73,7 @@ class CPythonWindows(CPython, WindowsSupports, ABC):
 
     @classmethod
     def host_python(cls, interpreter: PythonInfo) -> Path:
-        return Path(interpreter.system_executable)  # ty: ignore[invalid-argument-type]
+        return Path(interpreter.system_exe)
 
 
 def is_mac_os_framework(interpreter: PythonInfo) -> bool:

--- a/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
+++ b/src/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py
@@ -150,7 +150,7 @@ class CPython3Windows(CPythonWindows, CPython3):
 
     @classmethod
     def dll_and_pyd(cls, interpreter: PythonInfo) -> Generator[PathRefToDest]:
-        folders = [Path(interpreter.system_executable).parent]  # ty: ignore[invalid-argument-type]
+        folders = [Path(interpreter.system_exe).parent]
 
         # May be missing on some Python hosts.
         # See https://github.com/pypa/virtualenv/issues/2368

--- a/src/virtualenv/create/via_global_ref/builtin/graalpy/__init__.py
+++ b/src/virtualenv/create/via_global_ref/builtin/graalpy/__init__.py
@@ -40,14 +40,14 @@ class GraalPy(ViaGlobalRefVirtualenvBuiltin, ABC):
 
     @classmethod
     def _executables(cls, interpreter: PythonInfo) -> Generator[tuple[Path, list[str], RefMust, RefWhen], None, None]:  # ty: ignore[invalid-method-override]
-        host = Path(interpreter.system_executable)  # ty: ignore[invalid-argument-type]
+        host = Path(interpreter.system_exe)
         targets = sorted(f"{name}{cls.suffix}" for name in cls.exe_names(interpreter))
         yield host, targets, RefMust.NA, RefWhen.ANY
 
     @classmethod
     def sources(cls, interpreter: PythonInfo) -> Generator[PathRefToDest]:  # ty: ignore[invalid-method-override]
         yield from super().sources(interpreter)
-        python_dir = Path(interpreter.system_executable).resolve().parent  # ty: ignore[invalid-argument-type]
+        python_dir = Path(interpreter.system_exe).resolve().parent
         if python_dir.name in {"bin", "Scripts"}:
             python_dir = python_dir.parent
 
@@ -90,7 +90,7 @@ class GraalPyWindows(GraalPy, WindowsSupports):
     def set_pyenv_cfg(self) -> None:
         # GraalPy needs an additional entry in pyvenv.cfg on Windows
         super().set_pyenv_cfg()
-        self.pyenv_cfg["venvlauncher_command"] = self.interpreter.system_executable  # ty: ignore[invalid-assignment]
+        self.pyenv_cfg["venvlauncher_command"] = self.interpreter.system_exe
 
 
 __all__ = [

--- a/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
+++ b/src/virtualenv/create/via_global_ref/builtin/pypy/common.py
@@ -22,7 +22,7 @@ class PyPy(ViaGlobalRefVirtualenvBuiltin, abc.ABC):
 
     @classmethod
     def _executables(cls, interpreter: PythonInfo) -> Generator[tuple[Path, list[str], str, str]]:
-        host = Path(interpreter.system_executable)  # ty: ignore[invalid-argument-type]
+        host = Path(interpreter.system_exe)
         targets = sorted(f"{name}{PyPy.suffix}" for name in cls.exe_names(interpreter))
         yield host, targets, RefMust.NA, RefWhen.ANY
 
@@ -48,7 +48,7 @@ class PyPy(ViaGlobalRefVirtualenvBuiltin, abc.ABC):
     @classmethod
     def _add_shared_libs(cls, interpreter: PythonInfo) -> Generator[Path]:
         # https://bitbucket.org/pypy/pypy/issue/1922/future-proofing-virtualenv
-        python_dir = Path(interpreter.system_executable).resolve().parent  # ty: ignore[invalid-argument-type]
+        python_dir = Path(interpreter.system_exe).resolve().parent
         yield from cls._shared_libs(python_dir)
 
     @classmethod

--- a/src/virtualenv/create/via_global_ref/builtin/rustpython/__init__.py
+++ b/src/virtualenv/create/via_global_ref/builtin/rustpython/__init__.py
@@ -34,7 +34,7 @@ class RustPython(ViaGlobalRefVirtualenvBuiltin, Python3Supports, ABC):
 
     @classmethod
     def _executables(cls, interpreter: PythonInfo) -> Generator[tuple[Path, list[str], RefMust, RefWhen], None, None]:  # ty: ignore[invalid-method-override]
-        host = Path(interpreter.system_executable)  # ty: ignore[invalid-argument-type]
+        host = Path(interpreter.system_exe)
         targets = sorted(f"{name}{cls.suffix}" for name in cls.exe_names(interpreter))
         yield host, targets, RefMust.NA, RefWhen.ANY
 

--- a/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
+++ b/src/virtualenv/create/via_global_ref/builtin/via_global_self_do.py
@@ -126,7 +126,7 @@ class ViaGlobalRefVirtualenvBuiltin(ViaGlobalRefApi, VirtualenvBuiltin, ABC):
         super().set_pyenv_cfg()
         self.pyenv_cfg["base-prefix"] = self.interpreter.system_prefix
         self.pyenv_cfg["base-exec-prefix"] = self.interpreter.system_exec_prefix
-        self.pyenv_cfg["base-executable"] = self.interpreter.system_executable  # ty: ignore[invalid-assignment]
+        self.pyenv_cfg["base-executable"] = self.interpreter.system_exe
 
 
 __all__ = [

--- a/src/virtualenv/create/via_global_ref/store.py
+++ b/src/virtualenv/create/via_global_ref/store.py
@@ -16,7 +16,7 @@ def handle_store_python(meta: ViaGlobalRefMeta, interpreter: PythonInfo) -> ViaG
 
 
 def is_store_python(interpreter: PythonInfo) -> bool:
-    parts = Path(interpreter.system_executable).parts  # ty: ignore[invalid-argument-type]
+    parts = Path(interpreter.system_exe).parts
     return (
         len(parts) > 4  # ruff:ignore[magic-value-comparison]
         and parts[-4] == "Microsoft"


### PR DESCRIPTION
`PythonInfo.system_executable` carries type `str | None`, since python-discovery cannot name the base interpreter of a virtual environment by inspection alone. `resolve_to_system()` walks the prefix chain and fills the field in, and discovery runs that before a creator sees the interpreter, so `None` does not reach this code. 🔍 The annotation cannot say so, which left twelve `ty: ignore` comments across the builtin creators and the store, each restating an invariant discovery had settled.

[python-discovery 1.6.0](https://github.com/tox-dev/python-discovery/pull/127) adds `system_exe`, a reader typed `str` that falls back to `executable`. ✨ Because `executable` carries type `str`, the suppressions disappear rather than moving upstream, and the fallback matches what `resolve_to_system()` writes when a prefix links back to its own interpreter. Reading it here lifts the minimum requirement from `1.4.2` to `1.6.0`.

Behavior holds, because the property returns the value these call sites read today. Two of the twelve reported `invalid-assignment` rather than `invalid-argument-type`, on the `base-executable` and `venvlauncher_command` keys written into `pyvenv.cfg`; that is the same gap wearing a different error code, and it clears the same way.
