### PR TITLE
fix(test): EncodingWarning: 'encoding' argument not specified

### DIFF
--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -98,7 +98,7 @@ def test_bash_activate_relocation_resolves_virtual_env(tmp_path, current_fastest
         capture_output=True,
         text=True,
         cwd=str(work_dir),
-        encoding = "utf-8"
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert result.stdout.strip() == str(relocated)

--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -98,6 +98,7 @@ def test_bash_activate_relocation_resolves_virtual_env(tmp_path, current_fastest
         capture_output=True,
         text=True,
         cwd=str(work_dir),
+        encoding = "utf-8"
     )
     assert result.returncode == 0
     assert result.stdout.strip() == str(relocated)

--- a/tests/unit/activation/test_fish.py
+++ b/tests/unit/activation/test_fish.py
@@ -77,7 +77,9 @@ def test_fish_prompt_survives_shadowed_source(activation_python, tmp_path) -> No
         f"cd '{start}'\nfunction . ; cd '{trap}' ; end\nsource '{script}'\nfish_prompt\necho \"PWD=$PWD\"\n",
         encoding="utf-8",
     )
-    out = subprocess.run([FISH, str(driver)], capture_output=True, text=True, timeout=60, check=True).stdout
+    out = subprocess.run(
+        [FISH, str(driver)], capture_output=True, text=True, encoding="utf-8", timeout=60, check=True
+    ).stdout
     assert f"PWD={start}\n" in out, out
 
 

