### PR TITLE
🐛 fix(config): ignore a config file that fails to parse instead of crashing

### DIFF
--- a/docs/changelog/3230.bugfix.rst
+++ b/docs/changelog/3230.bugfix.rst
@@ -1,0 +1,4 @@
+A ``virtualenv.ini`` that fails to parse no longer crashes every invocation with an ``AttributeError``; it is skipped
+with the error logged and ``--help`` reports it as ``failed to parse``. A UTF-8 byte order mark, which PowerShell 5 and
+older versions of Notepad write, is now tolerated in the config file instead of being treated as a missing section
+header - by :user:`darrenhuai`.

--- a/docs/changelog/3230.bugfix.rst
+++ b/docs/changelog/3230.bugfix.rst
@@ -1,4 +1,2 @@
-A ``virtualenv.ini`` that fails to parse no longer crashes every invocation with an ``AttributeError``; it is skipped
-with the error logged and ``--help`` reports it as ``failed to parse``. A UTF-8 byte order mark, which PowerShell 5 and
-older versions of Notepad write, is now tolerated in the config file instead of being treated as a missing section
-header - by :user:`darrenhuai`.
+Ignore malformed or unreadable ``virtualenv.ini`` files and report the error in the log and ``--help``. Accept a UTF-8
+byte order mark, as written by PowerShell 5 and older Notepad versions - by :user:`darrenhuai`.

--- a/src/virtualenv/config/ini.py
+++ b/src/virtualenv/config/ini.py
@@ -38,6 +38,7 @@ class IniConfig:
 
         exception = None
         self.has_config_file = None
+        self.has_virtualenv_section = False
         try:
             self.has_config_file = self.config_file.exists()
         except OSError as exc:
@@ -50,12 +51,13 @@ class IniConfig:
                     self._load()
                     self.has_virtualenv_section = self.config_parser.has_section(self.section)
                 except Exception as exc:  # ruff:ignore[blind-except]
+                    self.has_config_file = None  # mark it failed to parse, so the config is ignored
                     exception = exc
         if exception is not None:
             LOGGER.error("failed to read config file %s because %r", config_file, exception)
 
     def _load(self) -> None:
-        with self.config_file.open("rt", encoding="utf-8") as file_handler:
+        with self.config_file.open("rt", encoding="utf-8-sig") as file_handler:
             return self.config_parser.read_file(file_handler)
 
     def get(self, key: str, as_type: TypeData) -> tuple[Any, str] | None:

--- a/src/virtualenv/config/ini.py
+++ b/src/virtualenv/config/ini.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import os
-from configparser import ConfigParser
+from configparser import ConfigParser, Error
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Final
 
 from platformdirs import user_config_dir
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from .convert import TypeData
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 class IniConfig:
@@ -36,25 +36,21 @@ class IniConfig:
         self.config_file = config_file
         self._cache = {}
 
-        exception = None
-        self.has_config_file = None
+        self.has_config_file: bool | None = None
         self.has_virtualenv_section = False
+        self.config_parser: Final[ConfigParser] = ConfigParser()
+        exception = None
         try:
             self.has_config_file = self.config_file.exists()
-        except OSError as exc:
-            exception = exc
-        else:
             if self.has_config_file:
                 self.config_file = self.config_file.resolve()
-                self.config_parser = ConfigParser()
-                try:
-                    self._load()
-                    self.has_virtualenv_section = self.config_parser.has_section(self.section)
-                except Exception as exc:  # ruff:ignore[blind-except]
-                    self.has_config_file = None  # mark it failed to parse, so the config is ignored
-                    exception = exc
+                self._load()
+                self.has_virtualenv_section = self.config_parser.has_section(self.section)
+        except (OSError, UnicodeError, Error) as exc:
+            self.has_config_file = None
+            exception = exc
         if exception is not None:
-            LOGGER.error("failed to read config file %s because %r", config_file, exception)
+            _LOGGER.error("failed to read config file %s because %r", config_file, exception)
 
     def _load(self) -> None:
         with self.config_file.open("rt", encoding="utf-8-sig") as file_handler:
@@ -83,3 +79,6 @@ class IniConfig:
             f"\nconfig file {self.config_file} {self.STATE[self.has_config_file]} "
             f"(change{'d' if self.is_env_var else ''} via env var {self.VIRTUALENV_CONFIG_FILE_ENV_VAR})"
         )
+
+
+__all__ = ["IniConfig"]

