### PR TITLE
📄 docs: document the interpreter names in an environment

### DIFF
--- a/docs/changelog/3225.doc.rst
+++ b/docs/changelog/3225.doc.rst
@@ -1,4 +1,3 @@
-Document the names the interpreter answers to inside a created environment. A new
-:doc:`reference/environment-layout` page lists them per platform, the tutorial and the usage guide point at it, and the
-explanation of creators covers why an environment carries several names and why Windows copies a redirector - by
-:user:`gaborbernat`.
+Document the names the interpreter answers to inside a created environment. A new :doc:`reference/environment-layout`
+page lists them per platform, the tutorial and the usage guide point at it, and the explanation of creators covers why
+an environment carries several names and why Windows copies a redirector - by :user:`gaborbernat`.

--- a/docs/changelog/3225.doc.rst
+++ b/docs/changelog/3225.doc.rst
@@ -1,0 +1,4 @@
+Document the names the interpreter answers to inside a created environment. A new
+:doc:`reference/environment-layout` page lists them per platform, the tutorial and the usage guide point at it, and the
+explanation of creators covers why an environment carries several names and why Windows copies a redirector - by
+:user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -328,7 +328,7 @@ venv creator otherwise.
 
 Whichever creator runs, the interpreter ends up reachable under several names, listed in
 :doc:`reference/environment-layout`. Tools reach for different ones - a shebang may say ``python``, a CI job may call
-``python3.14`` - and an environment offering only one of them would break the others. The builtin creators take the
+the versioned name - and an environment offering only one of them would break the others. The builtin creators take the
 version-bearing names from the target interpreter and add the host executable's own file name, so a host called
 ``pypy3.11`` or ``python_d.exe`` stays reachable under the name its callers already use.
 

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -326,6 +326,19 @@ Creators are responsible for constructing the virtual environment structure. vir
 virtualenv defaults to using the builtin creator if one is available for the target environment, falling back to the
 venv creator otherwise.
 
+Whichever creator runs, the interpreter ends up reachable under several names, listed in
+:doc:`reference/environment-layout`. Tools reach for different ones - a shebang may say ``python``, a CI job may call
+``python3.14`` - and an environment offering only one of them would break the others. The builtin creators take the
+version-bearing names from the target interpreter and add the host executable's own file name, so a host called
+``pypy3.11`` or ``python_d.exe`` stays reachable under the name its callers already use.
+
+Windows copies rather than symlinks, because symlinking the interpreter there is unreliable (`bpo-42013
+<https://bugs.python.org/issue42013>`_). From CPython 3.13 the file copied is the ``venvlauncher.exe`` redirector out of
+the host's standard library rather than the interpreter itself. The redirector reads ``pyvenv.cfg`` and hands off to the
+base prefix, which saves copying the DLLs and the standard library zip into every environment. Which name a copy carries
+makes no difference to where it lands, since the redirector resolves its target from a value compiled into it rather
+than from its own file name.
+
 *********
  Seeders
 *********

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -167,8 +167,8 @@ Use the environment without activating it by calling executables with their full
     $ venv/bin/python script.py
     $ venv/bin/pip install package
 
-``python3`` and ``python3.13`` reach the same interpreter, and on Windows the executables live in ``venv\Scripts`` under
-``.exe`` names. Reach for ``pythonw.exe`` there when you want a process without a console window.
+``python``, ``python3`` and the versioned name reach the same interpreter, and on Windows the executables live in
+``venv\Scripts`` under ``.exe`` names. Reach for ``pythonw.exe`` there when you want a process without a console window.
 :doc:`../reference/environment-layout` lists every name.
 
 Customize prompt

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -167,6 +167,10 @@ Use the environment without activating it by calling executables with their full
     $ venv/bin/python script.py
     $ venv/bin/pip install package
 
+``python3`` and ``python3.13`` reach the same interpreter, and on Windows the executables live in ``venv\Scripts`` under
+``.exe`` names. Reach for ``pythonw.exe`` there when you want a process without a console window.
+:doc:`../reference/environment-layout` lists every name.
+
 Customize prompt
 ================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,6 +115,7 @@ Learn more about virtualenv from these community resources:
 
     reference/compatibility
     reference/cli
+    reference/environment-layout
     reference/api
 
 .. toctree::

--- a/docs/reference/environment-layout.rst
+++ b/docs/reference/environment-layout.rst
@@ -6,21 +6,24 @@ The interpreter in a created environment answers to more than one name, so a scr
 keeps working. The names below are what the builtin creators write for CPython; PyPy, GraalPy and RustPython follow the
 same shape under their own executable names.
 
+``{minor}`` stands for the target interpreter's minor version, so ``python3.{minor}`` reads as ``python3.14`` for a
+CPython 3.14 target.
+
 *******
  POSIX
 *******
 
 ``bin`` holds one real reference to the host interpreter and links the rest to it:
 
-==================== =================================================================
+==================== ======================================================================
 Name                 Notes
-==================== =================================================================
+==================== ======================================================================
 ``python``           References the host interpreter.
 ``python3``          Alias.
-``python3.14``       Alias carrying the target's minor version.
-``python3.14t``      Free-threaded builds only.
-host executable name Appears when the host carries another name, such as ``pypy3.11``.
-==================== =================================================================
+``python3.{minor}``  Alias carrying the target's minor version.
+``python3.{minor}t`` Free-threaded builds only.
+host executable name Appears when the host carries another name, such as ``pypy3.{minor}``.
+==================== ======================================================================
 
 *********
  Windows