--- a/tests/unit/activation/test_nushell.py
+++ b/tests/unit/activation/test_nushell.py
@@ -112,5 +112,7 @@ if ($r2.exit_code == 0) {{ error make {{ msg: "expected deactivate to fail for c
 if not ("not an active overlay" in $r2.stderr) {{ error make {{ msg: "overlay error missing" }} }}
 if not ("overlay hide NAME" in $r2.stderr) {{ error make {{ msg: "hint missing for custom name" }} }}
 """
-    result = subprocess.run([nu, "--commands", script], capture_output=True, text=True, timeout=60, check=False)
+    result = subprocess.run(
+        [nu, "--commands", script], capture_output=True, text=True, encoding="utf-8", timeout=60, check=False
+    )
     assert result.returncode == 0, result.stderr

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -824,7 +824,7 @@ def test_pyenv_cfg_preserves_symlinks(tmp_path) -> None:
     real_dir = tmp_path / "real_directory"
     real_dir.mkdir()
     real_file = real_dir / "some_file.txt"
-    real_file.write_text("test")
+    real_file.write_text("test", encoding="utf-8")
 
     symlink_dir = tmp_path / "symlink_directory"
     try:
@@ -839,7 +839,7 @@ def test_pyenv_cfg_preserves_symlinks(tmp_path) -> None:
     cfg["test_path"] = symlink_path
     cfg.write()
 
-    written_content = cfg_path.read_text()
+    written_content = cfg_path.read_text(encoding="utf-8")
     expected_abspath = os.path.abspath(symlink_path)
     expected_realpath = os.path.realpath(symlink_path)
 

--- a/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
+++ b/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py
@@ -269,7 +269,7 @@ def test_safe_extract_zip_allows_normal_entry(tmp_path: Path) -> None:
     with zipfile.ZipFile(str(archive)) as zip_ref:
         _safe_extract_zip(zip_ref, target)
 
-    assert (target / "pkg" / "inner.txt").read_text() == "payload"
+    assert (target / "pkg" / "inner.txt").read_text(encoding="utf-8") == "payload"
 
 
 def test_safe_extract_zip_rejects_parent_traversal(tmp_path: Path) -> None:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -33,7 +33,7 @@ def test_safe_delete_removes_read_only_files(tmp_path: Path) -> None:
     nested.mkdir(parents=True)
     # the wheel image marks its files read-only via set_tree, which on Windows blocks os.unlink
     marked = nested / "wheel.py"
-    marked.write_text("cached")
+    marked.write_text("cached", encoding="utf-8")
     marked.chmod(S_IREAD)
 
     safe_delete(target)
@@ -61,7 +61,7 @@ def test_safe_delete_raises_the_original_error_not_a_retry_failure(tmp_path: Pat
     target = tmp_path / "target"
     blocked = target / "sub"
     blocked.mkdir(parents=True)
-    (blocked / "wheel.py").write_text("cached")
+    (blocked / "wheel.py").write_text("cached", encoding="utf-8")
     blocked.chmod(0o000)  # rmtree reports this one through os.open, which takes more than a path
 
     try:
@@ -76,7 +76,7 @@ def test_safe_delete_keeps_the_other_mode_bits_when_clearing_read_only(tmp_path:
     target = tmp_path / "target"
     target.mkdir()
     blocked = target / "wheel.py"
-    blocked.write_text("cached")
+    blocked.write_text("cached", encoding="utf-8")
     blocked.chmod(S_IREAD | S_IRGRP)
     target.chmod(S_IREAD | S_IEXEC)  # the unlink fails, so the mode the handler left behind stays observable
 
@@ -125,7 +125,7 @@ class TestCacheDirMigration:
         old_dir = str(tmp_path / "old-data")
         new_dir = str(tmp_path / "new-cache")
         os.makedirs(old_dir)
-        (tmp_path / "old-data" / "test.txt").write_text("hello")
+        (tmp_path / "old-data" / "test.txt").write_text("hello", encoding="utf-8")
 
         monkeypatch.setattr("virtualenv.app_data.user_cache_dir", lambda **_kw: new_dir)
         monkeypatch.setattr("virtualenv.app_data.user_data_dir", lambda **_kw: old_dir)
@@ -134,7 +134,7 @@ class TestCacheDirMigration:
         assert result == new_dir
         assert os.path.isdir(new_dir)
         assert not os.path.isdir(old_dir)
-        assert (tmp_path / "new-cache" / "test.txt").read_text() == "hello"
+        assert (tmp_path / "new-cache" / "test.txt").read_text(encoding="utf-8") == "hello"
 
     def test_no_migration_when_old_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         old_dir = str(tmp_path / "old-data")
@@ -152,7 +152,7 @@ class TestCacheDirMigration:
         new_dir = str(tmp_path / "new-cache")
         os.makedirs(old_dir)
         os.makedirs(new_dir)
-        (tmp_path / "old-data" / "old.txt").write_text("old")
+        (tmp_path / "old-data" / "old.txt").write_text("old", encoding="utf-8")
 
         monkeypatch.setattr("virtualenv.app_data.user_cache_dir", lambda **_kw: new_dir)
         monkeypatch.setattr("virtualenv.app_data.user_data_dir", lambda **_kw: old_dir)
@@ -199,7 +199,7 @@ class TestCacheDirMigration:
         wheel_img = tmp_path / "old-data" / "wheel" / "3.12" / "image" / "pip"
         wheel_img.mkdir(parents=True)
         (wheel_img / "pip.dist-info").mkdir()
-        (wheel_img / "pip.dist-info" / "METADATA").write_text("Name: pip")
+        (wheel_img / "pip.dist-info" / "METADATA").write_text("Name: pip", encoding="utf-8")
 
         venv_dir = tmp_path / "my-venv" / "lib" / "site-packages"
         venv_dir.mkdir(parents=True)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -50,9 +50,9 @@ def test_safe_delete_surfaces_undeletable_entries(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.mkdir()
     busy = target / "busy.txt"
-    busy.write_text("x")
+    busy.write_text("x", encoding="utf-8")
 
-    with busy.open(), pytest.raises(OSError, match="busy"):
+    with busy.open(encoding="utf-8"), pytest.raises(OSError, match="busy"):
         safe_delete(target)
 
 


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation


Hello

When running the tests, I see warnings.
`(virtualenv) ➜  virtualenv git:(main) tox -e py315
...
...
....................s............................................................................................ss...sss......................ss...... [ 41%]
s.....s....s....................s.....s...............s.s..s.......................................................................................s... [ 83%] 
......................s............s........s.............                                                                                              [100%] 
====================================================================== warnings summary =======================================================================
tests/unit/test_util.py::test_safe_delete_raises_the_original_error_not_a_retry_failure
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/test_util.py:64: EncodingWarning: 'encoding' argument not specified
    (blocked / "wheel.py").write_text("cached")

tests/unit/test_util.py::test_safe_delete_keeps_the_other_mode_bits_when_clearing_read_only
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/test_util.py:79: EncodingWarning: 'encoding' argument not specified
    blocked.write_text("cached")

tests/unit/seed/embed/test_bootstrap_link_via_app_data.py::test_safe_extract_zip_allows_normal_entry
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/seed/embed/test_bootstrap_link_via_app_data.py:272: EncodingWarning: 'encoding' argument not specified
    assert (target / "pkg" / "inner.txt").read_text() == "payload"

tests/unit/test_util.py::test_safe_delete_removes_read_only_files
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/test_util.py:36: EncodingWarning: 'encoding' argument not specified
    marked.write_text("cached")

tests/unit/test_util.py::TestCacheDirMigration::test_migrate_old_to_new
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/test_util.py:128: EncodingWarning: 'encoding' argument not specified
    (tmp_path / "old-data" / "test.txt").write_text("hello")

tests/unit/test_util.py::TestCacheDirMigration::test_migrate_old_to_new
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/test_util.py:137: EncodingWarning: 'encoding' argument not specified
    assert (tmp_path / "new-cache" / "test.txt").read_text() == "hello"

tests/unit/test_util.py::TestCacheDirMigration::test_symlink_app_data_survives_migration[False]
tests/unit/test_util.py::TestCacheDirMigration::test_symlink_app_data_survives_migration[True]
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/test_util.py:202: EncodingWarning: 'encoding' argument not specified
    (wheel_img / "pip.dist-info" / "METADATA").write_text("Name: pip")

tests/unit/test_util.py::TestCacheDirMigration::test_no_migration_when_new_exists
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/test_util.py:155: EncodingWarning: 'encoding' argument not specified
    (tmp_path / "old-data" / "old.txt").write_text("old")

tests/unit/activation/test_bash.py::test_bash_activate_relocation_resolves_virtual_env
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/activation/test_bash.py:96: EncodingWarning: 'encoding' argument not specified.
    result = subprocess.run(

tests/unit/create/test_creator.py::test_pyenv_cfg_preserves_symlinks
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/create/test_creator.py:827: EncodingWarning: 'encoding' argument not specified
    real_file.write_text("test")

tests/unit/create/test_creator.py::test_pyenv_cfg_preserves_symlinks
  /Users/vyuroshchin/github_my/virtualenv/tests/unit/create/test_creator.py:842: EncodingWarning: 'encoding' argument not specified
    written_content = cfg_path.read_text()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------- generated xml file: /Users/vyuroshchin/github_my/virtualenv/.tox/junit.py315.xml ---------------------------------------
======================================================== 340 passed, 20 skipped, 12 warnings in 46.79s ========================================================
`

In PR I fixed this warnings like https://github.com/python-poetry/poetry/pull/8893/changes#diff-a1176a239bb3b9e9eb632f8f1090097a3630cea9f405da6b0506642e5343dd07R921 (add param encoding="utf-8" in tests)