--- a/tests/unit/config/test_ini.py
+++ b/tests/unit/config/test_ini.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import codecs
+import logging
 import sys
 from textwrap import dedent
 
 import pytest
 
+from virtualenv.config.ini import IniConfig
 from virtualenv.info import IS_PYPY, IS_WIN, fs_supports_symlink
 from virtualenv.run import session_via_cli
 
@@ -32,3 +35,41 @@ def test_ini_can_be_overwritten_by_flag(tmp_path, monkeypatch) -> None:
 
     symlinks = result.creator.symlinks
     assert symlinks is True
+
+
+def test_ini_that_fails_to_parse_is_ignored(tmp_path, caplog) -> None:
+    bad_ini = tmp_path / "conf.ini"
+    bad_ini.write_text("this line has no section header\n", encoding="utf-8")
+
+    config = IniConfig(env={"VIRTUALENV_CONFIG_FILE": str(bad_ini)})
+
+    assert bool(config) is False
+    assert config.has_virtualenv_section is False
+    assert "failed to parse" in config.epilog
+    assert any("failed to read config file" in r.message for r in caplog.records if r.levelno == logging.ERROR)
+
+
+def test_ini_that_fails_to_parse_does_not_break_the_cli(tmp_path, monkeypatch) -> None:
+    bad_ini = tmp_path / "conf.ini"
+    bad_ini.write_text("this line has no section header\n", encoding="utf-8")
+    monkeypatch.setenv("VIRTUALENV_CONFIG_FILE", str(bad_ini))
+
+    result = session_via_cli(["venv"])  # the config is ignored, defaults apply
+
+    assert result.creator.clear is False
+
+
+def test_ini_with_utf8_bom_is_read(tmp_path, monkeypatch) -> None:
+    custom_ini = tmp_path / "conf.ini"
+    content = dedent(
+        """
+        [virtualenv]
+        clear = True
+        """,
+    )
+    custom_ini.write_bytes(codecs.BOM_UTF8 + content.encode("utf-8"))  # how Notepad and PowerShell 5 write UTF-8
+    monkeypatch.setenv("VIRTUALENV_CONFIG_FILE", str(custom_ini))
+
+    result = session_via_cli(["venv"])
+
+    assert result.creator.clear is True

--- a/tests/unit/config/test_ini.py
+++ b/tests/unit/config/test_ini.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 import codecs
 import logging
 import sys
-from textwrap import dedent
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, cast
 
 import pytest
 
 from virtualenv.config.ini import IniConfig
 from virtualenv.info import IS_PYPY, IS_WIN, fs_supports_symlink
 from virtualenv.run import session_via_cli
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from virtualenv.create.via_global_ref.api import ViaGlobalRefApi
 
 
 @pytest.mark.skipif(not fs_supports_symlink(), reason="symlink is not supported")
@@ -18,58 +24,69 @@ from virtualenv.run import session_via_cli
     IS_PYPY and IS_WIN and sys.version_info[0:2] >= (3, 9),
     reason="symlink is not supported",
 )
-def test_ini_can_be_overwritten_by_flag(tmp_path, monkeypatch) -> None:
-    custom_ini = tmp_path / "conf.ini"
-    custom_ini.write_text(
-        dedent(
-            """
-        [virtualenv]
-        copies = True
-        """,
-        ),
-        encoding="utf-8",
-    )
+def test_ini_can_be_overwritten_by_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    custom_ini: Final[Path] = tmp_path / "conf.ini"
+    custom_ini.write_text("[virtualenv]\ncopies = True\n", encoding="utf-8")
     monkeypatch.setenv("VIRTUALENV_CONFIG_FILE", str(custom_ini))
 