@@ -29,18 +32,18 @@ host executable name Appears when the host carries another name, such as ``pypy3
 ``Scripts`` holds copies rather than links, since symlinking the interpreter is unreliable there (`bpo-42013
 <https://bugs.python.org/issue42013>`_):
 
-==================== =====================================================================
-Name                 Notes
-==================== =====================================================================
-``python.exe``       References the host interpreter.
-``python3.exe``      Alias.
-``python3``          Alias without the extension.
-``python3.14t.exe``  Free-threaded builds only.
-``pythonw.exe``      Runs without opening a console window.
-``pythonw3.exe``     Alias for ``pythonw.exe``.
-``pythonw3.14t.exe`` Free-threaded builds only.
-host executable name Appears when the host carries another name, such as ``python_d.exe``.
-==================== =====================================================================
+========================= =====================================================================
+Name                      Notes
+========================= =====================================================================
+``python.exe``            References the host interpreter.
+``python3.exe``           Alias.
+``python3``               Alias without the extension.
+``python3.{minor}t.exe``  Free-threaded builds only.
+``pythonw.exe``           Runs without opening a console window.
+``pythonw3.exe``          Alias for ``pythonw.exe``.
+``pythonw3.{minor}t.exe`` Free-threaded builds only.
+host executable name      Appears when the host carries another name, such as ``python_d.exe``.
+========================= =====================================================================
 
 On CPython 3.13 and later ``python.exe`` holds a copy of the ``venvlauncher.exe`` redirector from the host's standard
 library rather than the interpreter binary, and ``pythonw.exe`` comes from ``venvwlauncher.exe``. The redirector reads

--- a/docs/reference/environment-layout.rst
+++ b/docs/reference/environment-layout.rst
@@ -1,0 +1,52 @@
+####################
+ Environment layout
+####################
+
+The interpreter in a created environment answers to more than one name, so a script or tool that hard-codes any of them
+keeps working. The names below are what the builtin creators write for CPython; PyPy, GraalPy and RustPython follow the
+same shape under their own executable names.
+
+*******
+ POSIX
+*******
+
+``bin`` holds one real reference to the host interpreter and links the rest to it:
+
+==================== =================================================================
+Name                 Notes
+==================== =================================================================
+``python``           References the host interpreter.
+``python3``          Alias.
+``python3.14``       Alias carrying the target's minor version.
+``python3.14t``      Free-threaded builds only.
+host executable name Appears when the host carries another name, such as ``pypy3.11``.
+==================== =================================================================
+
+*********
+ Windows
+*********
+
+``Scripts`` holds copies rather than links, since symlinking the interpreter is unreliable there (`bpo-42013
+<https://bugs.python.org/issue42013>`_):
+
+==================== =====================================================================
+Name                 Notes
+==================== =====================================================================
+``python.exe``       References the host interpreter.
+``python3.exe``      Alias.
+``python3``          Alias without the extension.
+``python3.14t.exe``  Free-threaded builds only.
+``pythonw.exe``      Runs without opening a console window.
+``pythonw3.exe``     Alias for ``pythonw.exe``.
+``pythonw3.14t.exe`` Free-threaded builds only.
+host executable name Appears when the host carries another name, such as ``python_d.exe``.
+==================== =====================================================================
+
+On CPython 3.13 and later ``python.exe`` holds a copy of the ``venvlauncher.exe`` redirector from the host's standard
+library rather than the interpreter binary, and ``pythonw.exe`` comes from ``venvwlauncher.exe``. The redirector reads
+``pyvenv.cfg`` and hands off to the interpreter in the base prefix, which is why the environment needs no copy of the
+DLLs. Its own file name stays out of ``Scripts``, matching what the standard library's ``venv`` writes.
+
+.. note::
+
+    ``--copies`` makes the POSIX layout use copies instead of links. The set of names does not change.

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -33,6 +33,15 @@ Let's create a virtual environment called ``myproject``:
 This creates a new directory called ``myproject`` containing a complete, isolated Python environment with its own copy
 of Python, pip, and other tools.
 
+The interpreter answers to several names, so a script expecting any of them keeps working inside the environment:
+
+.. code-block:: console
+
+    $ ls myproject/bin/python*
+    myproject/bin/python  myproject/bin/python3  myproject/bin/python3.13
+
+:doc:`../reference/environment-layout` lists the full set, which differs on Windows.
+
 **************************
  Activate the environment
 **************************


### PR DESCRIPTION
The docs show `venv/bin/python` and the activation scripts, and stop there. 📁 Nothing tells a reader that the interpreter also answers to `python3` and `python3.14`, that Windows writes `.exe` names into `Scripts` instead, or that `pythonw.exe` exists for running without a console window. A tool author picking a path to hard-code has to read the creator source to find out what is safe.

A new reference page, `Environment layout`, lists the names per platform and marks which ones appear only for free-threaded builds or for a host carrying its own name, such as `pypy3.11` or `python_d.exe`. The tutorial and the usage guide link to it from the two spots where a reader first runs an environment executable, and the creators section of the explanation covers why one environment carries several names, since a shebang saying `python` and a CI job calling `python3.14` both have to land.

That explanation also picks up the Windows story behind [#3223](https://github.com/pypa/virtualenv/pull/3223). Windows copies rather than symlinks because symlinking the interpreter there is unreliable ([bpo-42013](https://bugs.python.org/issue42013)), and from CPython 3.13 the copied file is the `venvlauncher.exe` redirector out of the host standard library rather than the interpreter, which is what lets the environment skip the DLLs and the standard library zip.
