### PR TITLE
🔧 chore: check spelling with typos in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,7 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.50.1
+    hooks:
+      - id: typos

--- a/tests/unit/create/via_global_ref/test_build_c_ext.py
+++ b/tests/unit/create/via_global_ref/test_build_c_ext.py
@@ -18,10 +18,10 @@ CREATOR_CLASSES = CreatorSelector.for_interpreter(CURRENT).key_to_class
 
 
 def builtin_shows_marker_missing() -> bool:
-    builtin_classs = CREATOR_CLASSES.get("builtin")
-    if builtin_classs is None:
+    builtin_classes = CREATOR_CLASSES.get("builtin")
+    if builtin_classes is None:
         return False
-    host_include_marker = getattr(builtin_classs, "host_include_marker", None)
+    host_include_marker = getattr(builtin_classes, "host_include_marker", None)
     if host_include_marker is None:
         return False
     marker = host_include_marker(CURRENT)


### PR DESCRIPTION
Add the [typos](https://github.com/crate-ci/typos) spell checker to pre-commit, as [ruff](https://github.com/astral-sh/ruff/blob/main/.pre-commit-config.yaml) does.

On the current tree it reports one typo, `builtin_classs` in `tests/unit/create/via_global_ref/test_build_c_ext.py`. The variable holds one class, so it becomes `builtin_class`.
