### PR TITLE
🐛 fix(activation): keep and restore the user's TCL_LIBRARY and TK_LIBRARY

### DIFF
--- a/docs/changelog/3234.bugfix.rst
+++ b/docs/changelog/3234.bugfix.rst
@@ -1,0 +1,4 @@
+Activation now saves and restores the user's ``TCL_LIBRARY`` and ``TK_LIBRARY`` in the bash, fish and PowerShell
+scripts. PowerShell (and fish, for interpreters with tcl) removed the user's values on activation and again on
+``deactivate``; bash left the value it set behind after ``deactivate`` when the variable had been unset before - by
+:user:`darrenhuai`.

--- a/src/virtualenv/activation/bash/activate.sh
+++ b/src/virtualenv/activation/bash/activate.sh
@@ -22,14 +22,22 @@ deactivate () {
         unset _OLD_VIRTUAL_PYTHONHOME
     fi
 
-    if [ -n "${_OLD_VIRTUAL_TCL_LIBRARY:-}" ]; then
-        TCL_LIBRARY="$_OLD_VIRTUAL_TCL_LIBRARY"
-        export TCL_LIBRARY
+    if [ -n "${_OLD_VIRTUAL_TCL_LIBRARY+x}" ]; then
+        if [ -n "$_OLD_VIRTUAL_TCL_LIBRARY" ]; then
+            TCL_LIBRARY="$_OLD_VIRTUAL_TCL_LIBRARY"
+            export TCL_LIBRARY
+        else
+            unset TCL_LIBRARY
+        fi
         unset _OLD_VIRTUAL_TCL_LIBRARY
     fi
-    if [ -n "${_OLD_VIRTUAL_TK_LIBRARY:-}" ]; then
-        TK_LIBRARY="$_OLD_VIRTUAL_TK_LIBRARY"
-        export TK_LIBRARY
+    if [ -n "${_OLD_VIRTUAL_TK_LIBRARY+x}" ]; then
+        if [ -n "$_OLD_VIRTUAL_TK_LIBRARY" ]; then
+            TK_LIBRARY="$_OLD_VIRTUAL_TK_LIBRARY"
+            export TK_LIBRARY
+        else
+            unset TK_LIBRARY
+        fi
         unset _OLD_VIRTUAL_TK_LIBRARY
     fi
     if [ -n "${_OLD_PKG_CONFIG_PATH:-}" ]; then
@@ -96,18 +104,15 @@ if [ -n "${PYTHONHOME:-}" ] ; then
     unset PYTHONHOME
 fi
 
+# saved even when empty, so deactivate knows to unset the value set here
 if [ __TCL_LIBRARY__ != "" ]; then
-    if [ -n "${TCL_LIBRARY:-}" ] ; then
-        _OLD_VIRTUAL_TCL_LIBRARY="$TCL_LIBRARY"
-    fi
+    _OLD_VIRTUAL_TCL_LIBRARY="${TCL_LIBRARY:-}"
     TCL_LIBRARY=__TCL_LIBRARY__
     export TCL_LIBRARY
 fi
 
 if [ __TK_LIBRARY__ != "" ]; then
-    if [ -n "${TK_LIBRARY:-}" ] ; then
-        _OLD_VIRTUAL_TK_LIBRARY="$TK_LIBRARY"
-    fi
+    _OLD_VIRTUAL_TK_LIBRARY="${TK_LIBRARY:-}"
     TK_LIBRARY=__TK_LIBRARY__
     export TK_LIBRARY
 fi

--- a/src/virtualenv/activation/fish/activate.fish
+++ b/src/virtualenv/activation/fish/activate.fish
@@ -8,21 +8,21 @@ function deactivate -d 'Exit virtualenv mode and return to the normal environmen
         set -e _OLD_VIRTUAL_PATH
     end
 
-    if test -n __TCL_LIBRARY__
-      if test -n "$_OLD_VIRTUAL_TCL_LIBRARY";
-        set -gx TCL_LIBRARY "$_OLD_VIRTUAL_TCL_LIBRARY";
-        set -e _OLD_VIRTUAL_TCL_LIBRARY;
-      else;
-        set -e TCL_LIBRARY;
-      end
+    if set -q _OLD_VIRTUAL_TCL_LIBRARY
+        if test -n "$_OLD_VIRTUAL_TCL_LIBRARY"
+            set -gx TCL_LIBRARY "$_OLD_VIRTUAL_TCL_LIBRARY"
+        else
+            set -e TCL_LIBRARY
+        end
+        set -e _OLD_VIRTUAL_TCL_LIBRARY
     end
-    if test -n __TK_LIBRARY__
-      if test -n "$_OLD_VIRTUAL_TK_LIBRARY";
-        set -gx TK_LIBRARY "$_OLD_VIRTUAL_TK_LIBRARY";
-        set -e _OLD_VIRTUAL_TK_LIBRARY;
-      else;
-        set -e TK_LIBRARY;
-      end
+    if set -q _OLD_VIRTUAL_TK_LIBRARY
+        if test -n "$_OLD_VIRTUAL_TK_LIBRARY"
+            set -gx TK_LIBRARY "$_OLD_VIRTUAL_TK_LIBRARY"
+        else
+            set -e TK_LIBRARY
+        end
+        set -e _OLD_VIRTUAL_TK_LIBRARY
     end
 
     if test -n "$_OLD_PKG_CONFIG_PATH"
@@ -71,16 +71,13 @@ set -gx PKG_CONFIG_PATH "$VIRTUAL_ENV/lib/pkgconfig:$PKG_CONFIG_PATH"
 set -gx _OLD_VIRTUAL_PATH $PATH
 set -gx PATH "$VIRTUAL_ENV"'/'__BIN_NAME__ $PATH
 
+# Saved even when unset, so deactivate knows to erase the value set here.
 if test -n __TCL_LIBRARY__
-  if set -q TCL_LIBRARY;
-    set -gx _OLD_VIRTUAL_TCL_LIBRARY $TCL_LIBRARY;
-  end
+  set -gx _OLD_VIRTUAL_TCL_LIBRARY "$TCL_LIBRARY"
   set -gx TCL_LIBRARY '__TCL_LIBRARY__'
 end
 if test -n __TK_LIBRARY__
-  if set -q TK_LIBRARY;
-    set -gx _OLD_VIRTUAL_TK_LIBRARY $TK_LIBRARY;
-  end
+  set -gx _OLD_VIRTUAL_TK_LIBRARY "$TK_LIBRARY"
   set -gx TK_LIBRARY '__TK_LIBRARY__'
 end
 

--- a/src/virtualenv/activation/powershell/activate.ps1
+++ b/src/virtualenv/activation/powershell/activate.ps1
@@ -97,19 +97,11 @@ function global:deactivate([switch] $NonDestructive) {
     if (Test-Path variable:_OLD_VIRTUAL_TCL_LIBRARY) {
         $env:TCL_LIBRARY = $variable:_OLD_VIRTUAL_TCL_LIBRARY
         Remove-Variable "_OLD_VIRTUAL_TCL_LIBRARY" -Scope global
-    } else {
-        if (Test-Path env:TCL_LIBRARY) {
-            Remove-Item env:TCL_LIBRARY -ErrorAction SilentlyContinue
-        }
     }
 
     if (Test-Path variable:_OLD_VIRTUAL_TK_LIBRARY) {
         $env:TK_LIBRARY = $variable:_OLD_VIRTUAL_TK_LIBRARY
         Remove-Variable "_OLD_VIRTUAL_TK_LIBRARY" -Scope global
-    } else {
-        if (Test-Path env:TK_LIBRARY) {
-            Remove-Item env:TK_LIBRARY -ErrorAction SilentlyContinue
-        }
     }
 
     if (Test-Path variable:_OLD_PKG_CONFIG_PATH) {
@@ -176,17 +168,14 @@ deactivate -nondestructive
 $env:VIRTUAL_ENV = $VenvDir
 $env:VIRTUAL_ENV_PROMPT = $Prompt
 
+# Saved even when unset ($null), so deactivate knows to remove the value set here.
 if (__TCL_LIBRARY__ -ne "") {
-    if (Test-Path env:TCL_LIBRARY) {
-        New-Variable -Scope global -Name _OLD_VIRTUAL_TCL_LIBRARY -Value $env:TCL_LIBRARY
-    }
+    New-Variable -Scope global -Name _OLD_VIRTUAL_TCL_LIBRARY -Value $env:TCL_LIBRARY
     $env:TCL_LIBRARY = __TCL_LIBRARY__
 }
 
 if (__TK_LIBRARY__ -ne "") {
-    if (Test-Path env:TK_LIBRARY) {
-        New-Variable -Scope global -Name _OLD_VIRTUAL_TK_LIBRARY -Value $env:TK_LIBRARY
-    }
+    New-Variable -Scope global -Name _OLD_VIRTUAL_TK_LIBRARY -Value $env:TK_LIBRARY
     $env:TK_LIBRARY = __TK_LIBRARY__
 }
 

--- a/tests/unit/activation/test_bash.py
+++ b/tests/unit/activation/test_bash.py
@@ -155,3 +155,43 @@ def test_bash(raise_on_non_source_class, hashing_enabled, activation_tester) -> 
             return 'printf "%s\\n" "$PS1"'
 
     activation_tester(Bash)
+
+
+@pytest.mark.skipif(IS_WIN, reason="Github Actions ships with WSL bash")
+@pytest.mark.parametrize("venv_sets_tcl", [True, False])
+@pytest.mark.parametrize("was_set", [True, False])
+def test_bash_deactivate_restores_tcl_tk_library(tmp_path, venv_sets_tcl, was_set) -> None:
+    class MockInterpreter:
+        pass
+
+    interpreter = MockInterpreter()
+    interpreter.tcl_lib = str(tmp_path / "venv-tcl") if venv_sets_tcl else None
+    interpreter.tk_lib = str(tmp_path / "venv-tk") if venv_sets_tcl else None
+
+    class MockCreator:
+        def __init__(self, dest) -> None:
+            self.dest = dest
+            self.bin_dir = dest / "bin"
+            self.bin_dir.mkdir(parents=True)
+            self.interpreter = interpreter
+            self.pyenv_cfg = {}
+            self.env_name = "env"
+
+    creator = MockCreator(tmp_path / "env")
+    BashActivator(Namespace(prompt=None)).generate(creator)
+
+    setup = "export TCL_LIBRARY=user-tcl TK_LIBRARY=user-tk" if was_set else "unset TCL_LIBRARY TK_LIBRARY"
+    show = 'printf "%s\\n" "${TCL_LIBRARY-None}" "${TK_LIBRARY-None}"'
+    script = shlex.quote(str(creator.bin_dir / "activate"))
+    result = subprocess.run(
+        ["bash", "-c", f"{setup}; source {script} && {show} && deactivate && {show}"],
+        capture_output=True,
+        encoding="utf-8",
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    before = ["user-tcl", "user-tk"] if was_set else ["None", "None"]
+    activated = [interpreter.tcl_lib, interpreter.tk_lib] if venv_sets_tcl else before
+    # activation must not drop a value it does not replace, and deactivate puts back what was there
+    assert result.stdout.splitlines() == [*activated, *before], result.stdout

--- a/tests/unit/activation/test_fish.py
+++ b/tests/unit/activation/test_fish.py
@@ -57,8 +57,8 @@ def test_fish_tkinter_generation(tmp_path, tcl_lib, tk_lib, present) -> None:
         assert "set -gx TCL_LIBRARY '/path/to/tcl'" in content
         assert "set -gx TK_LIBRARY '/path/to/tk'" in content
     else:
-        assert "if test -n ''\n  if set -q TCL_LIBRARY;" in content
-        assert "if test -n ''\n  if set -q TK_LIBRARY;" in content
+        assert "if test -n ''\n  set -gx _OLD_VIRTUAL_TCL_LIBRARY" in content
+        assert "if test -n ''\n  set -gx _OLD_VIRTUAL_TK_LIBRARY" in content
 
 
 @pytest.mark.skipif(IS_WIN, reason="fish is not available on Windows")
@@ -81,6 +81,47 @@ def test_fish_prompt_survives_shadowed_source(activation_python, tmp_path) -> No
         [FISH, str(driver)], capture_output=True, text=True, encoding="utf-8", timeout=60, check=True
     ).stdout
     assert f"PWD={start}\n" in out, out
+
+
+@pytest.mark.skipif(IS_WIN, reason="fish is not available on Windows")
+@pytest.mark.skipif(FISH is None, reason="fish is not installed")
+@pytest.mark.parametrize("venv_sets_tcl", [True, False])
+@pytest.mark.parametrize("was_set", [True, False])
+def test_fish_deactivate_restores_tcl_tk_library(tmp_path, venv_sets_tcl, was_set) -> None:
+    class MockInterpreter:
+        pass
+
+    interpreter = MockInterpreter()
+    interpreter.tcl_lib = str(tmp_path / "venv-tcl") if venv_sets_tcl else None
+    interpreter.tk_lib = str(tmp_path / "venv-tk") if venv_sets_tcl else None
+
+    class MockCreator:
+        def __init__(self, dest) -> None:
+            self.dest = dest
+            self.bin_dir = dest / "bin"
+            self.bin_dir.mkdir(parents=True)
+            self.interpreter = interpreter
+            self.pyenv_cfg = {}
+            self.env_name = "env"
+
+    creator = MockCreator(tmp_path / "env")
+    FishActivator(Namespace(prompt=None)).generate(creator)
+
+    setup = "set -gx TCL_LIBRARY user-tcl; set -gx TK_LIBRARY user-tk" if was_set else "set -e TCL_LIBRARY TK_LIBRARY"
+    show = "for name in TCL_LIBRARY TK_LIBRARY; if set -q $name; echo $$name; else; echo None; end; end"
+    driver = tmp_path / "driver.fish"
+    driver.write_text(
+        f"{setup}\nsource '{creator.bin_dir / 'activate.fish'}'\n{show}\ndeactivate\n{show}\n",
+        encoding="utf-8",
+    )
+    out = subprocess.run(
+        [FISH, str(driver)], capture_output=True, text=True, encoding="utf-8", timeout=60, check=True
+    ).stdout
+
+    before = ["user-tcl", "user-tk"] if was_set else ["None", "None"]
+    activated = [interpreter.tcl_lib, interpreter.tk_lib] if venv_sets_tcl else before
+    # activation must not drop a value it does not replace, and deactivate puts back what was there
+    assert out.splitlines() == [*activated, *before], out
 
 
 @pytest.mark.skipif(IS_WIN, reason="we have not setup fish in CI yet")

--- a/tests/unit/activation/test_powershell.py
+++ b/tests/unit/activation/test_powershell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
 import sys
 from argparse import Namespace
 
@@ -133,3 +134,54 @@ def test_powershell(activation_tester_class, activation_tester, monkeypatch) -> 
             return f"{cmd} {scr}".strip()
 
     activation_tester(PowerShell)
+
+
+@pytest.mark.parametrize("venv_sets_tcl", [True, False])
+@pytest.mark.parametrize("was_set", [True, False])
+def test_powershell_deactivate_restores_tcl_tk_library(tmp_path, venv_sets_tcl, was_set) -> None:
+    powershell = shutil.which("pwsh") or (shutil.which("powershell.exe") if sys.platform == "win32" else None)
+    if powershell is None:
+        pytest.skip("powershell is not installed")
+
+    class MockInterpreter:
+        os = "nt"
+
+    interpreter = MockInterpreter()
+    interpreter.tcl_lib = str(tmp_path / "venv-tcl") if venv_sets_tcl else None
+    interpreter.tk_lib = str(tmp_path / "venv-tk") if venv_sets_tcl else None
+
+    class MockCreator:
+        def __init__(self, dest) -> None:
+            self.dest = dest
+            self.bin_dir = dest / "Scripts"
+            self.bin_dir.mkdir(parents=True)
+            self.interpreter = interpreter
+            self.pyenv_cfg = {}
+            self.env_name = "env"
+
+    creator = MockCreator(tmp_path / "env")
+    (creator.dest / "pyvenv.cfg").write_text("", encoding="utf-8")
+    PowerShellActivator(Namespace(prompt=None)).generate(creator)
+
+    setup = "$env:TCL_LIBRARY = 'user-tcl'; $env:TK_LIBRARY = 'user-tk'" if was_set else ""
+    show = 'if ($env:{0} -eq $null) {{ "None" }} else {{ $env:{0} }}'
+    show_both = f"{show.format('TCL_LIBRARY')}\n{show.format('TK_LIBRARY')}"
+    driver = tmp_path / "driver.ps1"
+    driver.write_text(
+        f"Remove-Item env:TCL_LIBRARY, env:TK_LIBRARY -ErrorAction SilentlyContinue\n{setup}\n"
+        f". '{creator.bin_dir / 'activate.ps1'}'\n{show_both}\ndeactivate\n{show_both}\n",
+        encoding="utf-8-sig",
+    )
+    out = subprocess.run(
+        [powershell, "-NonInteractive", "-NoProfile", "-ExecutionPolicy", "ByPass", "-File", str(driver)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+        check=True,
+    ).stdout
+
+    before = ["user-tcl", "user-tk"] if was_set else ["None", "None"]
+    activated = [interpreter.tcl_lib, interpreter.tk_lib] if venv_sets_tcl else before
+    # activation must not drop a value it does not replace, and deactivate puts back what was there
+    assert out.splitlines() == [*activated, *before], out


### PR DESCRIPTION
Activation sets `TCL_LIBRARY` and `TK_LIBRARY` to the interpreter's paths when it knows them, and saves the previous
values for `deactivate`. Four scripts get this wrong.

PowerShell, fish and csh run `deactivate` at the start of activation. With no saved copy, their TCL/TK branches removed
the variables, so a user-set `TCL_LIBRARY` disappeared on activation and stayed gone after `deactivate`. PowerShell and
csh did this for every environment, fish only when the interpreter has tcl. In PowerShell, setting
`$env:TCL_LIBRARY = 'C:\tcl\lib\tcl8.6'`, then activating and deactivating, left `$env:TCL_LIBRARY` empty.

bash saved a previous value only when it was non-empty and tested the saved copy with `-n`. After activating an
environment with tcl, it could not tell "was unset" from "nothing saved", so an unset `TCL_LIBRARY` stayed at
`/usr/lib/tcl8.6` after `deactivate`.

All four scripts now save the previous value whenever they replace it, as an empty string or `$null` when it was unset.
`deactivate` acts only when a saved copy exists (`${var+x}`, `set -q`, `Test-Path variable:`, `$?var`), restoring a
non-empty value and unsetting otherwise. batch already worked this way.

`ActivationTester` now prints `TCL_LIBRARY` and `TK_LIBRARY` before activation, while active and after deactivation, so
every shell it drives checks them. `activation_python` adds an environment whose scripts carry tcl paths: the
interpreter reports `tcl_lib` only when `TCL_LIBRARY` is set during its cached probe, so the fixture regenerates the
scripts with `tcl_lib` and `tk_lib` patched. `activation_tester` runs each shell with the user's values unset and set.
On `main`, PowerShell and csh fail the set cases, fish fails set with tcl, and bash fails unset with tcl.

`activate.nu` never sets these variables (its `let $new_env` inside `if` only shadows the outer binding), so the nushell
tester expects them unchanged. This PR leaves that as is.

