### PR TITLE
🐛 fix(create): skip blank and comment lines in pyvenv.cfg

### DIFF
--- a/docs/changelog/3232.bugfix.rst
+++ b/docs/changelog/3232.bugfix.rst
@@ -1,0 +1,2 @@
+Skip blank lines, comments and lines without ``=`` when reading ``pyvenv.cfg``, matching how CPython parses it, instead
+of failing with ``ValueError`` - by :user:`r3wretrhy`.

--- a/src/virtualenv/create/pyenv_cfg.py
+++ b/src/virtualenv/create/pyenv_cfg.py
@@ -29,9 +29,11 @@ class PyEnvCfg:
     def _read_values(path: Path) -> OrderedDict[str, str]:
         content = OrderedDict()
         for line in path.read_text(encoding="utf-8").splitlines():
-            equals_at = line.index("=")
-            key = line[:equals_at].strip()
-            value = line[equals_at + 1 :].strip()
+            key, separator, value = line.partition("=")
+            key = key.strip()
+            if not separator or key.startswith("#"):
+                continue
+            value = value.strip()
             if len(value) > 1 and value[0] in {"'", '"'} and value[0] == value[-1]:
                 value = value[1:-1]
             content[key] = value

--- a/tests/unit/create/test_creator.py
+++ b/tests/unit/create/test_creator.py
@@ -874,3 +874,18 @@ def test_pyenv_cfg_preserves_symlinks(tmp_path) -> None:
 
     assert f"test_path = {expected_abspath}" in written_content
     assert expected_abspath != expected_realpath, "Test setup error: paths should differ for symlinks"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        pytest.param("\n\nhome = /a\n", {"home": "/a"}, id="blank-line"),
+        pytest.param("# home = /b\nhome = /a\n", {"home": "/a"}, id="comment"),
+        pytest.param("no-separator\nhome = /a\n", {"home": "/a"}, id="no-separator"),
+        pytest.param('home = /a\nprompt = "a b"\n', {"home": "/a", "prompt": "a b"}, id="quoted-value"),
+    ],
+)
+def test_pyenv_cfg_read_values(tmp_path, text, expected) -> None:
+    (tmp_path / "pyvenv.cfg").write_text(text, encoding="utf-8")
+
+    assert PyEnvCfg.from_folder(tmp_path).content == expected


### PR DESCRIPTION
`PyEnvCfg._read_values` called `line.index("=")` on each line of `pyvenv.cfg`, so a blank line, a `#` comment or a line
without `=` raised `ValueError` when virtualenv read the file of an existing environment.

The parser now skips those lines. `test_pyenv_cfg_from_folder_skips_non_entries` in `tests/unit/create/test_creator.py`
covers each case and fails on `main`.