-    result = session_via_cli(["venv", "--symlinks"])
-
-    symlinks = result.creator.symlinks
-    assert symlinks is True
+    assert cast("ViaGlobalRefApi", session_via_cli(["venv", "--symlinks"]).creator).symlinks is True
 
 
-def test_ini_that_fails_to_parse_is_ignored(tmp_path, caplog) -> None:
-    bad_ini = tmp_path / "conf.ini"
-    bad_ini.write_text("this line has no section header\n", encoding="utf-8")
-
-    config = IniConfig(env={"VIRTUALENV_CONFIG_FILE": str(bad_ini)})
-
-    assert bool(config) is False
-    assert config.has_virtualenv_section is False
-    assert "failed to parse" in config.epilog
-    assert any("failed to read config file" in r.message for r in caplog.records if r.levelno == logging.ERROR)
+def test_ini_that_fails_to_parse_is_ignored(invalid_ini: Path) -> None:
+    config: Final[IniConfig] = IniConfig(env={"VIRTUALENV_CONFIG_FILE": str(invalid_ini)})
+    assert (bool(config), config.has_virtualenv_section) == (False, False)
 
 
-def test_ini_that_fails_to_parse_does_not_break_the_cli(tmp_path, monkeypatch) -> None:
-    bad_ini = tmp_path / "conf.ini"
-    bad_ini.write_text("this line has no section header\n", encoding="utf-8")
-    monkeypatch.setenv("VIRTUALENV_CONFIG_FILE", str(bad_ini))
-
-    result = session_via_cli(["venv"])  # the config is ignored, defaults apply
-
-    assert result.creator.clear is False
-
-
-def test_ini_with_utf8_bom_is_read(tmp_path, monkeypatch) -> None:
-    custom_ini = tmp_path / "conf.ini"
-    content = dedent(
-        """
-        [virtualenv]
-        clear = True
-        """,
+def test_ini_that_fails_to_parse_is_reported(invalid_ini: Path) -> None:
+    config: Final[IniConfig] = IniConfig(env={"VIRTUALENV_CONFIG_FILE": str(invalid_ini)})
+    assert config.epilog == (
+        f"\nconfig file {invalid_ini.resolve()} failed to parse (changed via env var VIRTUALENV_CONFIG_FILE)"
     )
-    custom_ini.write_bytes(codecs.BOM_UTF8 + content.encode("utf-8"))  # how Notepad and PowerShell 5 write UTF-8
-    monkeypatch.setenv("VIRTUALENV_CONFIG_FILE", str(custom_ini))
 
-    result = session_via_cli(["venv"])
 
-    assert result.creator.clear is True
+def test_ini_that_fails_to_parse_is_logged(invalid_ini: Path, caplog: pytest.LogCaptureFixture) -> None:
+    IniConfig(env={"VIRTUALENV_CONFIG_FILE": str(invalid_ini)})
+    assert [(record.levelno, record.message.split(" because ")[0]) for record in caplog.records] == [
+        (logging.ERROR, f"failed to read config file {invalid_ini}")
+    ]
+
+
+def test_ini_that_fails_to_parse_does_not_break_the_cli(invalid_ini: Path) -> None:
+    assert session_via_cli(["venv"], env={"VIRTUALENV_CONFIG_FILE": str(invalid_ini)}).creator.clear is False
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(b"no section header\n", id="missing-header"),
+        pytest.param(b"[virtualenv]\nclear = True\ninvalid\n", id="partial-parse"),
+        pytest.param(b"[virtualenv]\nclear = True\nclear = False\n", id="duplicate-option"),
+        pytest.param(b"[virtualenv]\nclear = True\n[virtualenv]\n", id="duplicate-section"),
+        pytest.param(b"[virtualenv]\nclear = True\n\xff", id="invalid-utf8"),
+    ]
+)
+def invalid_ini(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
+    config_file: Final[Path] = tmp_path / "conf.ini"
+    config_file.write_bytes(request.param)
+    return config_file
+
+
+@pytest.mark.parametrize(
+    "method",
+    [pytest.param("exists", id="stat"), pytest.param("resolve", id="resolve"), pytest.param("open", id="read")],
+)
+def test_ini_filesystem_error_is_ignored(tmp_path: Path, mocker: MockerFixture, method: str) -> None:
+    config_file: Final[Path] = tmp_path / "conf.ini"
+    config_file.write_text("[virtualenv]\nclear = True\n", encoding="utf-8")
+    mocker.patch.object(Path, method, autospec=True, side_effect=PermissionError("access denied"))
+
+    config: Final[IniConfig] = IniConfig(env={"VIRTUALENV_CONFIG_FILE": str(config_file)})
+
+    assert (bool(config), config.has_config_file, config.has_virtualenv_section) == (False, None, False)
+
+
+@pytest.mark.parametrize("prefix", [pytest.param(b"", id="utf8"), pytest.param(codecs.BOM_UTF8, id="utf8-bom")])
+def test_ini_utf8_is_read(tmp_path: Path, prefix: bytes) -> None:
+    config_file: Final[Path] = tmp_path / "conf.ini"
+    config_file.write_bytes(prefix + b"[virtualenv]\nclear = True\n")
+
+    assert session_via_cli(["venv"], env={"VIRTUALENV_CONFIG_FILE": str(config_file)}).creator.clear is True

--- a/tests/unit/config/test_ini.py
+++ b/tests/unit/config/test_ini.py
@@ -51,8 +51,10 @@ def test_ini_that_fails_to_parse_is_logged(invalid_ini: Path, caplog: pytest.Log
     ]
 
 
-def test_ini_that_fails_to_parse_does_not_break_the_cli(invalid_ini: Path) -> None:
-    assert session_via_cli(["venv"], env={"VIRTUALENV_CONFIG_FILE": str(invalid_ini)}).creator.clear is False
+def test_ini_that_fails_to_parse_does_not_break_the_cli(invalid_ini: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VIRTUALENV_CONFIG_FILE", str(invalid_ini))
+
+    assert session_via_cli(["venv"]).creator.clear is False
 
 
 @pytest.fixture(
@@ -85,8 +87,9 @@ def test_ini_filesystem_error_is_ignored(tmp_path: Path, mocker: MockerFixture, 
 
 
 @pytest.mark.parametrize("prefix", [pytest.param(b"", id="utf8"), pytest.param(codecs.BOM_UTF8, id="utf8-bom")])
-def test_ini_utf8_is_read(tmp_path: Path, prefix: bytes) -> None:
+def test_ini_utf8_is_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, prefix: bytes) -> None:
     config_file: Final[Path] = tmp_path / "conf.ini"
     config_file.write_bytes(prefix + b"[virtualenv]\nclear = True\n")
+    monkeypatch.setenv("VIRTUALENV_CONFIG_FILE", str(config_file))
 
-    assert session_via_cli(["venv"], env={"VIRTUALENV_CONFIG_FILE": str(config_file)}).creator.clear is True
+    assert session_via_cli(["venv"]).creator.clear is True


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

---

`IniConfig.__init__` is written to survive a config file it cannot parse: it catches the exception, logs `failed to read config file ... because ...`, and there is a `"failed to parse"` entry in `STATE` for the help epilog. But `has_virtualenv_section` is only assigned after a successful `_load()`, and `__bool__` reads it unconditionally:

```python
def __bool__(self) -> bool:
    return bool(self.has_config_file) and bool(self.has_virtualenv_section)
```

`VirtualEnvConfigParser._fix_defaults` evaluates `if outcome is None and self.file_config:` for every option, so the first one without an env var override blows up. Any `virtualenv.ini` that `configparser` rejects takes every invocation down, right after the log line saying the file would be ignored:

```
$ printf '\xef\xbb\xbf[virtualenv]\nclear = True\n' > bom.ini
$ VIRTUALENV_CONFIG_FILE=bom.ini virtualenv --help
failed to read config file bom.ini because MissingSectionHeaderError('File contains no section headers.\nfile: ...bom.ini, line: 1\n\'\ufeff[virtualenv]\n\'')
Traceback (most recent call last):
  ...
  File "src/virtualenv/config/cli/parser.py", line 110, in _fix_defaults
    if outcome is None and self.file_config:
  File "src/virtualenv/config/ini.py", line 76, in __bool__
    return bool(self.has_config_file) and bool(self.has_virtualenv_section)
AttributeError: 'IniConfig' object has no attribute 'has_virtualenv_section'
```

The `"failed to parse"` epilog state was unreachable for the same reason; a file that failed to parse still reported itself as `active`.

The BOM above is the way I expect people actually hit this. On Windows, `Out-File -Encoding utf8` in PowerShell 5 and older versions of Notepad both write a UTF-8 BOM, and `configparser` then sees `\ufeff[virtualenv]` as a line outside any section. A stray line inside the section or a missing header fail the same way.

Three changes in `IniConfig`:

- initialise `has_virtualenv_section = False` before trying to load, so `__bool__` is always answerable
- on a parse exception set `has_config_file = None`, which is the state `STATE` already reserves for `"failed to parse"`; the config is then skipped and `--help` says why instead of `active`
- open the file with `utf-8-sig` so a BOM is stripped rather than fatal; it is a no-op for files without one

With the fix the three files above all produce a working `--help`. The BOM one is parsed normally (`clear = True` takes effect), and the other two are ignored with the error logged and the epilog reading `config file ... failed to parse`.

Three tests: a bad file is ignored and reported (`bool(config)` is `False`, the epilog says `failed to parse`, the error is logged), a bad file does not break `session_via_cli`, and a BOM-prefixed file is read. All three fail on `main`, and I checked that reverting each of the three source lines individually makes exactly one of them fail. `tests/unit` is 314 passed / 40 skipped on Windows 3.14; `ruff` and `ty check src/virtualenv` are clean.
